### PR TITLE
Missing an ending quotation mark in the dummy example.

### DIFF
--- a/views/examples/dummy.ejs
+++ b/views/examples/dummy.ejs
@@ -78,7 +78,7 @@
           },
           target: {
             '@type': 'feed',
-            id: 'https://sockethub.org/examples/dummy
+            id: 'https://sockethub.org/examples/dummy'
           }
         };
         bdebug('sending message: ', msg);


### PR DESCRIPTION
This is causing issues running the dummy example.