### PR TITLE
SessionManager timing (rebase of #170)

### DIFF
--- a/lib/sockethub/session-manager.js
+++ b/lib/sockethub/session-manager.js
@@ -211,6 +211,7 @@ SessionManager.prototype._destroyAllSessions = function () {
  *   promise with session object
  */
 SessionManager.prototype.get = function (sid, create) {
+  console.log('SessionManager.prototype.get called', sid, create);//seems to help against https://github.com/michielbdejong/meute/issues/23
   var q = Q.defer();
   var self = this;
   create = (typeof create !== 'undefined') ? create : true;


### PR DESCRIPTION
Sorry we couldn't reproduce it last time - it's now quite easy to reproduce if you just run `node butler` in meute master (with sockethub on ws://localhost:10550/ and secret 1234567890).
