### PR TITLE
Ensure config is only loaded once per thread

### DIFF
--- a/packages/sockethub/src/config.ts
+++ b/packages/sockethub/src/config.ts
@@ -1,7 +1,6 @@
 import nconf from 'nconf';
 import debug from 'debug';
 
-let config;
 const log = debug.debug('sockethub:bootstrap:config');
 
 class Config {
@@ -78,5 +77,5 @@ class Config {
   get = (key: string): any => nconf.get(key);
 }
 
-config = new Config();
+const config = new Config();
 export default config;


### PR DESCRIPTION
This is just to ensure that nowhere the config object is being re-initialized within the same thread, as that could be indicative of a larger issue.