### PR TITLE
Safely parse resultString

### DIFF
--- a/packages/sockethub/src/platform-instance.ts
+++ b/packages/sockethub/src/platform-instance.ts
@@ -89,7 +89,7 @@ export default class PlatformInstance {
   public initQueue(secret: string) {
     this.queue = new Queue(this.parentId + this.id, redisConfig);
     this.queue.on('global:completed', (jobId, resultString) => {
-      const result = JSON.parse(resultString);
+      const result = resultString ? JSON.parse(resultString) : "";
       this.queue.getJob(jobId).then(async (job: JobEncrypted) => {
         await this.handleJobResult('completed', decryptJobData(job, secret), result);
         job.remove();


### PR DESCRIPTION
Only try to parse `resultString` if it's not undefined