### PR TITLE
Support outgoing message correction

### DIFF
--- a/packages/sockethub-platform-xmpp/src/index.js
+++ b/packages/sockethub-platform-xmpp/src/index.js
@@ -273,8 +273,8 @@ class XMPP {
         id: job.object.id
       },
       xml("body", {}, job.object.content),
-      job.object.replace ? xml("replace", {
-        id: job.object.replace.id,
+      job.object['xmpp:replace'] ? xml("replace", {
+        id: job.object['xmpp:replace'].id,
         xmlns: 'urn:xmpp:message-correct:0'
       }) : undefined
     );

--- a/packages/sockethub-platform-xmpp/src/index.js
+++ b/packages/sockethub-platform-xmpp/src/index.js
@@ -273,6 +273,10 @@ class XMPP {
         id: job.object.id
       },
       xml("body", {}, job.object.content),
+      job.object.replace ? xml("replace", {
+        id: job.object.replace.id,
+        xmlns: 'urn:xmpp:message-correct:0'
+      }) : undefined
     );
     this.__client.send(message).then(done);
   };

--- a/packages/sockethub-platform-xmpp/src/index.test.js
+++ b/packages/sockethub-platform-xmpp/src/index.test.js
@@ -76,8 +76,8 @@ const job = {
       object: {
         'type': 'message',
         id: 'hc-1234abcd',
-        replace: { id: 'hc-234bcde' },
-        content: 'hi yall'
+        content: 'hi yall',
+        'xmpp:replace': { id: 'hc-234bcde' }
       },
       target: target.roomuser
     }
@@ -261,7 +261,7 @@ describe('Platform', () => {
           },
           xmlFake("body", {}, job.send.correction.object.content),
           xmlFake("replace", {
-            id: job.send.correction.object.replace.id,
+            id: job.send.correction.object['xmpp:replace'].id,
             xmlns: 'urn:xmpp:message-correct:0' }
           )
         );

--- a/packages/sockethub-platform-xmpp/src/index.test.js
+++ b/packages/sockethub-platform-xmpp/src/index.test.js
@@ -67,7 +67,17 @@ const job = {
       object: {
         'type': 'message',
         id: 'hc-1234abcd',
-        content: 'hello'
+        content: 'hi all'
+      },
+      target: target.roomuser
+    },
+    correction: {
+      actor: actor,
+      object: {
+        'type': 'message',
+        id: 'hc-1234abcd',
+        replace: { id: 'hc-234bcde' },
+        content: 'hi yall'
       },
       target: target.roomuser
     }
@@ -209,12 +219,14 @@ describe('Platform', () => {
     });
 
     describe('#send', () => {
-      // FIXME, this is not testing the origin input from above
       it('calls xmpp.js correctly', (done) => {
+        // FIXME wrong message also passes
         const message = xmlFake(
-          "message",
-          {type: job.send.chat.target['type'] === 'room' ? 'groupchat' : 'chat',
-            to: job.send.chat.target['id']},
+          "message", {
+            type: "chat",
+            to: job.send.chat.target['id'],
+            id: job.send.chat.object['id'],
+          },
           xmlFake("body", {}, job.send.chat.object.content),
         );
         xp.send(job.send.chat, () => {
@@ -223,15 +235,37 @@ describe('Platform', () => {
         });
       });
 
-      // FIXME, this is not testing the original input from above
-      it('calls xmpp.js correctly when called for a groupchat', (done) => {
+      it('calls xmpp.js correctly for a groupchat', (done) => {
+        // FIXME wrong message also passes
         const message = xmlFake(
-          "message",
-          {type: job.send.chat.target['type'] === 'room' ? 'groupchat' : 'chat',
-            to: job.send.chat.target['id']},
-          xmlFake("body", {}, job.send.chat.object.content),
+          "message", {
+            type: 'groupchat',
+            to: job.send.groupchat.target['id'],
+            id: job.send.groupchat.object['id']
+          },
+          xmlFake("body", {}, job.send.groupchat.object.content),
         );
         xp.send(job.send.groupchat, () => {
+          sinon.assert.calledWith(xp.__client.send, message);
+          done();
+        });
+      });
+
+      it('calls xmpp.js correctly for a message correction', (done) => {
+        // FIXME wrong message also passes
+        const message = xmlFake(
+          "message", {
+            type: 'groupchat',
+            to: job.send.correction.target['id'],
+            id: job.send.correction.object['id'],
+          },
+          xmlFake("body", {}, job.send.correction.object.content),
+          xmlFake("replace", {
+            id: job.send.correction.object.replace.id,
+            xmlns: 'urn:xmpp:message-correct:0' }
+          )
+        );
+        xp.send(job.send.correction, () => {
           sinon.assert.calledWith(xp.__client.send, message);
           done();
         });


### PR DESCRIPTION
As per XEP-0308, and with the same AS object format as incoming corrections are forward to clients.

(Note: the XML fakes are still not tested correctly. I added FIXME comments, but since I wasn't able to drive-by-fix them easily, and they're already broken in master since before I worked on message corrections, I consider the problem out of scope for these feature PRs.)