### PR TITLE
Fix erroneous use of imported socket.io Server class

### DIFF
--- a/packages/sockethub/src/services/http.ts
+++ b/packages/sockethub/src/services/http.ts
@@ -2,7 +2,7 @@ import debug from 'debug';
 import bodyParser from 'body-parser';
 import express from 'express';
 import * as HTTP from 'http';
-import SocketIO from 'socket.io';
+import { Server } from 'socket.io';
 
 import config from '../config';
 import routeBase from '../routes/base';
@@ -15,7 +15,7 @@ const http = {
     const app = this.__initExpress();
     // initialize express and socket.io objects
     const http = new HTTP.Server(app);
-    const io = SocketIO(http, {path: config.get('service:path')});
+    const io = new Server(http, {path: config.get('service:path')});
 
     // routes list
     [


### PR DESCRIPTION
Not sure how this worked before and suddenly was failing (or if it was erroneously changed at some point) but this fix isn't related to socket.io 4.x which I'm also working on separately. TS linting started failing on this import recently.