### PR TITLE
Define bun in each package.json

### DIFF
--- a/packages/activity-streams/package.json
+++ b/packages/activity-streams/package.json
@@ -7,21 +7,9 @@
     "files": [
         "dist/"
     ],
-    "dependencies": {
-        "eventemitter3": "5.0.1"
-    },
-    "devDependencies": {
-        "@sockethub/schemas": "workspace:*",
-        "@types/bun": "latest",
-        "@web/test-runner": "^0.19.0",
-        "@web/test-runner-puppeteer": "^0.17.0"
-    },
-    "scripts": {
-        "build": "bun run clean && bun run build:js && bun run build:minify",
-        "build:js": "bun build ./src/activity-streams.ts --outdir=dist/ --target=browser --sourcemap=inline --format=esm",
-        "build:minify": "bun build ./src/activity-streams.ts --target=browser --sourcemap=inline --minify --outfile=dist/activity-streams.min.js",
-        "clean": "rm -rf dist",
-        "test:browser": "wtr dist/**/*.test.js --node-resolve --puppeteer"
+    "packageManager": "bun@1.2.2",
+    "engines": {
+        "bun": ">=1.2"
     },
     "repository": {
         "type": "git",
@@ -39,5 +27,21 @@
     "bugs": {
         "url": "https://github.com/sockethub/sockethub/issues"
     },
-    "homepage": "https://github.com/sockethub/sockethub/tree/master/packages/activity-streams"
+    "homepage": "https://github.com/sockethub/sockethub/tree/master/packages/activity-streams",
+    "scripts": {
+        "build": "bun run clean && bun run build:js && bun run build:minify",
+        "build:js": "bun build ./src/activity-streams.ts --outdir=dist/ --target=browser --sourcemap=inline --format=esm",
+        "build:minify": "bun build ./src/activity-streams.ts --target=browser --sourcemap=inline --minify --outfile=dist/activity-streams.min.js",
+        "clean": "rm -rf dist",
+        "test:browser": "wtr dist/**/*.test.js --node-resolve --puppeteer"
+    },
+    "dependencies": {
+        "eventemitter3": "5.0.1"
+    },
+    "devDependencies": {
+        "@sockethub/schemas": "workspace:*",
+        "@types/bun": "latest",
+        "@web/test-runner": "^0.19.0",
+        "@web/test-runner-puppeteer": "^0.17.0"
+    }
 }

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -6,6 +6,10 @@
     "files": [
         "dist/"
     ],
+    "packageManager": "bun@1.2.2",
+    "engines": {
+        "bun": ">=1.2"
+    },
     "repository": {
         "type": "git",
         "url": "git+https://github.com/sockethub/sockethub.git",

--- a/packages/crypto/package.json
+++ b/packages/crypto/package.json
@@ -7,6 +7,10 @@
     "author": "Nick Jennings <nick@silverbucket.net>",
     "license": "MIT",
     "main": "src/index.ts",
+    "packageManager": "bun@1.2.2",
+    "engines": {
+        "bun": ">=1.2"
+    },
     "keywords": [
         "sockethub",
         "messaging",
@@ -24,9 +28,6 @@
     "dependencies": {
         "@sockethub/schemas": "workspace:*",
         "object-hash": "3.0.0"
-    },
-    "engines": {
-        "bun": ">= 1.2"
     },
     "devDependencies": {
         "@types/bun": "latest",

--- a/packages/data-layer/package.json
+++ b/packages/data-layer/package.json
@@ -7,6 +7,10 @@
     "author": "Nick Jennings <nick@silverbucket.net>",
     "license": "MIT",
     "main": "src/index.ts",
+    "packageManager": "bun@1.2.2",
+    "engines": {
+        "bun": ">=1.2"
+    },
     "keywords": [
         "sockethub",
         "messaging",
@@ -28,9 +32,6 @@
         "debug": "4.3.4",
         "ioredis": "5.3.2",
         "secure-store-redis": "3.0.7"
-    },
-    "engines": {
-        "bun": ">= 1.2"
     },
     "devDependencies": {
         "@types/bun": "latest",

--- a/packages/examples/package.json
+++ b/packages/examples/package.json
@@ -1,11 +1,14 @@
 {
     "name": "@sockethub/examples",
     "version": "1.0.0-alpha.4",
-    "packageManager": "bun@1.2.2",
     "type": "module",
     "files": [
         "build"
     ],
+    "packageManager": "bun@1.2.2",
+    "engines": {
+        "bun": ">=1.2"
+    },
     "keywords": [
         "sockethub",
         "example",

--- a/packages/irc2as/package.json
+++ b/packages/irc2as/package.json
@@ -4,6 +4,10 @@
     "description": "IRC to ActivityStreams objects",
     "type": "module",
     "main": "src/index.js",
+    "packageManager": "bun@1.2.2",
+    "engines": {
+        "bun": ">=1.2"
+    },
     "repository": {
         "type": "git",
         "url": "git+https://github.com/sockethub/sockethub.git",

--- a/packages/platform-dummy/package.json
+++ b/packages/platform-dummy/package.json
@@ -7,6 +7,10 @@
     "author": "Nick Jennings <nick@silverbucket.net>",
     "license": "LGPL-3.0+",
     "main": "src/index.ts",
+    "packageManager": "bun@1.2.2",
+    "engines": {
+        "bun": ">=1.2"
+    },
     "keywords": [
         "sockethub",
         "dummy"

--- a/packages/platform-feeds/package.json
+++ b/packages/platform-feeds/package.json
@@ -10,6 +10,10 @@
     "files": [
         "src/"
     ],
+    "packageManager": "bun@1.2.2",
+    "engines": {
+        "bun": ">=1.2"
+    },
     "keywords": [
         "sockethub",
         "messaging",

--- a/packages/platform-irc/package.json
+++ b/packages/platform-irc/package.json
@@ -7,6 +7,10 @@
     "license": "LGPL-3.0+",
     "type": "module",
     "main": "src/index.ts",
+    "packageManager": "bun@1.2.2",
+    "engines": {
+        "bun": ">=1.2"
+    },
     "keywords": [
         "sockethub",
         "messaging",

--- a/packages/platform-xmpp/package.json
+++ b/packages/platform-xmpp/package.json
@@ -7,6 +7,10 @@
     "author": "Nick Jennings <nick@silverbucket.net>",
     "license": "LGPL-3.0+",
     "main": "src/index.js",
+    "packageManager": "bun@1.2.2",
+    "engines": {
+        "bun": ">=1.2"
+    },
     "keywords": [
         "sockethub",
         "messaging",

--- a/packages/schemas/package.json
+++ b/packages/schemas/package.json
@@ -10,6 +10,10 @@
     "files": [
         "src/schemas"
     ],
+    "packageManager": "bun@1.2.2",
+    "engines": {
+        "bun": ">=1.2"
+    },
     "keywords": [
         "sockethub",
         "sockethub schema",

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -9,6 +9,10 @@
     "main": "src/index.ts",
     "bin": "bin/sockethub",
     "preferGlobal": true,
+    "packageManager": "bun@1.2.2",
+    "engines": {
+        "bun": ">=1.2"
+    },
     "keywords": [
         "sockethub",
         "messaging",
@@ -52,9 +56,6 @@
     "scripts": {
         "start": "DEBUG=sockethub* ./bin/sockethub",
         "dev": "DEBUG=sockethub* ./bin/sockethub --examples"
-    },
-    "engines": {
-        "bun": ">=1.2"
     },
     "devDependencies": {
         "@types/body-parser": "1.19.5",

--- a/packages/sockethub/package.json
+++ b/packages/sockethub/package.json
@@ -8,6 +8,10 @@
     "main": "",
     "bin": "bin/sockethub",
     "preferGlobal": true,
+    "packageManager": "bun@1.2.2",
+    "engines": {
+        "bun": ">=1.2"
+    },
     "keywords": [
         "sockethub",
         "messaging",
@@ -44,8 +48,5 @@
         "build": "bun build.js",
         "dev": "DEBUG=sockethub* ./bin/sockethub --examples",
         "start": "DEBUG=sockethub* ./bin/sockethub"
-    },
-    "engines": {
-        "bun": ">=1.2"
     }
 }


### PR DESCRIPTION
Renovatebot seems confused, thinking sub-packages are still managed by npm while the root is bun. Setting bun in each package.json to be explicit.