### PR TITLE
fix(release): remove custom changelog preset causing module not found error

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -7,27 +7,7 @@
       "conventionalCommits": true,
       "createRelease": "github",
       "message": "chore(release): prepare %s",
-      "ignoreChanges": ["**/*.md", "**/*.test.ts", "**/test/**"],
-      "changelogPreset": {
-        "name": "conventionalcommits",
-        "types": [
-          { "type": "feat", "section": "Features" },
-          { "type": "fix", "section": "Bug Fixes" },
-          { "type": "perf", "section": "Performance Improvements" },
-          { "type": "revert", "section": "Reverts" },
-          { "type": "docs", "section": "Documentation", "hidden": false },
-          { "type": "style", "section": "Styles", "hidden": true },
-          {
-            "type": "chore",
-            "section": "Miscellaneous Chores",
-            "hidden": true
-          },
-          { "type": "refactor", "section": "Code Refactoring", "hidden": true },
-          { "type": "test", "section": "Tests", "hidden": true },
-          { "type": "build", "section": "Build System", "hidden": true },
-          { "type": "ci", "section": "Continuous Integration", "hidden": true }
-        ]
-      }
+      "ignoreChanges": ["**/*.md", "**/*.test.ts", "**/test/**"]
     },
     "publish": {
       "registry": "https://registry.npmjs.org/"


### PR DESCRIPTION
Fixes the release-prepare workflow failure caused by missing `conventional-changelog-conventionalcommits` module.

The custom `changelogPreset` config was trying to load a preset that isn't installed. Lerna's default conventional changelog preset works fine and doesn't need customization for our use case.

Fixes https://github.com/sockethub/sockethub/actions/runs/20834702207