### PR TITLE
Fix client exception when AS object has no target

### DIFF
--- a/packages/sockethub/src/js/client.js
+++ b/packages/sockethub/src/js/client.js
@@ -175,7 +175,7 @@
 
   SockethubClient.prototype.__getKey = function (content) {
     let actor = content.actor['@id'] || content.actor;
-    let target = content.target['@id'] || content.target;
+    let target = content.target ? content.target['@id'] || content.target : '';
     return actor + '-' + target;
   };
 


### PR DESCRIPTION
Not all ActivityStreams objects contain a target. If there is none, then accessing sub properties fails.

Not sure if this is the correct fix, and why that string combines actor and target.