### PR TITLE
Migrate to travis-ci.com and enable graviton2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,7 @@
 language: node_js
+os: linux
+arch: arm64-graviton2
+group: edge
 node_js:
   - 'lts/*'
   - 13


### PR DESCRIPTION
travis-ci.org is being deprecated at the end of the year and the PRs were taking sometimes days to be queued (or never). Switched to travis-ci.com and at the same time enabled the new graviton2 platform which they claim is even faster.

https://docs.travis-ci.com/user/migrate/open-source-repository-migration/
https://blog.travis-ci.com/2020-09-11-arm-on-aws