### PR TITLE
allow specifying explicit from and to parameters

### DIFF
--- a/lib/platforms/email.js
+++ b/lib/platforms/email.js
@@ -177,8 +177,9 @@ Email.prototype.send = function (job) {
  *   perPage     - Number of messages to fetch per page.
  *   page        - Page number to fetch.
  *   includeBody - Include message body.
- *   fromSeqNo   - explicit lowest imap sequence number to fetch
- *   toSeqNo     - explicit highest imap sequence number to fetch
+ *   property    - has to be 'seqno' for <after> and <before> to take effect
+ *   after       - will only fetch imap sequence numbers strictly greater than this
+ *   before      - will only fetch imap sequence numbers strictly smaller than this
  *
  * Responds with an object with the following properties:
  *   total   - Total number of messages.

--- a/lib/platforms/imap-implementation.js
+++ b/lib/platforms/imap-implementation.js
@@ -83,8 +83,10 @@ ImapImplementation.prototype = {
         openInbox(function(err, box) {
           var from = box.messages.total-(options.page*options.perPage),
               to = from+options.perPage;
-          if (options.fromSeqNo ) { from = options.fromSeqNo; }
-          if (options.toSeqNo ) { to = options.toSeqNo; }
+          if (options.property === 'seqno') {
+            if (options.after) { from = options.after + 1; }
+            if (options.before) { to = options.before - 1; }
+          }
           console.log('from '+from+' to '+to);
           var f = imap.seq.fetch( from+':'+ to, { bodies: '' });
           f.on('end', function() {


### PR DESCRIPTION
sometimes you know exactly which message or range of messages (by `imapSeqNo`) you want to retrieve, so with this change it's possible to specify that explicitly
