### PR TITLE
Revert "self-call function"

### DIFF
--- a/lib/middleware.js
+++ b/lib/middleware.js
@@ -35,6 +35,7 @@ module.exports = function () {
         count = count + 1;
         setTimeout(_callFunc.bind(this, count), 0);
       }]);
-    }(count);
+    }
+    _callFunc(count);
   };
 };


### PR DESCRIPTION
This reverts commit 8e9e72ad4bfc2b692b517b3c173be2f0f41e243c.

I was testing the latest master with Hyperchannel, and Sockethub didn't join me to any channels anymore. There were no apparent error messages in the Sockethub log that I could see. I checked the most recent commits and found this to be the culprit breaking it.

To be honest, I have no clue how it would break anything, because it looks like it should behave the exact same way. 