### PR TITLE
fix(server): make examples package optional and add publishConfig

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -1,6 +1,5 @@
 {
   "lockfileVersion": 1,
-  "configVersion": 0,
   "workspaces": {
     "": {
       "name": "root",
@@ -9,10 +8,10 @@
         "@esm-bundle/chai": "^4.3.4-fix.0",
         "@lerna-lite/cli": "4.9.0",
         "@lerna-lite/publish": "4.9.0",
-        "@sockethub/client": "workspace:5.0.0-alpha.4",
-        "@sockethub/data-layer": "workspace:1.0.0-alpha.4",
-        "@sockethub/examples": "workspace:1.0.0-alpha.4",
-        "@sockethub/schemas": "workspace:3.0.0-alpha.4",
+        "@sockethub/client": "workspace:5.0.0-alpha.5",
+        "@sockethub/data-layer": "workspace:1.0.0-alpha.5",
+        "@sockethub/examples": "workspace:1.0.0-alpha.5",
+        "@sockethub/schemas": "workspace:3.0.0-alpha.5",
         "@types/bun": "^1.2.22",
         "@types/mocha": "10.0.10",
         "@web/test-runner": "^0.20.2",
@@ -29,7 +28,7 @@
     },
     "packages/activity-streams": {
       "name": "@sockethub/activity-streams",
-      "version": "4.4.0-alpha.4",
+      "version": "4.4.0-alpha.5",
       "dependencies": {
         "eventemitter3": "5.0.1",
       },
@@ -42,7 +41,7 @@
     },
     "packages/client": {
       "name": "@sockethub/client",
-      "version": "5.0.0-alpha.4",
+      "version": "5.0.0-alpha.5",
       "dependencies": {
         "eventemitter3": "5.0.1",
       },
@@ -59,7 +58,7 @@
     },
     "packages/crypto": {
       "name": "@sockethub/crypto",
-      "version": "1.0.0-alpha.4",
+      "version": "1.0.0-alpha.5",
       "dependencies": {
         "@sockethub/schemas": "workspace:*",
         "object-hash": "3.0.0",
@@ -74,7 +73,7 @@
     },
     "packages/data-layer": {
       "name": "@sockethub/data-layer",
-      "version": "1.0.0-alpha.4",
+      "version": "1.0.0-alpha.5",
       "dependencies": {
         "@sockethub/crypto": "workspace:*",
         "@sockethub/schemas": "workspace:*",
@@ -94,7 +93,7 @@
     },
     "packages/examples": {
       "name": "@sockethub/examples",
-      "version": "1.0.0-alpha.4",
+      "version": "1.0.0-alpha.5",
       "devDependencies": {
         "@playwright/test": "^1.50.1",
         "@sockethub/client": "workspace:^",
@@ -119,7 +118,7 @@
     },
     "packages/irc2as": {
       "name": "@sockethub/irc2as",
-      "version": "4.0.0-alpha.4",
+      "version": "4.0.0-alpha.5",
       "dependencies": {
         "debug": "^4.4.0",
         "fast-deep-equal": "^3.1.3",
@@ -130,7 +129,7 @@
     },
     "packages/platform-dummy": {
       "name": "@sockethub/platform-dummy",
-      "version": "3.0.0-alpha.4",
+      "version": "3.0.0-alpha.5",
       "devDependencies": {
         "@sockethub/schemas": "workspace:*",
         "@types/bun": "latest",
@@ -144,7 +143,7 @@
     },
     "packages/platform-feeds": {
       "name": "@sockethub/platform-feeds",
-      "version": "4.0.0-alpha.4",
+      "version": "4.0.0-alpha.5",
       "dependencies": {
         "html-tags": "3.3.1",
         "htmlparser2": "9.0.0",
@@ -164,9 +163,9 @@
     },
     "packages/platform-irc": {
       "name": "@sockethub/platform-irc",
-      "version": "4.0.0-alpha.4",
+      "version": "4.0.0-alpha.5",
       "dependencies": {
-        "@sockethub/irc2as": "workspace:4.0.0-alpha.4",
+        "@sockethub/irc2as": "workspace:4.0.0-alpha.5",
         "irc-socket-sasl": "4.0.0",
       },
       "devDependencies": {
@@ -183,7 +182,7 @@
     },
     "packages/platform-metadata": {
       "name": "@sockethub/platform-metadata",
-      "version": "1.0.0",
+      "version": "1.0.1-alpha.0",
       "dependencies": {
         "open-graph-scraper": "^6.9.0",
       },
@@ -196,7 +195,7 @@
     },
     "packages/platform-xmpp": {
       "name": "@sockethub/platform-xmpp",
-      "version": "5.0.0-alpha.4",
+      "version": "5.0.0-alpha.5",
       "dependencies": {
         "@xmpp/client": "^0.13.1",
       },
@@ -215,7 +214,7 @@
     },
     "packages/schemas": {
       "name": "@sockethub/schemas",
-      "version": "3.0.0-alpha.4",
+      "version": "3.0.0-alpha.5",
       "dependencies": {
         "ajv": "8.12.0",
         "ajv-formats": "2.1.1",
@@ -229,7 +228,7 @@
     },
     "packages/server": {
       "name": "@sockethub/server",
-      "version": "5.0.0-alpha.4",
+      "version": "5.0.0-alpha.5",
       "bin": "bin/sockethub",
       "dependencies": {
         "@sentry/bun": "^10.15.0",
@@ -237,7 +236,6 @@
         "@sockethub/client": "workspace:^",
         "@sockethub/crypto": "workspace:^",
         "@sockethub/data-layer": "workspace:^",
-        "@sockethub/examples": "workspace:^",
         "@sockethub/schemas": "workspace:^",
         "body-parser": "1.20.3",
         "chalk": "^5.3.0",
@@ -262,6 +260,7 @@
         "web-streams-polyfill": "^3.3.3",
       },
       "optionalDependencies": {
+        "@sockethub/examples": "workspace:^",
         "@sockethub/platform-dummy": "workspace:*",
         "@sockethub/platform-feeds": "workspace:*",
         "@sockethub/platform-irc": "workspace:*",
@@ -271,7 +270,7 @@
     },
     "packages/sockethub": {
       "name": "sockethub",
-      "version": "5.0.0-alpha.4",
+      "version": "5.0.0-alpha.5",
       "bin": "bin/sockethub",
       "dependencies": {
         "@sockethub/platform-dummy": "workspace:*",

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
   },
   "scripts": {
     "build": "bun run --filter='*' build && bun run build:server:post",
-    "build:server:post": "rm -rf packages/server/res && mkdir -p  packages/server/res && cp -r node_modules/@sockethub/examples/build packages/server/res/examples && cp node_modules/@sockethub/client/dist/* packages/server/res/ && cp node_modules/socket.io-client/dist/socket.io.js packages/server/res/socket.io.js",
+    "build:server:post": "rm -rf packages/server/res && mkdir -p packages/server/res && cp node_modules/@sockethub/client/dist/* packages/server/res/ && cp node_modules/socket.io-client/dist/socket.io.js packages/server/res/socket.io.js",
     "clean": "bun run --filter='*' clean",
     "clean:deps": "bun run --filter='*' clean:deps && bunx rimraf node_modules",
     "dev": "bun run build && cd packages/sockethub && bun run dev",

--- a/packages/activity-streams/package.json
+++ b/packages/activity-streams/package.json
@@ -16,6 +16,9 @@
   "keywords": ["activity", "streams", "json-ld", "activity-streams"],
   "author": "Nick Jennings <nick@silverbucket.net>",
   "license": "MIT",
+  "publishConfig": {
+    "access": "public"
+  },
   "bugs": {
     "url": "https://github.com/sockethub/sockethub/issues"
   },

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -15,6 +15,9 @@
   "homepage": "https://github.com/sockethub/sockethub/tree/master/packages/client",
   "author": "Nick Jennings <nick@silverbucket.net>",
   "license": "LGPL-3.0+",
+  "publishConfig": {
+    "access": "public"
+  },
   "keywords": [
     "sockethub",
     "messaging",

--- a/packages/crypto/package.json
+++ b/packages/crypto/package.json
@@ -6,6 +6,9 @@
   "private": false,
   "author": "Nick Jennings <nick@silverbucket.net>",
   "license": "MIT",
+  "publishConfig": {
+    "access": "public"
+  },
   "main": "src/index.ts",
   "engines": {
     "bun": ">=1.2"

--- a/packages/data-layer/package.json
+++ b/packages/data-layer/package.json
@@ -6,6 +6,9 @@
   "private": false,
   "author": "Nick Jennings <nick@silverbucket.net>",
   "license": "MIT",
+  "publishConfig": {
+    "access": "public"
+  },
   "main": "src/index.ts",
   "engines": {
     "bun": ">=1.2"

--- a/packages/examples/package.json
+++ b/packages/examples/package.json
@@ -15,6 +15,9 @@
   "homepage": "https://github.com/sockethub/sockethub/tree/master/packages/examples",
   "author": "Nick Jennings <nick@silverbucket.net>",
   "license": "LGPL-3.0+",
+  "publishConfig": {
+    "access": "public"
+  },
   "scripts": {
     "dev": "bunx --bun vite dev",
     "build": "bunx --bun vite build",

--- a/packages/irc2as/package.json
+++ b/packages/irc2as/package.json
@@ -15,6 +15,9 @@
   "keywords": ["irc", "activitystreams", "activity-streams", "sockethub"],
   "author": "Nick Jennings <nick@silverbucket.net>",
   "license": "MIT",
+  "publishConfig": {
+    "access": "public"
+  },
   "bugs": {
     "url": "https://github.com/sockethub/sockethub/issues"
   },

--- a/packages/platform-dummy/package.json
+++ b/packages/platform-dummy/package.json
@@ -6,6 +6,9 @@
   "private": false,
   "author": "Nick Jennings <nick@silverbucket.net>",
   "license": "LGPL-3.0+",
+  "publishConfig": {
+    "access": "public"
+  },
   "main": "src/index.ts",
   "engines": {
     "bun": ">=1.2"

--- a/packages/platform-feeds/package.json
+++ b/packages/platform-feeds/package.json
@@ -6,6 +6,9 @@
   "private": false,
   "author": "Nick Jennings <nick@silverbucket.net>",
   "license": "LGPL-3.0+",
+  "publishConfig": {
+    "access": "public"
+  },
   "main": "./src/index.ts",
   "files": ["src/"],
   "engines": {

--- a/packages/platform-irc/package.json
+++ b/packages/platform-irc/package.json
@@ -5,6 +5,9 @@
   "private": false,
   "author": "Nick Jennings <nick@silverbucket.net>",
   "license": "LGPL-3.0+",
+  "publishConfig": {
+    "access": "public"
+  },
   "type": "module",
   "main": "src/index.ts",
   "engines": {

--- a/packages/platform-metadata/package.json
+++ b/packages/platform-metadata/package.json
@@ -4,6 +4,9 @@
   "description": "Fetch metadata from a given URL",
   "author": "Nick Jennings <nick@silverbucket.net>",
   "license": "LGPL-3.0+",
+  "publishConfig": {
+    "access": "public"
+  },
   "type": "module",
   "main": "src/index.ts",
   "engines": {

--- a/packages/platform-xmpp/package.json
+++ b/packages/platform-xmpp/package.json
@@ -6,6 +6,9 @@
   "type": "module",
   "author": "Nick Jennings <nick@silverbucket.net>",
   "license": "LGPL-3.0+",
+  "publishConfig": {
+    "access": "public"
+  },
   "main": "src/index.js",
   "engines": {
     "bun": ">=1.2"

--- a/packages/schemas/package.json
+++ b/packages/schemas/package.json
@@ -6,6 +6,9 @@
   "private": false,
   "author": "Nick Jennings <nick@silverbucket.net>",
   "license": "MIT",
+  "publishConfig": {
+    "access": "public"
+  },
   "main": "src/index.ts",
   "files": ["src/schemas"],
   "engines": {

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -6,6 +6,9 @@
   "private": false,
   "author": "Nick Jennings <nick@silverbucket.net>",
   "license": "LGPL-3.0+",
+  "publishConfig": {
+    "access": "public"
+  },
   "main": "src/index.ts",
   "bin": "bin/sockethub",
   "preferGlobal": true,
@@ -43,7 +46,6 @@
     "@sockethub/client": "workspace:^",
     "@sockethub/crypto": "workspace:^",
     "@sockethub/data-layer": "workspace:^",
-    "@sockethub/examples": "workspace:^",
     "@sockethub/schemas": "workspace:^",
     "body-parser": "1.20.3",
     "chalk": "^5.3.0",
@@ -72,6 +74,7 @@
     "web-streams-polyfill": "^3.3.3"
   },
   "optionalDependencies": {
+    "@sockethub/examples": "workspace:^",
     "@sockethub/platform-dummy": "workspace:*",
     "@sockethub/platform-feeds": "workspace:*",
     "@sockethub/platform-irc": "workspace:*",


### PR DESCRIPTION
## Summary

- Add `publishConfig` with `access: public` to all `@sockethub/*` packages to fix E402 "must sign up for private packages" npm error
- Move `@sockethub/examples` from `dependencies` to `optionalDependencies` in server package
- Remove bundled examples fallback from build process
- Dynamically resolve `@sockethub/examples` at runtime via `require.resolve()`
- Exit with clear error message if `--examples` flag used without package installed

## Behavior

**Dev mode (workspace):** Examples resolve automatically via workspace link

**npm install:** Users who want examples must explicitly install:
```
bun add @sockethub/examples
```

If `--examples` is used without the package installed:
```
❌ Error: --examples flag requires @sockethub/examples package

The examples package is not installed. To use the examples feature, install it:

  bun add @sockethub/examples

Or run sockethub without the --examples flag.
```

## Test plan

- [x] `bun run lint` passes
- [x] `bun run build` passes  
- [x] `bun test` passes
- [x] Examples resolve correctly in dev mode via workspace