### PR TITLE
New config option to define which platform methods require the credentials option passed in. 

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -14,8 +14,9 @@
         "indent": ["error", 2, {
             "SwitchCase": 1,
             "VariableDeclarator": { "var": 2, "let": 2, "const": 3 },
-            "FunctionDeclaration": { "parameters": "first" },
-            "FunctionExpression": { "parameters":  "first" }
+            "FunctionDeclaration": { "parameters":  "first" },
+            "FunctionExpression": { "parameters":  "first" },
+            "CallExpression": { "arguments":  1 }
         }],
         "keyword-spacing": 2,
         "max-len": [2, { "code": 99 }],

--- a/.eslintrc
+++ b/.eslintrc
@@ -15,8 +15,7 @@
             "SwitchCase": 1,
             "VariableDeclarator": { "var": 2, "let": 2, "const": 3 },
             "FunctionDeclaration": { "parameters": "first" },
-            "FunctionExpression": { "parameters":  "first" },
-            "CallExpression": { "arguments":  "first" }
+            "FunctionExpression": { "parameters":  "first" }
         }],
         "keyword-spacing": 2,
         "max-len": [2, { "code": 99 }],
@@ -24,7 +23,6 @@
         "no-eval": 2,
         "no-tabs": 2,
         "no-var": 2,
-//        "quotes": [2, "single", { "allowTemplateLiterals": true }],
         "semi": 2,
         "space-before-blocks": 2,
         "space-before-function-paren": [2, {"anonymous": "always", "named": "never"}]

--- a/packages/sockethub-platform-feeds/index.js
+++ b/packages/sockethub-platform-feeds/index.js
@@ -112,7 +112,8 @@ class Feeds {
 
   get config() {
     return {
-      persist: false
+      persist: false,
+      requireCredentials: []
     }
   }
 

--- a/packages/sockethub-platform-irc/index.js
+++ b/packages/sockethub-platform-irc/index.js
@@ -155,7 +155,8 @@ IRC.prototype.schema = {
 
 
 IRC.prototype.config = {
-  persist: true
+  persist: true,
+  requireCredentials: [ 'join', 'leave', 'send', 'update', 'observe' ]
 };
 
 

--- a/packages/sockethub-platform-xmpp/index.js
+++ b/packages/sockethub-platform-xmpp/index.js
@@ -156,7 +156,9 @@ class XMPP {
 
   get config() {
     return {
-      persist: true
+      persist: true,
+      requireCredentials: [ 'connect', 'join', 'send', 'update', 'request-friend', 'remove-friend', 'make-friend',
+        'observe' ]
     }
   };
 

--- a/packages/sockethub/src/bootstrap/platforms.js
+++ b/packages/sockethub/src/bootstrap/platforms.js
@@ -78,7 +78,7 @@ module.exports = function platformLoad(moduleList) {
             // register the platforms credentials schema
             types.push('credentials');
             tv4.addSchema(`http://sockethub.org/schemas/v0/context/${platformName}/credentials`,
-                          p.schema.credentials);
+              p.schema.credentials);
           } else {
             p.config.noCredentials = true;
           }
@@ -86,7 +86,7 @@ module.exports = function platformLoad(moduleList) {
         }
 
         tv4.addSchema(`http://sockethub.org/schemas/v0/context/${platformName}/messages`,
-                      p.schema.messages);
+          p.schema.messages);
 
         if (platformListsSupportedTypes(p)) {
           types = [...types, ...p.schema.messages.properties['@type'].enum];

--- a/packages/sockethub/src/platform.ts
+++ b/packages/sockethub/src/platform.ts
@@ -130,10 +130,18 @@ function startQueueListener(refresh: boolean = false) {
     const sessionSecret = job.data.msg.sessionSecret;
     delete job.data.msg.sessionSecret;
     getCredentials(job.data.msg.actor['@id'], job.data.socket, sessionSecret,
-                   (err, credentials) => {
-                     if (err) { return done(err); }
-                     platform[job.data.msg['@type']](job.data.msg, credentials, done);
-                   });
+      (err, credentials) => {
+        if (err) { return done(err); }
+        const params = [ job.data.msg ];
+        if ((Array.isArray(platform.config.requireCredentials)) &&
+            (platform.config.requireCredentials.includes(job.data.msg['@type']))) {
+          // pass credentials object as second param if this method is defined in the
+          // `requireCredentials` list in the platform config.
+          params.push(credentials);
+        }
+        params.push(done);
+        platform[job.data.msg['@type']](...params);
+      });
   });
 }
 

--- a/packages/sockethub/src/platform.ts
+++ b/packages/sockethub/src/platform.ts
@@ -135,8 +135,7 @@ function startQueueListener(refresh: boolean = false) {
         const params = [ job.data.msg ];
         if ((Array.isArray(platform.config.requireCredentials)) &&
             (platform.config.requireCredentials.includes(job.data.msg['@type']))) {
-          // pass credentials object as second param if this method is defined in the
-          // `requireCredentials` list in the platform config.
+          // add the credentials object if this method requires it
           params.push(credentials);
         }
         params.push(done);
@@ -144,4 +143,3 @@ function startQueueListener(refresh: boolean = false) {
       });
   });
 }
-

--- a/packages/sockethub/src/sockethub.ts
+++ b/packages/sockethub/src/sockethub.ts
@@ -239,7 +239,7 @@ class Sockethub {
     socket.on(
       'activity-object',
       middleware.chain(validate('activity-object', socket.id),
-                       this.handleActivityObject(sessionLog))
+        this.handleActivityObject(sessionLog))
     );
   }
 }


### PR DESCRIPTION
Currently credentials are passed in to every platform function which were previously used to access the appropriate client instance or re-connect if needed. The architecture has progressively moved away from that to simply destroying and restarting the platform if the connection is lost. This PR adds a `requireCredentials` property to the platform config, which is an array listing every method that needs the credentials object passed in. For now, all functions are defined, but as the client internals of each platform is improved we can slowly remove methods from the list.
Resolves #287 