### PR TITLE
Use relative path for process forking

### DIFF
--- a/packages/sockethub/src/platform-instance.ts
+++ b/packages/sockethub/src/platform-instance.ts
@@ -1,4 +1,5 @@
 import { ChildProcess, fork } from 'child_process';
+import { join } from 'path';
 
 import SharedResources from "./shared-resources";
 
@@ -38,7 +39,7 @@ class PlatformInstance {
       this.actor = actor;
     }
     // spin off a process
-    this.process = fork('dist/platform.js', [parentId, name, id]);
+    this.process = fork(join(__dirname, 'platform.js'), [parentId, name, id]);
   }
 
   public registerSession(sessionId: string) {


### PR DESCRIPTION
Fixes #255

When installing Sockethub as a dependency of another project and then trying to run it from there, an error is thrown:

```
Error: Cannot find module '/Users/galfert/code/active/kosmos/hyperchannel/dist/platform.js'
    at Function.Module._resolveFilename (internal/modules/cjs/loader.js:1030:15)
    at Function.Module._load (internal/modules/cjs/loader.js:899:27)
    at Function.executeUserEntryPoint [as runMain] (internal/modules/run_main.js:71:12)
    at internal/main/run_main_module.js:17:47 {
  code: 'MODULE_NOT_FOUND',
  requireStack: []
}
```

This fixes that error.