### PR TITLE
Add debug logging toggle to SockethubClient

### DIFF
--- a/packages/sockethub/src/js/client.js
+++ b/packages/sockethub/src/js/client.js
@@ -18,6 +18,7 @@
     this.socket = socket;
     this.ActivityStreams = ASFactory({specialObjs: ['credentials']});
     this.online = false;
+    this.debug = false;
 
     this.__registerSocketIOHandlers();
 
@@ -29,6 +30,12 @@
       this.ActivityStreams.Object.create(obj);
     });
   }
+
+  SockethubClient.prototype.log = function (msg, obj) {
+    if (this.debug) {
+      console.log(msg, obj);
+    }
+  };
 
   SockethubClient.prototype.__handlers = {
     // wrapping the `on` method in order to automatically unpack Activity Streams objects
@@ -152,6 +159,7 @@
 
   SockethubClient.prototype.__replay = function (name, asMap) {
     asMap.forEach((obj) => {
+      this.log(`replaying ${name}`, obj);
       this.socket._emit(name, obj);
     });
   };


### PR DESCRIPTION
Show replay objects played back to server when SockethubClient instances `debug` property is true