### PR TITLE
Replace cdd call with cd -

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,8 +12,8 @@
     "test": "lerna run test",
     "travis": "lerna run travis",
     "build": "lerna run build",
-    "dev": "[[ -f config.json ]] && cp config.json packages/sockethub/; cd packages/sockethub && yarn run dev; cd -",
-    "start": "[[ -f config.json ]] && cp config.json packages/sockethub/; cd packages/sockethub && yarn run start; cd -"
+    "dev": "[[ -f config.json ]] && cp config.json packages/sockethub/; cd packages/sockethub && yarn run dev",
+    "start": "[[ -f config.json ]] && cp config.json packages/sockethub/; cd packages/sockethub && yarn run start"
   },
   "dependencies": {}
 }

--- a/package.json
+++ b/package.json
@@ -12,8 +12,8 @@
     "test": "lerna run test",
     "travis": "lerna run travis",
     "build": "lerna run build",
-    "dev": "[[ -f config.json ]] && cp config.json packages/sockethub/; cd packages/sockethub && yarn run dev; cdd",
-    "start": "[[ -f config.json ]] && cp config.json packages/sockethub/; cd packages/sockethub && yarn run start"
+    "dev": "[[ -f config.json ]] && cp config.json packages/sockethub/; cd packages/sockethub && yarn run dev; cd -",
+    "start": "[[ -f config.json ]] && cp config.json packages/sockethub/; cd packages/sockethub && yarn run start; cd -"
   },
   "dependencies": {}
 }


### PR DESCRIPTION
In the `dev` script in package.json I noticed a call to `cdd` at the end. I didn't recognize that commend and found that I don't have such a command (on macOS).
I don't know if it's a custom script or something Linux specific, but I assume it's for changing back to the original directory after the script previously changed into `packages/sockethub`. I replaced it witch `cd -`, which does exactly that, but AFAIK is in the POSIX standard. So it should be available in most shells.

I also added it to the end of the `start` script as well, because that also changes directories.