### PR TITLE
fix https://github.com/michielbdejong/meute/issues/23

### DIFF
--- a/lib/sockethub/session.js
+++ b/lib/sockethub/session.js
@@ -242,6 +242,7 @@ SessionManager.prototype.getAllSessionIDs = function () {
  *   promise with session object
  */
 SessionManager.prototype.get = function (sid, create) {
+  console.log('SessionManager.prototype.get called', sid, create);//seems to help against https://github.com/michielbdejong/meute/issues/23
   var q = Q.defer();
   var self = this;
   create = (typeof create !== 'undefined') ? create : true;


### PR DESCRIPTION
I don't fully understand what is going wrong here, but adding a `console.log` statement fixed it for me.

@silverbucket Obviously you don't want the robustness of sockethub to depend on the timing of `console.log` statements, I'm sending you this PR so you can find a real solution :)

The problem is described in https://github.com/michielbdejong/meute/issues/23 - when connecting, registering, setting credentials, joining an room, and saying something on irc, all in immediate succession without waiting in between, sockethub chokes and seems to create two irc clients, one of which it tries to use while it is (still?) undefined.
