### PR TITLE
Remove comments from the JSON config: JSON doesn't allow comments

### DIFF
--- a/config.json.example
+++ b/config.json.example
@@ -32,8 +32,6 @@
   "redis": {
     "host": "redis",
     "port": 6379
-    // if defined overrides host + port pair, env: REDIS_URL
-    // "url": "redis://user:password@hostname:port"
   },
   "workers": 1
 }


### PR DESCRIPTION
I found out about the problem while working on the Docker setup (I'll send a PR soon, using Docker Compose)

The config entry for the Redis URL is explained in the README. If you
want comments you need to use YAML or another format that has comments