### PR TITLE
Ensure bootstrap initialization is only run once

### DIFF
--- a/packages/server/src/bootstrap/init.test.ts
+++ b/packages/server/src/bootstrap/init.test.ts
@@ -1,0 +1,35 @@
+import { expect } from "chai";
+import * as sinon from "sinon";
+import getInitObject, { __clearInit, IInitObject } from "./init";
+import { SinonStub } from "sinon";
+
+describe("Init", () => {
+    const initObject = {
+        version: "init object",
+        platforms: new Map(),
+    } as IInitObject;
+    let loadInitMock: SinonStub;
+
+    beforeEach(() => {
+        __clearInit();
+        loadInitMock = sinon.stub().callsFake(async () => {
+            return Promise.resolve(initObject);
+        });
+    });
+
+    it("getInitObject calls __loadInit", async () => {
+        const i = await getInitObject(loadInitMock);
+        expect(i).to.eql(initObject);
+        sinon.assert.calledOnce(loadInitMock);
+    });
+
+    it("__loadInit is only called once", async () => {
+        getInitObject(loadInitMock);
+        getInitObject(loadInitMock);
+        getInitObject(loadInitMock);
+        getInitObject(loadInitMock);
+        const i = await getInitObject(loadInitMock);
+        expect(i).to.eql(initObject);
+        sinon.assert.calledOnce(loadInitMock);
+    });
+});

--- a/packages/server/src/bootstrap/init.ts
+++ b/packages/server/src/bootstrap/init.ts
@@ -66,13 +66,32 @@ function printSettingsInfo(version, platforms) {
     console.log();
     process.exit();
 }
+
+let initCalled = false;
 export default async function getInitObject(): Promise<IInitObject> {
-    if (init) {
-        return init;
-    } else {
-        return await loadInit();
-    }
+    return new Promise((resolve, reject) => {
+        if (initCalled) {
+            setTimeout(() => {
+                if (!init) {
+                    reject("failed to initialize");
+                } else {
+                    resolve(init);
+                }
+            }, 500);
+        } else {
+            initCalled = true;
+            if (init) {
+                resolve(init);
+            } else {
+                loadInit().then((_init) => {
+                    init = _init;
+                    resolve(init);
+                });
+            }
+        }
+    });
 }
+
 async function loadInit(): Promise<IInitObject> {
     log("running init routines");
     // eslint-disable-next-line @typescript-eslint/no-var-requires

--- a/packages/server/src/bootstrap/init.ts
+++ b/packages/server/src/bootstrap/init.ts
@@ -68,7 +68,9 @@ function printSettingsInfo(version, platforms) {
 }
 
 let initCalled = false;
-export default async function getInitObject(): Promise<IInitObject> {
+export default async function getInitObject(
+    initFunc = __loadInit,
+): Promise<IInitObject> {
     return new Promise((resolve, reject) => {
         if (initCalled) {
             setTimeout(() => {
@@ -83,7 +85,7 @@ export default async function getInitObject(): Promise<IInitObject> {
             if (init) {
                 resolve(init);
             } else {
-                loadInit().then((_init) => {
+                initFunc().then((_init) => {
                     init = _init;
                     resolve(init);
                 });
@@ -92,7 +94,7 @@ export default async function getInitObject(): Promise<IInitObject> {
     });
 }
 
-async function loadInit(): Promise<IInitObject> {
+async function __loadInit(): Promise<IInitObject> {
     log("running init routines");
     // eslint-disable-next-line @typescript-eslint/no-var-requires
     const packageJSON = require("./../../package.json");
@@ -109,4 +111,9 @@ async function loadInit(): Promise<IInitObject> {
         version: version,
         platforms: platforms,
     };
+}
+
+export function __clearInit() {
+    init = undefined;
+    initCalled = false;
 }


### PR DESCRIPTION
There was a bug (that didn't seem to produce any symptoms) where the bootstrap process was being run twice during startup. This fixes the issue and adds some tests.