### PR TITLE
ci: fix release check in unpublish workflow

### DIFF
--- a/.github/workflows/release-unpublish.yml
+++ b/.github/workflows/release-unpublish.yml
@@ -62,11 +62,11 @@ jobs:
           echo ""
 
           # Check GitHub release
-          RELEASE_EXISTS=$(gh release view "$TAG" --json tagName 2>/dev/null && echo "true" || echo "false")
-          echo "release_exists=$RELEASE_EXISTS" >> $GITHUB_OUTPUT
-          if [ "$RELEASE_EXISTS" = "true" ]; then
+          if gh release view "$TAG" &>/dev/null; then
+            echo "release_exists=true" >> $GITHUB_OUTPUT
             echo "✅ GitHub release exists: $TAG"
           else
+            echo "release_exists=false" >> $GITHUB_OUTPUT
             echo "ℹ️ No GitHub release found for $TAG"
           fi
 


### PR DESCRIPTION
## Summary

Fixes the release unpublish workflow which was failing with:
```
Invalid format 'true'
```

The issue was that `gh release view --json tagName` outputs JSON, which was being captured along with "true" in the variable, then written to `$GITHUB_OUTPUT`.

## Fix

Changed from:
```bash
RELEASE_EXISTS=$(gh release view "$TAG" --json tagName 2>/dev/null && echo "true" || echo "false")
```

To:
```bash
if gh release view "$TAG" &>/dev/null; then
  echo "release_exists=true" >> $GITHUB_OUTPUT
```

## Test plan

- [ ] Merge and re-run unpublish workflow with version `5.0.0-alpha.5`