### PR TITLE
Update renovate config to be less spammy

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,8 +1,15 @@
 {
   "labels": [ "kredits-1", "dependencies" ],
   "reviewers": [ "silverbucket" ],
-  "additionalBranchPrefix": "{{parentDir}}-",
   "extends": [
     "config:base"
-  ]
+  ],
+  "dependencyDashboard": true,
+  "lockFileMaintenance": { "enabled": true },
+  "prCreation": "not-pending",
+  "rebaseWhen": "behind-base-branch",
+  "rebaseStale": true,
+  "schedule": "every weekday",
+  "stabilityDays": 3,
+  "updateNotScheduled": true
 }


### PR DESCRIPTION
This config will:
* Not separate by packages within the monorepo for the same dependency update
* Only create PRs during the weekdays (avoid weekend pileups)
* Wait 3 days after a release before creating the PR
* Auto-update branches when behind master
* Will create an Issue which will act as a dashboard (overview) or all of the existing and pending (not created yet) PRs

