### PR TITLE
Fix "cleanup" call to platforms

### DIFF
--- a/lib/sockethub/dispatcher.js
+++ b/lib/sockethub/dispatcher.js
@@ -225,24 +225,23 @@ Dispatcher.connect = function(connection) {
   Dispatcher.session.get(sessionId).then(function (session) {
     console.debug(' [dispatcher] initializing connection handlers');
     connection.on("close", function() {
-      try {
-        session.getPlatforms().forEach(function(platform) {
-          var channel = 'sockethub:' + _this.sockethubId +
-            ':listener:' + platform + ':incoming';
-          _this.util.redis.set('lpush', channel, JSON.stringify({
-            verb: 'cleanup',
-            sessionId: sessionId
-          }));
-        });
-        setTimeout(function () {
-          Dispatcher.session.destroy(sessionId);
-          session = undefined;
-        }, 5000);
-
-      } catch(e) {
+      if(typeof(session) == 'undefined') {
+        // FIXME: under which circumstances would this code ever be reached?
         console.error(' [dispatcher] failed session cleanup, session already undefined');
       }
 
+      session.getPlatforms().forEach(function(platform) {
+        var channel = 'sockethub:' + _this.sockethubId +
+          ':listener:' + platform + ':incoming';
+        _this.util.redis.set('lpush', channel, JSON.stringify({
+          verb: 'cleanup',
+          sessionId: sessionId
+        }));
+      });
+      setTimeout(function () {
+        Dispatcher.session.destroy(sessionId);
+        session = undefined;
+      }, 5000);
     });
 
     connection.on("message", function (message) {


### PR DESCRIPTION
This was always just showing "[dispatcher] failed session cleanup, session already undefined" in the console, despite the actual error being that the function "Dispatcher.sendSubSystem" doesn't exist anymore.

I'm not sure if going via the ":incoming" channel of the platform to issue the "cleanup" command is the best way to go, but it seems to work fine.
