### PR TITLE
Pass complete job object to handleJobResult method

### DIFF
--- a/packages/sockethub/src/platform-instance.ts
+++ b/packages/sockethub/src/platform-instance.ts
@@ -85,7 +85,8 @@ export default class PlatformInstance {
     this.queue = new Queue(this.parentId + this.id, redisConfig);
     this.queue.on('global:completed', (jobId, result) => {
       this.queue.getJob(jobId).then((job) => {
-        this.handleJobResult('completed', crypto.decrypt(job.data.msg, secret), result);
+        job.data.msg = crypto.decrypt(job.data.msg, secret);
+        this.handleJobResult('completed', job, result);
       });
     });
     this.queue.on('global:error', (jobId, result) => {
@@ -93,7 +94,8 @@ export default class PlatformInstance {
     });
     this.queue.on('global:failed', (jobId, result) => {
       this.queue.getJob(jobId).then((job) => {
-        this.handleJobResult('failed', crypto.decrypt(job.data.msg, secret), result);
+        job.data.msg = crypto.decrypt(job.data.msg, secret);
+        this.handleJobResult('failed', job, result);
       });
     });
   }


### PR DESCRIPTION
Fixes #354

This fixes the error "TypeError: Cannot read property 'socket' of undefined", by passing the complete job object instead of just the decrypted message to the job handler.