### PR TITLE
Use valid SPDX license ID

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "version": "1.0.3",
   "private": false,
   "author": "Nick Jennings <nick@silverbucket.net>",
-  "license": "LGPL",
+  "license": "LGPL-3.0+",
   "main": "bin/sockethub",
   "preferGlobal": true,
   "keywords": [


### PR DESCRIPTION
This fixes an npm warning:

```
npm WARN sockethub@1.0.3 license should be a valid SPDX license expression
```

I'm not sure this version is actually what you were going for. So take this as more of a constructive issue report than an actual proposal for this specific license.

If you want to use a different version, here's a list with valid expressions for LGPL:

https://github.com/stdarg/spdx-licenses/blob/master/spdx.json#L527-L556
