### PR TITLE
Add disconnect() function for XMPP and IRC platforms

### DIFF
--- a/packages/platform-irc/src/index.test.ts
+++ b/packages/platform-irc/src/index.test.ts
@@ -75,6 +75,7 @@ describe("Initialize IRC Platform", () => {
             "send",
             "query",
             "announce",
+            "disconnect"
         ]);
     });
 

--- a/packages/platform-irc/src/index.test.ts
+++ b/packages/platform-irc/src/index.test.ts
@@ -246,6 +246,25 @@ describe("Initialize IRC Platform", () => {
                 platform.completeJob();
             });
 
+            it("disconnect()", (done) => {
+                expect(platform.config.initialized).toEqual(true);
+                let cleanupCalled = false;
+                platform.cleanup = (cb) => {
+                    cleanupCalled = true;
+                    cb();
+                }
+                platform.disconnect({
+                        context: "irc",
+                        type: "disconnect",
+                        actor: actor,
+                    },
+                    () => {
+                    expect(platform.config.initialized).toEqual(true);
+                    expect(cleanupCalled).toEqual(true);
+                    done();
+                });
+            });
+
             it("cleanup()", (done) => {
                 expect(platform.config.initialized).toEqual(true);
                 platform.cleanup(() => {

--- a/packages/platform-irc/src/index.ts
+++ b/packages/platform-irc/src/index.ts
@@ -502,6 +502,22 @@ export default class IRC implements PlatformInterface {
         });
     }
 
+    /**
+     * Disconnect IRC client
+     * @param {object} job activity streams object
+     * @param done
+     *
+     * @example
+     *
+     * {
+     *    context: 'irc',
+     *    type: 'disconnect',
+     *    actor: {
+     *      id: 'slvrbckt@irc.freenode.net',
+     *      type: 'person'
+     *    }
+     *  }
+     */
     disconnect(job: ActivityStream, done: PlatformCallback) {
         this.debug(`disconnect called for ${job.actor.id}`);
         this.client(done);

--- a/packages/platform-irc/src/index.ts
+++ b/packages/platform-irc/src/index.ts
@@ -502,15 +502,20 @@ export default class IRC implements PlatformInterface {
         });
     }
 
+    disconnect(job: ActivityStream, done: PlatformCallback) {
+        this.debug(`disconnect called for ${job.actor.id}`);
+        this.client(done);
+    }
+
     cleanup(done: PlatformCallback) {
         this.debug("cleanup() called");
+        this.config.initialized = false;
         this.forceDisconnect = true;
         if (typeof this.client === "object") {
             if (typeof this.client.end === "function") {
                 this.client.end();
             }
         }
-        this.config.initialized = false;
         this.client = undefined;
         return done();
     }

--- a/packages/platform-irc/src/index.ts
+++ b/packages/platform-irc/src/index.ts
@@ -520,7 +520,7 @@ export default class IRC implements PlatformInterface {
      */
     disconnect(job: ActivityStream, done: PlatformCallback) {
         this.debug(`disconnect called for ${job.actor.id}`);
-        this.client(done);
+        this.cleanup(done);
     }
 
     cleanup(done: PlatformCallback) {

--- a/packages/platform-irc/src/schema.ts
+++ b/packages/platform-irc/src/schema.ts
@@ -16,6 +16,7 @@ export const PlatformIrcSchema = {
                     "send",
                     "query",
                     "announce",
+                    "disconnect",
                 ],
             },
         },

--- a/packages/platform-xmpp/src/index.js
+++ b/packages/platform-xmpp/src/index.js
@@ -546,7 +546,7 @@ export default class XMPP {
      */
     cleanup(done) {
         this.debug("cleanup");
-        this.initialized = false;
+        this.config.initialized = false;
         this.__client.stop();
         done();
     }

--- a/packages/platform-xmpp/src/index.js
+++ b/packages/platform-xmpp/src/index.js
@@ -519,12 +519,34 @@ export default class XMPP {
     }
 
     /**
+     * Disconnect XMPP client
+     * @param {object} job activity streams object
+     * @param done
+     *
+     * @example
+     *
+     * {
+     *    context: 'xmpp',
+     *    type: 'disconnect',
+     *    actor: {
+     *      id: 'slvrbckt@jabber.net/Home',
+     *      type: 'person'
+     *    }
+     *  }
+     */
+    disconnect(job, done) {
+        this.debug("disconnecting");
+        this.cleanup(done);
+    }
+
+    /**
      * Called when it's time to close any connections or clean data before being wiped
      * forcefully.
      * @param {function} done - callback when complete
      */
     cleanup(done) {
-        this.debug("attempting to close connection now");
+        this.debug("cleanup");
+        this.initialized = false;
         this.__client.stop();
         done();
     }

--- a/packages/platform-xmpp/src/index.test.js
+++ b/packages/platform-xmpp/src/index.test.js
@@ -144,6 +144,7 @@ describe("Platform", () => {
             start: sinon.fake.resolves(),
             send: sinon.fake.resolves(),
             join: sinon.fake.resolves(),
+            stop: sinon.fake.resolves()
         };
         clientFake = sinon.fake.returns(clientObjectFake);
         xmlFake = sinon.fake();
@@ -426,6 +427,31 @@ describe("Platform", () => {
                     done();
                 });
             });
+        });
+
+        describe("#disconnect", () => {
+            it("calls cleanup", (done) => {
+                let cleanupCalled = false;
+                xp.cleanup = (done) => {
+                    cleanupCalled = true;
+                    done();
+                }
+                xp.disconnect(job, () => {
+                    expect(cleanupCalled).toEqual(true);
+                    done()
+                });
+            })
+        });
+
+        describe("#cleanup", () => {
+            it("calls client.stop", (done) => {
+                expect(xp.config.initialized).toEqual(true);
+                xp.cleanup(() => {
+                    expect(xp.config.initialized).toEqual(false);
+                    sinon.assert.calledOnce(xp.__client.stop);
+                    done()
+                });
+            })
         });
     });
 });

--- a/packages/platform-xmpp/src/schema.js
+++ b/packages/platform-xmpp/src/schema.js
@@ -9,14 +9,15 @@ export const PlatformSchema = {
             type: {
                 enum: [
                     "connect",
-                    "update",
-                    "send",
                     "join",
                     "leave",
-                    "query",
+                    "send",
+                    "update",
                     "request-friend",
                     "remove-friend",
                     "make-friend",
+                    "query",
+                    "disconnect",
                 ],
             },
         },


### PR DESCRIPTION
Added `disctonnect()` functions for both IRC and XMPP platforms, which calls cleanup and sets `initialized` to `false`, which - when checked with the `janitor` process - will indicate the thread can be destroyed.