### PR TITLE
Fix XMPP example - target format

### DIFF
--- a/packages/server/views/examples/xmpp.ejs
+++ b/packages/server/views/examples/xmpp.ejs
@@ -134,7 +134,10 @@
             type: 'message',
             content: text_message
           },
-          target: target
+          target: {
+            id: target,
+            type: 'person'
+          }
         };
 
         console.log('[normalize?] sending ', msg);


### PR DESCRIPTION
As a quick short-hand, if you use `an@xmpp.address: a message` in the text input, it uses the data left of the `:` as the target, this fixes the object format. 