### PR TITLE
Remove `?.` conditional accessor from JS code

### DIFF
--- a/packages/sockethub-schemas/src/validator.js
+++ b/packages/sockethub-schemas/src/validator.js
@@ -31,6 +31,8 @@ function getTypeList(msg) {
   let types = [];
   if ((typeof msg === 'object') && (msg.type)) {
     types.push(msg.type);
+  } else {
+    types.push(undefined);
   }
   for (let prop in msg) {
     if ((typeof msg[prop] === 'object') && (msg[prop].type)) {
@@ -142,7 +144,6 @@ function validatePlatformSchema(schema) {
   // validate schema property
   const err = validate(schema);
   if (! err) {
-    console.log('res: ', validate);
     return `platform schema failed to validate: ` +
       `${validate.errors[0].instancePath} ${validate.errors[0].message}`;
   } else {

--- a/packages/sockethub-schemas/src/validator.js
+++ b/packages/sockethub-schemas/src/validator.js
@@ -28,9 +28,12 @@ function parseMsg(error) {
 }
 
 function getTypeList(msg) {
-  let types = [ msg?.type ];
+  let types = [];
+  if ((typeof msg === 'object') && (msg.type)) {
+    types.push(msg.type);
+  }
   for (let prop in msg) {
-    if (msg[prop]?.type) {
+    if ((typeof msg[prop] === 'object') && (msg[prop].type)) {
       types = [...types, ...getTypeList(msg[prop])];
     }
   }


### PR DESCRIPTION
It was only being used in one place, and I didn't notice the incompatibility as I'm running node `16.5` locally. This way we can keep node `12` support. Eventually this will be TypeScript so it doesn't matter that we don't use this in the JS.
