### PR TITLE
Initial Docker Compose support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,8 @@
-FROM nodesource/xenial:latest
+FROM "node:6"
 MAINTAINER Ben Kero <ben.kero@gmail.com>
 
-RUN apt-get update && apt-get install -y git-core
-
 ADD package.json /tmp/package.json
+ADD package-lock.json /tmp/package-lock.json
 RUN cd /tmp && npm install
 RUN mkdir -p /app
 ADD config.json.example /app/config.json

--- a/README.md
+++ b/README.md
@@ -61,6 +61,22 @@ platforms actions.
 
 You should then be able to browse to `http://localhost:10550` and try out the examples.
 
+# Running using Docker Compose
+
+Requires [Docker Compose](https://docs.docker.com/compose/) 1.10.0+
+
+`$ docker-compose up`
+
+> If you’re using Docker natively on Linux, Docker for Mac, or Docker for
+> Windows, then sockethub should now be listening on port 10550 on your Docker
+> daemon host. Point your web browser to http://localhost:10550 to find
+> sockethub. If this doesn’t resolve, you can also try
+> http://0.0.0.0:10550.
+
+> If you’re using Docker Machine on a Mac or Windows, use docker-machine ip
+> MACHINE_VM to get the IP address of your Docker host. Then, open
+> http://MACHINE_VM_IP:10550 in a browser.
+
 # Environment Variables
 
 * PORT

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,10 @@
+version: '2'
+services:
+  sockethub:
+    build: .
+    ports:
+    - "10550:10550"
+    links:
+    - redis
+  redis:
+    image: redis


### PR DESCRIPTION
I'm considering using Docker Compose to deploy sockethub, so here's a PR. The old Docker setup was using another non-official image and didn't set up Redis (this does it as a separate linked container).

Can someone else give this a try? On this branch `docker-compose up` should give you a working sockethub on http://localhost:10550/

I tested it on my Mac using Docker for Mac and on Ubuntu 16.04 (using official Docker packages)