### PR TITLE
fix github repo url

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git://github.com/sockcwethub/sockethub.git"
+    "url": "git://github.com/sockethub/sockethub.git"
   },
   "homepage": "http://github.com/sockethub/sockethub",
   "dependencies": {


### PR DESCRIPTION
Also on an unrelated note, there are API changes (from 0.7.x) in version 0.8 of the `imap` module which you can find [here](https://github.com/mscdex/node-imap/wiki/API-changes-between-v0.7-and-v0.8).
