### PR TITLE
Require a halfway modern node version

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,5 +59,8 @@
   "scripts": {
     "test": "node_modules/.bin/jaribu",
     "start": "DEBUG=* ./bin/sockethub"
+  },
+  "engines": {
+    "node": ">= 5.0.0"
   }
 }


### PR DESCRIPTION
There are already features used in the code, which aren't available by default on versions older than 5. LTS is 6.x and current is 7.7.2, so I think this is a reasonable requirement.

closes #206