### PR TITLE
queue incoming messages until session is set up

### DIFF
--- a/lib/sockethub/dispatcher.js
+++ b/lib/sockethub/dispatcher.js
@@ -222,6 +222,14 @@ Dispatcher.connect = function(connection) {
     connection.sendUTF(msg);
   });
 
+  var pendingMessages = [];
+
+  function queueMessage(message) {
+    pendingMessages.push(message);
+  }
+
+  connection.on('message', queueMessage);
+
   Dispatcher.session.get(sessionId).then(function (session) {
     console.debug(' [dispatcher] initializing connection handlers');
     connection.on("close", function() {
@@ -239,6 +247,8 @@ Dispatcher.connect = function(connection) {
       }
 
     });
+
+    connection.removeListener('message', queueMessage);
 
     connection.on("message", function (message) {
       errorSent = false;
@@ -324,6 +334,13 @@ Dispatcher.connect = function(connection) {
         connection.sendBytes(message.binaryData);
       }
     });
+
+    // fake a "message" event for each message that was received
+    // before the session had been fetched:
+    var message;
+    while(message = pendingMessages.shift()) {
+      connection.emit('message', message);
+    }
   });
 
   var sendConfirm = function (rid) {


### PR DESCRIPTION
with this patch the test @silverbucket wrote for #90 passes. Also I can't reproduce the bug with the browser anymore either.

As far as I understand, this wouldn't solve the [related issue](https://github.com/Worlize/WebSocket-Node/issues/91) in WebSocket-Node, but it seems to me that this was never the problem here.
The "message" handler for the connection was only installed by the Dispatcher after Dispatcher.session.get()'s promise was fulfilled, giving the connection time to receive data in between that was then never received by sockethub.
