### PR TITLE
ci: add release unpublish workflow

### DIFF
--- a/.github/workflows/release-unpublish.yml
+++ b/.github/workflows/release-unpublish.yml
@@ -139,6 +139,7 @@ jobs:
         if: inputs.unpublish_npm && steps.npm_check.outputs.has_published == 'true'
         run: |
           echo "//registry.npmjs.org/:_authToken=${{ secrets.NPM_TOKEN }}" > ~/.npmrc
+          chmod 600 ~/.npmrc
 
       - name: Unpublish npm packages
         if: inputs.unpublish_npm && steps.npm_check.outputs.has_published == 'true'


### PR DESCRIPTION
## Summary

Adds a manually triggered workflow to unpublish failed releases.

## Features

- **Delete GitHub release** - removes the release from GitHub
- **Delete git tag** - removes the tag from remote
- **Unpublish npm packages** - unpublishes any packages published for that version (only works within 72 hours of publishing)

Each action can be toggled independently via workflow inputs.

## Usage

1. Go to **Actions** → **Unpublish Release**
2. Click **Run workflow**
3. Enter the version (e.g., `5.0.0-alpha.5`)
4. Select which actions to perform
5. Click **Run workflow**

## Test plan

- [ ] Merge PR
- [ ] Run workflow with version `5.0.0-alpha.5` to clean up the failed release