### PR TITLE
XMPP credentials `server` property no longer required

### DIFF
--- a/packages/sockethub-platform-xmpp/src/schema.js
+++ b/packages/sockethub-platform-xmpp/src/schema.js
@@ -23,7 +23,7 @@ module.exports = {
       "object": {
         "name": "object",
         "type": "object",
-        "required": ['@type', 'username', 'password', 'server', 'resource'],
+        "required": ['@type', 'username', 'password', 'resource'],
         "additionalProperties": false,
         "properties": {
           "@type": {


### PR DESCRIPTION
Fixes #491