### PR TITLE
Replace old 'set' type with 'credentials' in examples

### DIFF
--- a/packages/sockethub-platform-irc/API.md
+++ b/packages/sockethub-platform-irc/API.md
@@ -58,7 +58,7 @@ Valid AS object for setting IRC credentials:
 **Example**  
 ```js
 {
-   '@type': 'set',
+   '@type': 'credentials',
    context: 'irc',
    actor: {
      '@id': 'testuser@irc.host.net',

--- a/packages/sockethub-platform-irc/index.js
+++ b/packages/sockethub-platform-irc/index.js
@@ -80,7 +80,7 @@ function IRC(cfg) {
  * @example
  *
  *  {
- *    'type': 'set',
+ *    type: 'credentials',
  *    context: 'irc',
  *    actor: {
  *      'id': 'testuser@irc.host.net',

--- a/packages/sockethub-platform-xmpp/API.md
+++ b/packages/sockethub-platform-xmpp/API.md
@@ -70,7 +70,7 @@ Valid AS object for setting XMPP credentials:
 **Example**  
 ```js
 {
-  '@type': 'set',
+  '@type': 'credentials',
   context: 'xmpp',
   actor: {
     '@id': 'testuser@jabber.net',

--- a/packages/sockethub-platform-xmpp/src/index.js
+++ b/packages/sockethub-platform-xmpp/src/index.js
@@ -72,7 +72,7 @@ class XMPP {
    * @example
    *
    * {
-   *   'type': 'set',
+   *   type: 'credentials',
    *   context: 'xmpp',
    *   actor: {
    *     'id': 'testuser@jabber.net',


### PR DESCRIPTION
Found some occurrences of the obsolete `type: 'set'` for credentials objects in the examples.

NB: In the `API.md` files I didn't remove the `@` from the `@type` as well. I think that should be a separate PR that removes all of them in the whole document.