### PR TITLE
fix(release): format package.json files after lerna version to prevent lint failures

### DIFF
--- a/.github/workflows/release-prepare.yml
+++ b/.github/workflows/release-prepare.yml
@@ -72,6 +72,13 @@ jobs:
           find packages -name "CHANGELOG.md" -type f -delete
           echo "Removed per-package changelogs, keeping root CHANGELOG.md only"
 
+      - name: Fix package.json formatting
+        run: |
+          # Lerna modifies package.json with inconsistent formatting
+          # Run biome format to fix any formatting issues
+          bunx biome format --write "packages/*/package.json"
+          echo "Fixed package.json formatting"
+
       - name: Extract new version
         id: extract_version
         run: |


### PR DESCRIPTION
Fixes formatting issues in the release-prepare workflow where Lerna modifies package.json files with inconsistent array spacing (e.g., `["dist/"]` vs `[ "dist/" ]`).

After Lerna runs `version`, we now run `biome format` on all package.json files to ensure consistent formatting before committing, preventing lint failures in the release PR.

Fixes https://github.com/sockethub/sockethub/pull/949 formatting issues