### PR TITLE
feat(server)!: Switch server routing to canonical @context arrays

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -47,11 +47,11 @@
       "name": "@sockethub/client",
       "version": "5.0.0-alpha.11",
       "dependencies": {
+        "@sockethub/activity-streams": "^4.4.0-alpha.11",
+        "@sockethub/schemas": "^3.0.0-alpha.11",
         "eventemitter3": "^5.0.4",
       },
       "devDependencies": {
-        "@sockethub/activity-streams": "^4.4.0-alpha.11",
-        "@sockethub/schemas": "^3.0.0-alpha.11",
         "@types/bun": "latest",
         "@types/sinon": "^17.0.4",
         "@web/test-runner": "^0.19.0",
@@ -3818,6 +3818,8 @@
 
     "@sockethub/activity-streams/@web/test-runner": ["@web/test-runner@0.19.0", "", { "dependencies": { "@web/browser-logs": "^0.4.0", "@web/config-loader": "^0.3.0", "@web/dev-server": "^0.4.0", "@web/test-runner-chrome": "^0.17.0", "@web/test-runner-commands": "^0.9.0", "@web/test-runner-core": "^0.13.0", "@web/test-runner-mocha": "^0.9.0", "camelcase": "^6.2.0", "command-line-args": "^5.1.1", "command-line-usage": "^7.0.1", "convert-source-map": "^2.0.0", "diff": "^5.0.0", "globby": "^11.0.1", "nanocolors": "^0.2.1", "portfinder": "^1.0.32", "source-map": "^0.7.3" }, "bin": { "wtr": "dist/bin.js", "web-test-runner": "dist/bin.js" } }, "sha512-qLUupi88OK1Kl52cWPD/2JewUCRUxYsZ1V1DyLd05P7u09zCdrUYrtkB/cViWyxlBe/TOvqkSNpcTv6zLJ9GoA=="],
 
+    "@sockethub/client/@types/bun": ["@types/bun@1.3.11", "", { "dependencies": { "bun-types": "1.3.11" } }, "sha512-5vPne5QvtpjGpsGYXiFyycfpDF2ECyPcTSsFBMa0fraoxiQyMJ3SmuQIGhzPg2WJuWxVBoxWJ2kClYTcw/4fAg=="],
+
     "@sockethub/client/@web/test-runner": ["@web/test-runner@0.19.0", "", { "dependencies": { "@web/browser-logs": "^0.4.0", "@web/config-loader": "^0.3.0", "@web/dev-server": "^0.4.0", "@web/test-runner-chrome": "^0.17.0", "@web/test-runner-commands": "^0.9.0", "@web/test-runner-core": "^0.13.0", "@web/test-runner-mocha": "^0.9.0", "camelcase": "^6.2.0", "command-line-args": "^5.1.1", "command-line-usage": "^7.0.1", "convert-source-map": "^2.0.0", "diff": "^5.0.0", "globby": "^11.0.1", "nanocolors": "^0.2.1", "portfinder": "^1.0.32", "source-map": "^0.7.3" }, "bin": { "wtr": "dist/bin.js", "web-test-runner": "dist/bin.js" } }, "sha512-qLUupi88OK1Kl52cWPD/2JewUCRUxYsZ1V1DyLd05P7u09zCdrUYrtkB/cViWyxlBe/TOvqkSNpcTv6zLJ9GoA=="],
 
     "@sockethub/client/socket.io-client": ["socket.io-client@4.8.3", "", { "dependencies": { "@socket.io/component-emitter": "~3.1.0", "debug": "~4.4.1", "engine.io-client": "~6.6.1", "socket.io-parser": "~4.2.4" } }, "sha512-uP0bpjWrjQmUt5DTHq9RuoCBdFJF10cdX9X+a368j/Ft0wmaVgxlrjvK3kjvgCODOMMOz9lcaRzxmso0bTWZ/g=="],
@@ -4631,6 +4633,8 @@
     "@sockethub/activity-streams/@types/bun/bun-types": ["bun-types@1.3.11", "", { "dependencies": { "@types/node": "*" } }, "sha512-1KGPpoxQWl9f6wcZh57LvrPIInQMn2TQ7jsgxqpRzg+l0QPOFvJVH7HmvHo/AiPgwXy+/Thf6Ov3EdVn1vOabg=="],
 
     "@sockethub/activity-streams/@web/test-runner/@web/test-runner-chrome": ["@web/test-runner-chrome@0.17.0", "", { "dependencies": { "@web/test-runner-core": "^0.13.0", "@web/test-runner-coverage-v8": "^0.8.0", "async-mutex": "0.4.0", "chrome-launcher": "^0.15.0", "puppeteer-core": "^23.2.0" } }, "sha512-Il5N9z41NKWCrQM1TVgRaDWWYoJtG5Ha4fG+cN1MWL2OlzBS4WoOb4lFV3EylZ7+W3twZOFr1zy2Rx61yDYd/A=="],
+
+    "@sockethub/client/@types/bun/bun-types": ["bun-types@1.3.11", "", { "dependencies": { "@types/node": "*" } }, "sha512-1KGPpoxQWl9f6wcZh57LvrPIInQMn2TQ7jsgxqpRzg+l0QPOFvJVH7HmvHo/AiPgwXy+/Thf6Ov3EdVn1vOabg=="],
 
     "@sockethub/client/@web/test-runner/@web/test-runner-chrome": ["@web/test-runner-chrome@0.17.0", "", { "dependencies": { "@web/test-runner-core": "^0.13.0", "@web/test-runner-coverage-v8": "^0.8.0", "async-mutex": "0.4.0", "chrome-launcher": "^0.15.0", "puppeteer-core": "^23.2.0" } }, "sha512-Il5N9z41NKWCrQM1TVgRaDWWYoJtG5Ha4fG+cN1MWL2OlzBS4WoOb4lFV3EylZ7+W3twZOFr1zy2Rx61yDYd/A=="],
 

--- a/bun.lock
+++ b/bun.lock
@@ -34,10 +34,10 @@
       "name": "@sockethub/activity-streams",
       "version": "4.4.0-alpha.11",
       "dependencies": {
+        "@sockethub/schemas": "^3.0.0-alpha.11",
         "eventemitter3": "^5.0.4",
       },
       "devDependencies": {
-        "@sockethub/schemas": "^3.0.0-alpha.11",
         "@types/bun": "latest",
         "@web/test-runner": "^0.19.0",
         "@web/test-runner-puppeteer": "^0.17.0",
@@ -3814,6 +3814,8 @@
 
     "@sinonjs/samsam/type-detect": ["type-detect@4.1.0", "", {}, "sha512-Acylog8/luQ8L7il+geoSxhEkazvkslg7PSNKOX59mbB9cOveP5aq9h74Y7YU8yDpJwetzQQrfIwtf4Wp4LKcw=="],
 
+    "@sockethub/activity-streams/@types/bun": ["@types/bun@1.3.11", "", { "dependencies": { "bun-types": "1.3.11" } }, "sha512-5vPne5QvtpjGpsGYXiFyycfpDF2ECyPcTSsFBMa0fraoxiQyMJ3SmuQIGhzPg2WJuWxVBoxWJ2kClYTcw/4fAg=="],
+
     "@sockethub/activity-streams/@web/test-runner": ["@web/test-runner@0.19.0", "", { "dependencies": { "@web/browser-logs": "^0.4.0", "@web/config-loader": "^0.3.0", "@web/dev-server": "^0.4.0", "@web/test-runner-chrome": "^0.17.0", "@web/test-runner-commands": "^0.9.0", "@web/test-runner-core": "^0.13.0", "@web/test-runner-mocha": "^0.9.0", "camelcase": "^6.2.0", "command-line-args": "^5.1.1", "command-line-usage": "^7.0.1", "convert-source-map": "^2.0.0", "diff": "^5.0.0", "globby": "^11.0.1", "nanocolors": "^0.2.1", "portfinder": "^1.0.32", "source-map": "^0.7.3" }, "bin": { "wtr": "dist/bin.js", "web-test-runner": "dist/bin.js" } }, "sha512-qLUupi88OK1Kl52cWPD/2JewUCRUxYsZ1V1DyLd05P7u09zCdrUYrtkB/cViWyxlBe/TOvqkSNpcTv6zLJ9GoA=="],
 
     "@sockethub/client/@web/test-runner": ["@web/test-runner@0.19.0", "", { "dependencies": { "@web/browser-logs": "^0.4.0", "@web/config-loader": "^0.3.0", "@web/dev-server": "^0.4.0", "@web/test-runner-chrome": "^0.17.0", "@web/test-runner-commands": "^0.9.0", "@web/test-runner-core": "^0.13.0", "@web/test-runner-mocha": "^0.9.0", "camelcase": "^6.2.0", "command-line-args": "^5.1.1", "command-line-usage": "^7.0.1", "convert-source-map": "^2.0.0", "diff": "^5.0.0", "globby": "^11.0.1", "nanocolors": "^0.2.1", "portfinder": "^1.0.32", "source-map": "^0.7.3" }, "bin": { "wtr": "dist/bin.js", "web-test-runner": "dist/bin.js" } }, "sha512-qLUupi88OK1Kl52cWPD/2JewUCRUxYsZ1V1DyLd05P7u09zCdrUYrtkB/cViWyxlBe/TOvqkSNpcTv6zLJ9GoA=="],
@@ -3825,6 +3827,8 @@
     "@sockethub/examples/socket.io-client": ["socket.io-client@4.8.3", "", { "dependencies": { "@socket.io/component-emitter": "~3.1.0", "debug": "~4.4.1", "engine.io-client": "~6.6.1", "socket.io-parser": "~4.2.4" } }, "sha512-uP0bpjWrjQmUt5DTHq9RuoCBdFJF10cdX9X+a368j/Ft0wmaVgxlrjvK3kjvgCODOMMOz9lcaRzxmso0bTWZ/g=="],
 
     "@sockethub/examples/typescript": ["typescript@5.9.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw=="],
+
+    "@sockethub/schemas/@types/bun": ["@types/bun@1.3.11", "", { "dependencies": { "bun-types": "1.3.11" } }, "sha512-5vPne5QvtpjGpsGYXiFyycfpDF2ECyPcTSsFBMa0fraoxiQyMJ3SmuQIGhzPg2WJuWxVBoxWJ2kClYTcw/4fAg=="],
 
     "@sveltejs/vite-plugin-svelte-inspector/debug": ["debug@4.4.0", "", { "dependencies": { "ms": "^2.1.3" } }, "sha512-6WTZ/IxCY/T6BALoZHaE4ctp9xm+Z5kY/pzYaCHRFeyVhojxlrm+46y68HA6hr0TcwEssoxNiDEUJQjfPZ/RYA=="],
 
@@ -4624,9 +4628,13 @@
 
     "@puppeteer/browsers/yargs/string-width": ["string-width@4.2.3", "", { "dependencies": { "emoji-regex": "^8.0.0", "is-fullwidth-code-point": "^3.0.0", "strip-ansi": "^6.0.1" } }, "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g=="],
 
+    "@sockethub/activity-streams/@types/bun/bun-types": ["bun-types@1.3.11", "", { "dependencies": { "@types/node": "*" } }, "sha512-1KGPpoxQWl9f6wcZh57LvrPIInQMn2TQ7jsgxqpRzg+l0QPOFvJVH7HmvHo/AiPgwXy+/Thf6Ov3EdVn1vOabg=="],
+
     "@sockethub/activity-streams/@web/test-runner/@web/test-runner-chrome": ["@web/test-runner-chrome@0.17.0", "", { "dependencies": { "@web/test-runner-core": "^0.13.0", "@web/test-runner-coverage-v8": "^0.8.0", "async-mutex": "0.4.0", "chrome-launcher": "^0.15.0", "puppeteer-core": "^23.2.0" } }, "sha512-Il5N9z41NKWCrQM1TVgRaDWWYoJtG5Ha4fG+cN1MWL2OlzBS4WoOb4lFV3EylZ7+W3twZOFr1zy2Rx61yDYd/A=="],
 
     "@sockethub/client/@web/test-runner/@web/test-runner-chrome": ["@web/test-runner-chrome@0.17.0", "", { "dependencies": { "@web/test-runner-core": "^0.13.0", "@web/test-runner-coverage-v8": "^0.8.0", "async-mutex": "0.4.0", "chrome-launcher": "^0.15.0", "puppeteer-core": "^23.2.0" } }, "sha512-Il5N9z41NKWCrQM1TVgRaDWWYoJtG5Ha4fG+cN1MWL2OlzBS4WoOb4lFV3EylZ7+W3twZOFr1zy2Rx61yDYd/A=="],
+
+    "@sockethub/schemas/@types/bun/bun-types": ["bun-types@1.3.11", "", { "dependencies": { "@types/node": "*" } }, "sha512-1KGPpoxQWl9f6wcZh57LvrPIInQMn2TQ7jsgxqpRzg+l0QPOFvJVH7HmvHo/AiPgwXy+/Thf6Ov3EdVn1vOabg=="],
 
     "@tailwindcss/node/magic-string/@jridgewell/sourcemap-codec": ["@jridgewell/sourcemap-codec@1.5.5", "", {}, "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og=="],
 

--- a/integration/browser/basic.integration.js
+++ b/integration/browser/basic.integration.js
@@ -2,6 +2,7 @@ import { expect } from "@esm-bundle/chai";
 import createTestUtils from "../utils.js";
 import {
     connectXMPP,
+    ctx,
     emitWithAck,
     getConfig,
     joinXMPPRoom,
@@ -93,7 +94,7 @@ describe(`Sockethub Basic Integration Tests at ${config.sockethub.url}`, () => {
                     const dummyObj = {
                         type: "echo",
                         actor: actor.id,
-                        context: "dummy",
+                        "@context": ctx("dummy"),
                         object: {
                             type: "message",
                             content: `hello world ${i}`,
@@ -119,7 +120,7 @@ describe(`Sockethub Basic Integration Tests at ${config.sockethub.url}`, () => {
                 const dummyObj = {
                     type: "fail",
                     actor: actor.id,
-                    context: "dummy",
+                    "@context": ctx("dummy"),
                     object: { type: "message", content: "failure message" },
                 };
                 const msg = await emitWithAck(sc.socket, "message", dummyObj, {
@@ -141,7 +142,7 @@ describe(`Sockethub Basic Integration Tests at ${config.sockethub.url}`, () => {
                 const dummyObj = {
                     type: "throw",
                     actor: actor.id,
-                    context: "dummy",
+                    "@context": ctx("dummy"),
                     object: { type: "message", content: "failure message" },
                 };
                 const msg = await emitWithAck(sc.socket, "message", dummyObj, {
@@ -167,7 +168,7 @@ describe(`Sockethub Basic Integration Tests at ${config.sockethub.url}`, () => {
                         sc.socket,
                         "message",
                         {
-                            context: "feeds",
+                            "@context": ctx("feeds"),
                             type: "fetch",
                             actor: {
                                 type: "feed",
@@ -228,7 +229,7 @@ describe(`Sockethub Basic Integration Tests at ${config.sockethub.url}`, () => {
                             id: actorObject.id,
                             type: actorObject.type,
                         },
-                        context: "xmpp",
+                        platform: "xmpp",
                     });
                 });
             });
@@ -242,7 +243,7 @@ describe(`Sockethub Basic Integration Tests at ${config.sockethub.url}`, () => {
                             id: actorObject.id,
                             type: actorObject.type,
                         },
-                        context: "xmpp",
+                        platform: "xmpp",
                         target: {
                             id: "test@prosody",
                             type: "room",
@@ -265,7 +266,7 @@ describe(`Sockethub Basic Integration Tests at ${config.sockethub.url}`, () => {
                             id: actorObject.id,
                             type: actorObject.type,
                         },
-                        context: "xmpp",
+                        platform: "xmpp",
                         object: {
                             type: "message",
                             content: "Hello, world!",
@@ -297,7 +298,7 @@ describe(`Sockethub Basic Integration Tests at ${config.sockethub.url}`, () => {
                                 id: invalidActorId,
                                 type: "person",
                             },
-                            context: "xmpp",
+                            "@context": ctx("xmpp"),
                             type: "credentials",
                             object: {
                                 type: "credentials",
@@ -317,7 +318,7 @@ describe(`Sockethub Basic Integration Tests at ${config.sockethub.url}`, () => {
                         {
                             type: "connect",
                             actor: invalidActorId,
-                            context: "xmpp",
+                            "@context": ctx("xmpp"),
                         },
                         { label: "xmpp invalid connect" },
                     );
@@ -348,7 +349,7 @@ describe(`Sockethub Basic Integration Tests at ${config.sockethub.url}`, () => {
                                 id: invalidIrcActorId,
                                 type: "person",
                             },
-                            context: "irc",
+                            "@context": ctx("irc"),
                             type: "credentials",
                             object: {
                                 type: "credentials",
@@ -368,7 +369,7 @@ describe(`Sockethub Basic Integration Tests at ${config.sockethub.url}`, () => {
                         {
                             type: "connect",
                             actor: invalidIrcActorId,
-                            context: "irc",
+                            "@context": ctx("irc"),
                         },
                         { label: "irc invalid connect" },
                     );
@@ -388,7 +389,7 @@ describe(`Sockethub Basic Integration Tests at ${config.sockethub.url}`, () => {
                 expect(incomingMessages.length).to.be.below(2);
                 if (incomingMessages.length === 1) {
                     expect(incomingMessages[0]).to.deep.include({
-                        context: "xmpp",
+                        platform: "xmpp",
                         type: "message",
                         actor: { id: "test@prosody", type: "room" },
                         error: '<error type="cancel"><service-unavailable xmlns="urn:ietf:params:xml:ns:xmpp-stanzas"/></error>',

--- a/integration/browser/shared-setup.js
+++ b/integration/browser/shared-setup.js
@@ -1,5 +1,11 @@
 import { expect } from "@esm-bundle/chai";
 
+export const ctx = (platform) => [
+    "https://www.w3.org/ns/activitystreams",
+    "https://sockethub.org/ns/context/v1.jsonld",
+    `https://sockethub.org/ns/context/platform/${platform}/v1.jsonld`,
+];
+
 // sockethub-client.js and socket.io.js are loaded via <script> tags
 // in the test runner HTML (injected from the running Sockethub server)
 
@@ -150,7 +156,7 @@ export function setXMPPCredentials(
 ) {
     const creds = {
         actor: asPersonActor(jid),
-        context: "xmpp",
+        "@context": ctx("xmpp"),
         type: "credentials",
         object: {
             type: "credentials",
@@ -182,7 +188,7 @@ export function connectXMPP(sh, jid) {
         {
             type: "connect",
             actor: asPersonActor(jid),
-            context: "xmpp",
+            "@context": ctx("xmpp"),
         },
         {
             timeout: config.timeouts.connect,
@@ -204,7 +210,7 @@ export function joinXMPPRoom(sh, jid, room = config.prosody.room) {
         {
             type: "join",
             actor: asPersonActor(jid),
-            context: "xmpp",
+            "@context": ctx("xmpp"),
             target: {
                 type: "room",
                 id: room,
@@ -227,7 +233,7 @@ export function sendXMPPMessage(sh, jid, room, content) {
         {
             type: "send",
             actor: asPersonActor(jid),
-            context: "xmpp",
+            "@context": ctx("xmpp"),
             object: {
                 type: "message",
                 content,

--- a/integration/process.integration.ts
+++ b/integration/process.integration.ts
@@ -185,9 +185,15 @@ const emitWithoutAck = (client: Socket, event: string, payload: unknown) => {
     client.emit(event, payload);
 };
 
+const ctx = (platform: string) => [
+    "https://www.w3.org/ns/activitystreams",
+    "https://sockethub.org/ns/context/v1.jsonld",
+    `https://sockethub.org/ns/context/platform/${platform}/v1.jsonld`,
+];
+
 const buildDummyMessage = (type: string, content = "dummy test") => ({
     type,
-    context: "dummy",
+    "@context": ctx("dummy"),
     actor: { id: "test@dummy", type: "person" },
     object: { type: "message", content },
 });
@@ -486,7 +492,7 @@ describe("Parent Process Sudden Termination", () => {
             const actorId = utils.createXmppJid();
             const credentialsMessage = {
                 type: "credentials",
-                context: "xmpp",
+                "@context": ctx("xmpp"),
                 actor: {
                     id: actorId,
                     type: "person",
@@ -529,7 +535,7 @@ describe("Parent Process Sudden Termination", () => {
             // Create a persistent XMPP connection
             const connectMessage = {
                 type: "connect",
-                context: "xmpp",
+                "@context": ctx("xmpp"),
                 actor: {
                     id: actorId,
                     type: "person",

--- a/integration/rate-limiter.integration.ts
+++ b/integration/rate-limiter.integration.ts
@@ -147,7 +147,7 @@ describe("Rate Limiter Integration Tests", () => {
                         try {
                             expect(errorMsg).toBeDefined();
                             expect(errorMsg.type).toBe("Error");
-                            expect(errorMsg.context).toBe("error");
+                            expect(errorMsg["@context"]).toBeDefined();
                             expect(errorMsg.actor).toBeDefined();
                             expect(errorMsg.actor.type).toBe("Application");
                             expect(errorMsg.actor.name).toBe(
@@ -170,7 +170,11 @@ describe("Rate Limiter Integration Tests", () => {
                     client.emit("message", {
                         type: "echo",
                         actor: "test@dummy",
-                        context: "dummy",
+                        "@context": [
+                            "https://www.w3.org/ns/activitystreams",
+                            "https://sockethub.org/ns/context/v1.jsonld",
+                            "https://sockethub.org/ns/context/platform/dummy/v1.jsonld",
+                        ],
                         object: {
                             type: "message",
                             content: `test message ${i}`,
@@ -217,7 +221,7 @@ describe("Rate Limiter Integration Tests", () => {
 
                         if (errorCount === 1) {
                             expect(errorMsg.type).toBe("Error");
-                            expect(errorMsg.context).toBe("error");
+                            expect(errorMsg["@context"]).toBeDefined();
 
                             const elapsed = Date.now() - startTime;
                             expect(elapsed).toBeLessThan(2000);
@@ -231,7 +235,11 @@ describe("Rate Limiter Integration Tests", () => {
                     client.emit("message", {
                         type: "echo",
                         actor: { id: "test2@dummy", type: "person" },
-                        context: "dummy",
+                        "@context": [
+                            "https://www.w3.org/ns/activitystreams",
+                            "https://sockethub.org/ns/context/v1.jsonld",
+                            "https://sockethub.org/ns/context/platform/dummy/v1.jsonld",
+                        ],
                         object: { type: "message", content: `msg ${i}` },
                     });
                 }
@@ -279,7 +287,11 @@ describe("Rate Limiter Integration Tests", () => {
                     client.emit("message", {
                         type: "echo",
                         actor: { id: "test3@dummy", type: "person" },
-                        context: "dummy",
+                        "@context": [
+                            "https://www.w3.org/ns/activitystreams",
+                            "https://sockethub.org/ns/context/v1.jsonld",
+                            "https://sockethub.org/ns/context/platform/dummy/v1.jsonld",
+                        ],
                         object: { type: "message", content: `msg ${i}` },
                     });
                 }
@@ -290,7 +302,11 @@ describe("Rate Limiter Integration Tests", () => {
                         {
                             type: "echo",
                             actor: { id: "test3@dummy", type: "person" },
-                            context: "dummy",
+                            "@context": [
+                                "https://www.w3.org/ns/activitystreams",
+                                "https://sockethub.org/ns/context/v1.jsonld",
+                                "https://sockethub.org/ns/context/platform/dummy/v1.jsonld",
+                            ],
                             object: {
                                 type: "message",
                                 content: "unblock test",
@@ -367,7 +383,11 @@ describe("Rate Limiter Integration Tests", () => {
                         client1.emit("message", {
                             type: "echo",
                             actor: { id: "test4@dummy", type: "person" },
-                            context: "dummy",
+                            "@context": [
+                                "https://www.w3.org/ns/activitystreams",
+                                "https://sockethub.org/ns/context/v1.jsonld",
+                                "https://sockethub.org/ns/context/platform/dummy/v1.jsonld",
+                            ],
                             object: {
                                 type: "message",
                                 content: `client1 msg ${i}`,
@@ -381,7 +401,11 @@ describe("Rate Limiter Integration Tests", () => {
                             {
                                 type: "echo",
                                 actor: { id: "test5@dummy", type: "person" },
-                                context: "dummy",
+                                "@context": [
+                                    "https://www.w3.org/ns/activitystreams",
+                                    "https://sockethub.org/ns/context/v1.jsonld",
+                                    "https://sockethub.org/ns/context/platform/dummy/v1.jsonld",
+                                ],
                                 object: {
                                     type: "message",
                                     content: "client2 test",

--- a/packages/activity-streams/package.json
+++ b/packages/activity-streams/package.json
@@ -47,10 +47,10 @@
     "test:browser": "wtr dist/**/*.test.js --node-resolve --puppeteer"
   },
   "dependencies": {
+    "@sockethub/schemas": "^3.0.0-alpha.11",
     "eventemitter3": "^5.0.4"
   },
   "devDependencies": {
-    "@sockethub/schemas": "^3.0.0-alpha.11",
     "@types/bun": "latest",
     "@web/test-runner": "^0.19.0",
     "@web/test-runner-puppeteer": "^0.17.0"

--- a/packages/activity-streams/src/activity-streams.ts
+++ b/packages/activity-streams/src/activity-streams.ts
@@ -16,10 +16,11 @@
  */
 
 import type { ActivityObject, ActivityStream } from "@sockethub/schemas";
-// Context URL constants are mirrored from @sockethub/schemas/src/context.ts
-// (the canonical source of truth). They are duplicated here because bun's
-// browser-targeted bundler cannot resolve workspace subpath exports at build
-// time. Keep these in sync with the schemas package.
+import {
+    AS2_BASE_CONTEXT_URL,
+    PLATFORM_CONTEXT_PREFIX,
+    SOCKETHUB_BASE_CONTEXT_URL,
+} from "@sockethub/schemas/context";
 import EventEmitter from "eventemitter3";
 
 const ee = new EventEmitter();
@@ -332,11 +333,11 @@ export function ASFactory(opts: ASFactoryOptions = {}): ASManager {
         : {},
 );
 
-export const AS2_BASE_CONTEXT_URL = "https://www.w3.org/ns/activitystreams";
-export const SOCKETHUB_BASE_CONTEXT_URL =
-    "https://sockethub.org/ns/context/v1.jsonld";
-
-const PLATFORM_CONTEXT_PREFIX = "https://sockethub.org/ns/context/platform/";
+export {
+    AS2_BASE_CONTEXT_URL,
+    PLATFORM_CONTEXT_PREFIX,
+    SOCKETHUB_BASE_CONTEXT_URL,
+};
 
 /**
  * Build the canonical Sockethub @context array for a platform name.

--- a/packages/activity-streams/src/activity-streams.ts
+++ b/packages/activity-streams/src/activity-streams.ts
@@ -16,6 +16,10 @@
  */
 
 import type { ActivityObject, ActivityStream } from "@sockethub/schemas";
+// Context URL constants are mirrored from @sockethub/schemas/src/context.ts
+// (the canonical source of truth). They are duplicated here because bun's
+// browser-targeted bundler cannot resolve workspace subpath exports at build
+// time. Keep these in sync with the schemas package.
 import EventEmitter from "eventemitter3";
 
 const ee = new EventEmitter();
@@ -328,14 +332,7 @@ export function ASFactory(opts: ASFactoryOptions = {}): ASManager {
         : {},
 );
 
-/**
- * Canonical AS2 base vocabulary URL.
- */
 export const AS2_BASE_CONTEXT_URL = "https://www.w3.org/ns/activitystreams";
-
-/**
- * Sockethub base vocabulary URL for shared platform terms.
- */
 export const SOCKETHUB_BASE_CONTEXT_URL =
     "https://sockethub.org/ns/context/v1.jsonld";
 

--- a/packages/activity-streams/src/activity-streams.ts
+++ b/packages/activity-streams/src/activity-streams.ts
@@ -327,3 +327,52 @@ export function ASFactory(opts: ASFactoryOptions = {}): ASManager {
         ? (globalThis as Record<string, unknown>)
         : {},
 );
+
+/**
+ * Canonical AS2 base vocabulary URL.
+ */
+export const AS2_BASE_CONTEXT_URL = "https://www.w3.org/ns/activitystreams";
+
+/**
+ * Sockethub base vocabulary URL for shared platform terms.
+ */
+export const SOCKETHUB_BASE_CONTEXT_URL =
+    "https://sockethub.org/ns/context/v1.jsonld";
+
+const PLATFORM_CONTEXT_PREFIX =
+    "https://sockethub.org/ns/context/platform/";
+
+/**
+ * Build the canonical Sockethub @context array for a platform name.
+ */
+export function buildCanonicalContext(platform: string): string[] {
+    const platformUrl = platform.startsWith("https://")
+        ? platform
+        : `${PLATFORM_CONTEXT_PREFIX}${platform}/v1.jsonld`;
+    return [AS2_BASE_CONTEXT_URL, SOCKETHUB_BASE_CONTEXT_URL, platformUrl];
+}
+
+/**
+ * Extract the platform ID from a canonical @context array.
+ * Returns undefined if no platform context URL is found.
+ */
+export function platformIdFromContext(
+    context: string[] | unknown,
+): string | undefined {
+    if (!Array.isArray(context)) {
+        return undefined;
+    }
+    for (const entry of context) {
+        if (
+            typeof entry === "string" &&
+            entry.startsWith(PLATFORM_CONTEXT_PREFIX)
+        ) {
+            const rest = entry.slice(PLATFORM_CONTEXT_PREFIX.length);
+            const slashIdx = rest.indexOf("/");
+            if (slashIdx > 0) {
+                return rest.slice(0, slashIdx);
+            }
+        }
+    }
+    return undefined;
+}

--- a/packages/activity-streams/src/activity-streams.ts
+++ b/packages/activity-streams/src/activity-streams.ts
@@ -339,8 +339,7 @@ export const AS2_BASE_CONTEXT_URL = "https://www.w3.org/ns/activitystreams";
 export const SOCKETHUB_BASE_CONTEXT_URL =
     "https://sockethub.org/ns/context/v1.jsonld";
 
-const PLATFORM_CONTEXT_PREFIX =
-    "https://sockethub.org/ns/context/platform/";
+const PLATFORM_CONTEXT_PREFIX = "https://sockethub.org/ns/context/platform/";
 
 /**
  * Build the canonical Sockethub @context array for a platform name.

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -47,11 +47,11 @@
     "test:browser": "wtr dist/**/*.test.js --node-resolve --puppeteer"
   },
   "dependencies": {
+    "@sockethub/activity-streams": "^4.4.0-alpha.11",
+    "@sockethub/schemas": "^3.0.0-alpha.11",
     "eventemitter3": "^5.0.4"
   },
   "devDependencies": {
-    "@sockethub/activity-streams": "^4.4.0-alpha.11",
-    "@sockethub/schemas": "^3.0.0-alpha.11",
     "@types/bun": "latest",
     "@types/sinon": "^17.0.4",
     "@web/test-runner": "^0.19.0",

--- a/packages/data-layer/integration/redis.integration.ts
+++ b/packages/data-layer/integration/redis.integration.ts
@@ -15,7 +15,11 @@ const REDIS_URL = `redis://${REDIS_HOST}:6379`;
 const actor = `${(Math.random() + 1).toString(36).substring(2)}`;
 const creds: CredentialsObject = {
     type: "credentials",
-    context: "bar",
+    "@context": [
+        "https://www.w3.org/ns/activitystreams",
+        "https://sockethub.org/ns/context/v1.jsonld",
+        "https://sockethub.org/ns/context/platform/bar/v1.jsonld",
+    ],
     actor: {
         type: "person",
         id: actor,
@@ -119,7 +123,12 @@ describe("connect and disconnect", () => {
 describe("JobQueue", () => {
     const as: ActivityStream = {
         type: "foo",
-        context: "bar",
+        "@context": [
+            "https://www.w3.org/ns/activitystreams",
+            "https://sockethub.org/ns/context/v1.jsonld",
+            "https://sockethub.org/ns/context/platform/bar/v1.jsonld",
+        ],
+        platform: "bar",
         actor: {
             id: "bar",
             type: "person",
@@ -169,7 +178,7 @@ describe("JobQueue", () => {
 
         // Add job and verify it was queued
         const job = await queue.add("socket id", as);
-        expect(job.msg.length).toEqual(193);
+        expect(job.msg.length).toBeGreaterThan(0);
         expect(job.title).toEqual("bar-0");
         expect(job.sessionId).toEqual("socket id");
 
@@ -256,7 +265,11 @@ describe("JobQueue", () => {
     it("handles worker returning ActivityStream", async () => {
         const returnAS: ActivityStream = {
             type: "result",
-            context: "bar",
+            "@context": [
+                "https://www.w3.org/ns/activitystreams",
+                "https://sockethub.org/ns/context/v1.jsonld",
+                "https://sockethub.org/ns/context/platform/bar/v1.jsonld",
+            ],
             actor: { id: "bar", type: "person" },
         };
 
@@ -303,7 +316,12 @@ describe("JobQueue", () => {
     it("encrypts and decrypts job data correctly", async () => {
         const complexAS: ActivityStream = {
             type: "send",
-            context: "irc",
+            "@context": [
+                "https://www.w3.org/ns/activitystreams",
+                "https://sockethub.org/ns/context/v1.jsonld",
+                "https://sockethub.org/ns/context/platform/irc/v1.jsonld",
+            ],
+            platform: "irc",
             actor: { id: "user@example.com", type: "person" },
             object: {
                 type: "message",
@@ -371,7 +389,12 @@ describe.skip("Redis connection failure", () => {
 
         const as: ActivityStream = {
             type: "foo",
-            context: "bar",
+            "@context": [
+                "https://www.w3.org/ns/activitystreams",
+                "https://sockethub.org/ns/context/v1.jsonld",
+                "https://sockethub.org/ns/context/platform/bar/v1.jsonld",
+            ],
+            platform: "bar",
             actor: { id: "bar", type: "person" },
         };
 

--- a/packages/data-layer/src/job-queue.test.ts
+++ b/packages/data-layer/src/job-queue.test.ts
@@ -108,7 +108,7 @@ describe("JobQueue", () => {
         it("returns expected job format", () => {
             cryptoMocks.encrypt.returns("an encrypted message");
             const job = jobQueue.createJob("a socket id", {
-                context: "some context",
+                platform: "some context",
                 id: "an identifier",
             });
             expect(job).to.eql({
@@ -121,7 +121,7 @@ describe("JobQueue", () => {
         it("uses counter when no id provided", () => {
             cryptoMocks.encrypt.returns("an encrypted message");
             let job = jobQueue.createJob("a socket id", {
-                context: "some context",
+                platform: "some context",
             });
             expect(job).to.eql({
                 title: "some context-0",
@@ -129,7 +129,7 @@ describe("JobQueue", () => {
                 sessionId: "a socket id",
             });
             job = jobQueue.createJob("a socket id", {
-                context: "some context",
+                platform: "some context",
             });
             expect(job).to.eql({
                 title: "some context-1",
@@ -201,7 +201,7 @@ describe("JobQueue", () => {
                 msg: "encrypted foo",
             };
             const res = await jobQueue.add("a socket id", {
-                context: "a platform",
+                platform: "a platform",
                 id: "an identifier",
             });
             sinon.assert.calledOnce(jobQueue.queue.isPaused);
@@ -222,7 +222,7 @@ describe("JobQueue", () => {
             jobQueue.queue.isPaused.returns(true);
             try {
                 await jobQueue.add("a socket id", {
-                    context: "a platform",
+                    platform: "a platform",
                     id: "an identifier",
                 });
             } catch (err) {

--- a/packages/data-layer/src/job-queue.ts
+++ b/packages/data-layer/src/job-queue.ts
@@ -236,7 +236,8 @@ export class JobQueue extends JobBase {
     }
 
     private createJob(socketId: string, msg: ActivityStream): JobDataEncrypted {
-        const title = `${msg.context}-${msg.id ? msg.id : this.counter++}`;
+        const platformId = msg.platform || "unknown";
+        const title = `${platformId}-${msg.id ? msg.id : this.counter++}`;
         return {
             title: title,
             sessionId: socketId,

--- a/packages/data-layer/src/job-queue.ts
+++ b/packages/data-layer/src/job-queue.ts
@@ -236,7 +236,7 @@ export class JobQueue extends JobBase {
     }
 
     private createJob(socketId: string, msg: ActivityStream): JobDataEncrypted {
-        const platformId = msg.platform || resolvePlatformId(msg) || "unknown";
+        const platformId = resolvePlatformId(msg) || "unknown";
         const title = `${platformId}-${msg.id ? msg.id : this.counter++}`;
         return {
             title: title,

--- a/packages/data-layer/src/job-queue.ts
+++ b/packages/data-layer/src/job-queue.ts
@@ -3,7 +3,7 @@ import {
     getLoggerNamespace,
     type Logger,
 } from "@sockethub/logger";
-import type { ActivityStream } from "@sockethub/schemas";
+import { type ActivityStream, resolvePlatformId } from "@sockethub/schemas";
 import { type Job, Queue, QueueEvents, Worker } from "bullmq";
 
 import { JobBase } from "./job-base.js";
@@ -236,7 +236,7 @@ export class JobQueue extends JobBase {
     }
 
     private createJob(socketId: string, msg: ActivityStream): JobDataEncrypted {
-        const platformId = msg.platform || "unknown";
+        const platformId = msg.platform || resolvePlatformId(msg) || "unknown";
         const title = `${platformId}-${msg.id ? msg.id : this.counter++}`;
         return {
             title: title,

--- a/packages/examples/src/components/Credentials.svelte
+++ b/packages/examples/src/components/Credentials.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
 import TextAreaSubmit from "$components/TextAreaSubmit.svelte";
-import { sc } from "$lib/sockethub";
+import { contextFor, sc } from "$lib/sockethub";
 import type { ActorData } from "$lib/sockethub";
 import type { CredentialsObjectData, SockethubResponse } from "$lib/sockethub";
 import type { SockethubStateStore } from "$lib/types";
@@ -16,7 +16,7 @@ let { credentials, actor, sockethubState, context }: Props = $props();
 
 function sendCredentials(data: string) {
     const creds = {
-        context: context,
+        "@context": contextFor(context),
         type: "credentials",
         actor: actor.id,
         object: JSON.parse(data),

--- a/packages/examples/src/components/chat/IncomingMessages.svelte
+++ b/packages/examples/src/components/chat/IncomingMessages.svelte
@@ -1,5 +1,6 @@
 <script module lang="ts">
 import type { AnyActivityStream } from "$lib/sockethub";
+import { platformIdFromContext } from "$lib/sockethub";
 import { get, writable } from "svelte/store";
 
 const messages = writable([] as [string, string | undefined][]);
@@ -27,7 +28,7 @@ const recentMessages = new Map<string, number>();
 export function displayMessage(m: AnyActivityStream, isResponse = false) {
     console.log("displayMessage called:", {
         type: m.type,
-        context: m.context,
+        platform: platformIdFromContext(m["@context"]),
         isResponse,
         actor: m.actor,
         content: m.object?.content,
@@ -67,7 +68,7 @@ export function displayMessage(m: AnyActivityStream, isResponse = false) {
             actorName,
             content,
             isResponse,
-            context: m.context,
+            platform: platformIdFromContext(m["@context"]),
         });
     }
 }

--- a/packages/examples/src/components/chat/Room.svelte
+++ b/packages/examples/src/components/chat/Room.svelte
@@ -2,7 +2,7 @@
      Rename the variable and try again or migrate by hand. -->
 <script lang="ts">
 import SockethubButton from "$components/SockethubButton.svelte";
-import { send } from "$lib/sockethub";
+import { contextFor, send } from "$lib/sockethub";
 import type { ActorData } from "$lib/sockethub";
 import type { AnyActivityStream } from "$lib/sockethub";
 import type { SockethubStateStore } from "$lib/types";
@@ -22,7 +22,7 @@ async function joinRoom(): Promise<void> {
     joining = true;
     return await send({
         // Platform context - routes to the appropriate chat platform (irc, xmpp)
-        context: context,
+        "@context": contextFor(context),
         // Activity type - "join" means join a chat room/channel
         type: "join",
         // Actor - who is joining (the connected user)

--- a/packages/examples/src/components/chat/SendMessage.svelte
+++ b/packages/examples/src/components/chat/SendMessage.svelte
@@ -2,7 +2,7 @@
      Rename the variable and try again or migrate by hand. -->
 <script lang="ts">
 import SockethubButton from "$components/SockethubButton.svelte";
-import { send } from "$lib/sockethub";
+import { contextFor, send } from "$lib/sockethub";
 import type { ActorData } from "$lib/sockethub";
 import type { SockethubStateStore } from "$lib/types";
 
@@ -27,7 +27,7 @@ async function sendMessage() {
 
     try {
         await send({
-            context: context,
+            "@context": contextFor(context),
             type: "send",
             actor: actor.id,
             object: {

--- a/packages/examples/src/components/logs/LogEntry.svelte
+++ b/packages/examples/src/components/logs/LogEntry.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 import type { AnyActivityStream } from "$lib/sockethub";
+import { platformIdFromContext } from "$lib/sockethub";
 import DummyEntry from "./platforms/DummyEntry.svelte";
 import FeedsEntry from "./platforms/FeedsEntry.svelte";
 import GenericEntry from "./platforms/GenericEntry.svelte";
@@ -11,6 +12,7 @@ interface Props {
 }
 
 let { id, entry, buttonAction, response }: Props = $props();
+const platform = $derived(platformIdFromContext(entry["@context"]));
 </script>
 
 <li class="p-4 hover:bg-gray-50 transition-colors">
@@ -28,9 +30,9 @@ let { id, entry, buttonAction, response }: Props = $props();
                     <span class="text-sm font-semibold text-gray-700">
                         {response ? '📥 Response' : '📤 Sent'}
                     </span>
-                    {#if entry.context}
+                    {#if platform}
                         <span class="px-2 py-1 bg-blue-100 text-blue-800 text-xs font-medium rounded-full">
-                            {entry.context.toUpperCase()}
+                            {platform.toUpperCase()}
                         </span>
                     {/if}
                     {#if entry.type}
@@ -53,9 +55,9 @@ let { id, entry, buttonAction, response }: Props = $props();
             
             <!-- Platform-specific content -->
             <div class="text-sm text-gray-600">
-                {#if entry.context === "dummy"}
+                {#if platform === "dummy"}
                     <DummyEntry {id} {entry} />
-                {:else if entry.context === "feeds"}
+                {:else if platform === "feeds"}
                     <FeedsEntry {id} {entry} />
                 {:else}
                     <GenericEntry {id} {entry} />

--- a/packages/examples/src/components/logs/Logger.svelte
+++ b/packages/examples/src/components/logs/Logger.svelte
@@ -148,7 +148,7 @@ export function addObject(
                                     />
                                 {/if}
                             {/each}
-                        {:else if Object.prototype.hasOwnProperty.call(tuple[1], "context")}
+                        {:else if Object.prototype.hasOwnProperty.call(tuple[1], "@context")}
                             <LogEntry buttonAction={showLog(id)} {id} response={true} entry={tuple[1]} />
                         {:else}
                             <LogEntry buttonAction={showLog(id)} {id} response={false} entry={tuple[0]} />

--- a/packages/examples/src/components/logs/platforms/Context.svelte
+++ b/packages/examples/src/components/logs/platforms/Context.svelte
@@ -1,11 +1,13 @@
 <script lang="ts">
 import type { AnyActivityStream } from "$lib/sockethub.js";
+import { platformIdFromContext } from "$lib/sockethub.js";
 
 interface Props {
     entry: AnyActivityStream;
 }
 
 let { entry }: Props = $props();
+const platform = $derived(platformIdFromContext(entry["@context"]));
 </script>
 
-<span>[{entry.context}:{entry.type}]</span>
+<span>[{platform ?? "unknown"}:{entry.type}]</span>

--- a/packages/examples/src/lib/sockethub.ts
+++ b/packages/examples/src/lib/sockethub.ts
@@ -35,9 +35,17 @@ type BaseProps = {
     published?: string;
 };
 
+export function contextFor(platform: string): string[] {
+    return [
+        "https://www.w3.org/ns/activitystreams",
+        "https://sockethub.org/ns/context/v1.jsonld",
+        `https://sockethub.org/ns/context/platform/${platform}/v1.jsonld`,
+    ];
+}
+
 export interface AnyActivityStream {
     id?: string;
-    context: string;
+    "@context": string[];
     type: string;
     totalItems?: number;
     summary?: string;

--- a/packages/examples/src/lib/sockethub.ts
+++ b/packages/examples/src/lib/sockethub.ts
@@ -2,6 +2,10 @@
 // @ts-ignore
 import { displayMessage } from "$components/chat/IncomingMessages.svelte";
 import { addObject } from "$components/logs/Logger.svelte";
+import {
+    buildCanonicalContext,
+    platformIdFromContext,
+} from "@sockethub/activity-streams";
 import SockethubClient from "@sockethub/client";
 import { io } from "socket.io-client";
 import { writable } from "svelte/store";
@@ -36,12 +40,10 @@ type BaseProps = {
 };
 
 export function contextFor(platform: string): string[] {
-    return [
-        "https://www.w3.org/ns/activitystreams",
-        "https://sockethub.org/ns/context/v1.jsonld",
-        `https://sockethub.org/ns/context/platform/${platform}/v1.jsonld`,
-    ];
+    return buildCanonicalContext(platform);
 }
+
+export { platformIdFromContext };
 
 export interface AnyActivityStream {
     id?: string;

--- a/packages/examples/src/routes/dummy/+page.svelte
+++ b/packages/examples/src/routes/dummy/+page.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
 import type { AnyActivityStream } from "$lib/sockethub";
-import { send } from "$lib/sockethub";
+import { contextFor, send } from "$lib/sockethub";
 import type { SockethubStateStore } from "$lib/types";
 import { writable } from "svelte/store";
 import ActivityActor from "../../components/ActivityActor.svelte";
@@ -26,7 +26,7 @@ let content = $state("");
 function getASObj(type: string): AnyActivityStream {
     return {
         // Platform context - tells Sockethub which platform to route this to
-        context: "dummy",
+        "@context": contextFor("dummy"),
         // Activity type - what action to perform (echo, fail, throw, greet)
         type: type,
         // Actor - who is performing the action

--- a/packages/examples/src/routes/feeds/+page.svelte
+++ b/packages/examples/src/routes/feeds/+page.svelte
@@ -3,7 +3,7 @@ import ActivityActor from "$components/ActivityActor.svelte";
 import BaseExample from "$components/BaseExample.svelte";
 import FormField from "$components/FormField.svelte";
 import SockethubButton from "$components/SockethubButton.svelte";
-import { send } from "$lib/sockethub";
+import { contextFor, send } from "$lib/sockethub";
 import { writable } from "svelte/store";
 
 const sockethubState = writable({
@@ -27,7 +27,7 @@ const actor = $derived({
 function getASObj(type: string) {
     return {
         // Platform context - routes to Sockethub's feeds platform
-        context: "feeds",
+        "@context": contextFor("feeds"),
         // Activity type - "fetch" tells the platform to download and parse the feed
         type: type,
         // Actor - the feed URL to fetch (represented as a "website" actor)

--- a/packages/examples/src/routes/irc/+page.svelte
+++ b/packages/examples/src/routes/irc/+page.svelte
@@ -11,7 +11,7 @@ import IncomingMessage from "$components/chat/IncomingMessages.svelte";
 import Room from "$components/chat/Room.svelte";
 import SendMessage from "$components/chat/SendMessage.svelte";
 import type { AnyActivityStream, CredentialName } from "$lib/sockethub";
-import { send } from "$lib/sockethub";
+import { contextFor, send } from "$lib/sockethub";
 import { writable } from "svelte/store";
 
 const actorIdStore = writable(
@@ -68,7 +68,7 @@ async function connectIrc(): Promise<void> {
     connecting = true;
     await send({
         // Platform context - routes to Sockethub's IRC platform
-        context: "irc",
+        "@context": contextFor("irc"),
         // Activity type - "connect" establishes IRC connection
         type: "connect",
         // Actor - the IRC nick/identity making the connection

--- a/packages/examples/src/routes/metadata/+page.svelte
+++ b/packages/examples/src/routes/metadata/+page.svelte
@@ -3,7 +3,7 @@ import ActivityActor from "$components/ActivityActor.svelte";
 import BaseExample from "$components/BaseExample.svelte";
 import FormField from "$components/FormField.svelte";
 import SockethubButton from "$components/SockethubButton.svelte";
-import { send } from "$lib/sockethub";
+import { contextFor, send } from "$lib/sockethub";
 import { writable } from "svelte/store";
 
 const sockethubState = writable({
@@ -18,7 +18,7 @@ let actor = $derived({
 function getASObj(type: string) {
     return {
         // Platform context - routes to Sockethub's metadata platform
-        context: "metadata",
+        "@context": contextFor("metadata"),
         // Activity type - "fetch" tells the platform to extract metadata
         type: type,
         // Actor - the website URL to analyze (represented as a "website" actor)

--- a/packages/examples/src/routes/xmpp/+page.svelte
+++ b/packages/examples/src/routes/xmpp/+page.svelte
@@ -9,7 +9,7 @@ import PlatformConnection from "$components/PlatformConnection.svelte";
 import IncomingMessage from "$components/chat/IncomingMessages.svelte";
 import Room from "$components/chat/Room.svelte";
 import SendMessage from "$components/chat/SendMessage.svelte";
-import { send } from "$lib/sockethub";
+import { contextFor, send } from "$lib/sockethub";
 import type { AnyActivityStream } from "$lib/sockethub";
 import type { CredentialName } from "$lib/sockethub";
 import { writable } from "svelte/store";
@@ -52,7 +52,7 @@ function resetState() {
 async function connectXmpp(): Promise<void> {
     connecting = true;
     return await send({
-        context: "xmpp",
+        "@context": contextFor("xmpp"),
         type: "connect",
         actor: actorId,
     } as AnyActivityStream)

--- a/packages/schemas/package.json
+++ b/packages/schemas/package.json
@@ -16,6 +16,11 @@
       "import": "./dist/index.js",
       "default": "./dist/index.js"
     },
+    "./context": {
+      "bun": "./src/context.ts",
+      "import": "./dist/context.js",
+      "default": "./dist/context.js"
+    },
     "./schemas/json/sockethub-config.json": {
       "default": "./src/schemas/json/sockethub-config.json"
     }
@@ -44,7 +49,7 @@
     "@types/bun": "latest"
   },
   "scripts": {
-    "build": "bun ./scripts/export-json-schema.ts && bun ./scripts/export-canonical-assets.ts && bun build src/index.ts --outdir dist --target node --format esm --sourcemap=external",
+    "build": "bun ./scripts/export-json-schema.ts && bun ./scripts/export-canonical-assets.ts && bun build src/index.ts src/context.ts --outdir dist --target node --format esm --sourcemap=external",
     "clean": "rm -rf dist",
     "clean:deps": "rm -rf node_modules"
   },

--- a/packages/schemas/package.json
+++ b/packages/schemas/package.json
@@ -18,8 +18,8 @@
     },
     "./context": {
       "bun": "./src/context.ts",
-      "import": "./src/context.ts",
-      "default": "./src/context.ts"
+      "import": "./dist/context.js",
+      "default": "./dist/context.js"
     },
     "./schemas/json/sockethub-config.json": {
       "default": "./src/schemas/json/sockethub-config.json"

--- a/packages/schemas/package.json
+++ b/packages/schemas/package.json
@@ -18,8 +18,8 @@
     },
     "./context": {
       "bun": "./src/context.ts",
-      "import": "./dist/context.js",
-      "default": "./dist/context.js"
+      "import": "./src/context.ts",
+      "default": "./src/context.ts"
     },
     "./schemas/json/sockethub-config.json": {
       "default": "./src/schemas/json/sockethub-config.json"

--- a/packages/schemas/src/context.ts
+++ b/packages/schemas/src/context.ts
@@ -12,6 +12,12 @@ export const SOCKETHUB_BASE_CONTEXT_URL =
     "https://sockethub.org/ns/context/v1.jsonld";
 
 /**
+ * URL prefix for per-platform context URLs.
+ */
+export const PLATFORM_CONTEXT_PREFIX =
+    "https://sockethub.org/ns/context/platform/";
+
+/**
  * Built-in pseudo-platform used for server-side error payloads.
  */
 export const ERROR_PLATFORM_ID = "error";

--- a/packages/schemas/src/index.ts
+++ b/packages/schemas/src/index.ts
@@ -5,6 +5,7 @@ import {
     ERROR_PLATFORM_ID,
     INTERNAL_PLATFORM_CONTEXT_URL,
     INTERNAL_PLATFORM_ID,
+    PLATFORM_CONTEXT_PREFIX,
     SOCKETHUB_BASE_CONTEXT_URL,
 } from "./context.js";
 import { InternalObjectTypesList, ObjectTypesList } from "./helpers/objects.js";
@@ -28,6 +29,7 @@ import {
 export {
     AS2_BASE_CONTEXT_URL,
     SOCKETHUB_BASE_CONTEXT_URL,
+    PLATFORM_CONTEXT_PREFIX,
     ERROR_PLATFORM_ID,
     ERROR_PLATFORM_CONTEXT_URL,
     INTERNAL_PLATFORM_ID,

--- a/packages/schemas/src/validator.ts
+++ b/packages/schemas/src/validator.ts
@@ -196,8 +196,12 @@ export function addPlatformContext(
 
 export function resolvePlatformId(msg: ActivityStream): string | null {
     const platformContextUrl = resolvePlatformContextUrl(msg);
-    if (!platformContextUrl) {
-        return null;
+    if (platformContextUrl) {
+        const id = getPlatformIdByContextUrl(platformContextUrl);
+        if (id) return id;
     }
-    return getPlatformIdByContextUrl(platformContextUrl) || null;
+    if (typeof msg.platform === "string" && msg.platform) {
+        return msg.platform;
+    }
+    return null;
 }

--- a/packages/server/integration/credentials-queue.integration.ts
+++ b/packages/server/integration/credentials-queue.integration.ts
@@ -24,7 +24,11 @@ describe("credentials + queue integration", () => {
     const actorId = `user-${crypto.randToken(6)}@localhost`;
     const credentials: CredentialsObject = {
         type: "credentials",
-        context: "xmpp",
+        "@context": [
+            "https://www.w3.org/ns/activitystreams",
+            "https://sockethub.org/ns/context/v1.jsonld",
+            "https://sockethub.org/ns/context/platform/xmpp/v1.jsonld",
+        ],
         actor: { id: actorId, type: "person" },
         object: {
             type: "credentials",
@@ -73,7 +77,12 @@ describe("credentials + queue integration", () => {
 
         const message = {
             type: "connect",
-            context: "xmpp",
+            "@context": [
+                "https://www.w3.org/ns/activitystreams",
+                "https://sockethub.org/ns/context/v1.jsonld",
+                "https://sockethub.org/ns/context/platform/xmpp/v1.jsonld",
+            ],
+            platform: "xmpp",
             actor: { id: actorId, type: "person" },
             sessionSecret,
         } as ActivityStream & { sessionSecret: string };

--- a/packages/server/src/middleware/expand-activity-stream.test.data.ts
+++ b/packages/server/src/middleware/expand-activity-stream.test.data.ts
@@ -1,3 +1,9 @@
+const ctx = (platform: string) => [
+    "https://www.w3.org/ns/activitystreams",
+    "https://sockethub.org/ns/context/v1.jsonld",
+    `https://sockethub.org/ns/context/platform/${platform}/v1.jsonld`,
+];
+
 export default [
     {
         name: "not an object",
@@ -13,7 +19,7 @@ export default [
         input: {
             id: "foo",
             type: "send",
-            context: "dummy",
+            "@context": ctx("dummy"),
             actor: {
                 id: "dood@irc.freenode.net",
                 type: "person",
@@ -37,7 +43,7 @@ export default [
         input: {
             id: "foo",
             type: "credentials",
-            context: "dummy",
+            "@context": ctx("dummy"),
             actor: {
                 id: "dood@irc.freenode.net",
                 type: "person",
@@ -60,7 +66,7 @@ export default [
         type: "credentials",
         input: {
             type: "credentials",
-            context: "irc",
+            "@context": ctx("irc"),
             actor: {
                 id: "sh-9K3Vk@irc.freenode.net",
                 type: "person",
@@ -89,7 +95,7 @@ export default [
         type: "credentials",
         input: {
             actor: "hyper_rau@localhost",
-            context: "xmpp",
+            "@context": ctx("xmpp"),
             object: {
                 username: "hyper_rau",
                 password: "123",
@@ -105,7 +111,7 @@ export default [
         type: "message",
         valid: "true",
         input: {
-            context: "foo",
+            "@context": ctx("foo"),
             type: "bar",
             actor: "foo@bar",
             object: {
@@ -113,7 +119,7 @@ export default [
             },
         },
         output: {
-            context: "foo",
+            "@context": ctx("foo"),
             type: "bar",
             actor: {
                 id: "foo@bar",
@@ -128,7 +134,7 @@ export default [
         type: "message",
         valid: "true",
         input: {
-            context: "foo",
+            "@context": ctx("foo"),
             type: "bar",
             actor: "someone@example.org/resource",
             object: {
@@ -136,7 +142,7 @@ export default [
             },
         },
         output: {
-            context: "foo",
+            "@context": ctx("foo"),
             type: "bar",
             actor: {
                 id: "someone@example.org/resource",
@@ -151,7 +157,7 @@ export default [
         type: "message",
         valid: "true",
         input: {
-            context: "foo",
+            "@context": ctx("foo"),
             type: "bar",
             actor: "xmpp:someone@example.org/resource",
             object: {
@@ -159,7 +165,7 @@ export default [
             },
         },
         output: {
-            context: "foo",
+            "@context": ctx("foo"),
             type: "bar",
             actor: {
                 id: "xmpp:someone@example.org/resource",
@@ -174,13 +180,13 @@ export default [
         type: "message",
         valid: true,
         input: {
-            context: "some context",
+            "@context": ctx("some context"),
             type: "some type",
             actor: "blah",
             object: {},
         },
         output: {
-            context: "some context",
+            "@context": ctx("some context"),
             type: "some type",
             actor: {
                 id: "blah",
@@ -195,13 +201,13 @@ export default [
         valid: true,
         type: "message",
         input: {
-            context: "some context",
+            "@context": ctx("some context"),
             type: "some type",
             actor: "blah2",
             object: {},
         },
         output: {
-            context: "some context",
+            "@context": ctx("some context"),
             type: "some type",
             actor: {
                 id: "blah2",
@@ -229,7 +235,7 @@ export default [
             as: {
                 id: "blah",
                 type: "send",
-                context: "hello",
+                "@context": ctx("hello"),
                 actor: {
                     name: "dood",
                 },
@@ -252,7 +258,7 @@ export default [
                 id: "larg",
             },
         },
-        error: "Error: activity stream must contain a context property",
+        error: "Error: activity stream must contain an @context array.",
     },
     {
         name: "no actor specified",
@@ -260,7 +266,7 @@ export default [
         type: "message",
         input: {
             type: "some type",
-            context: "xmpp",
+            "@context": ctx("xmpp"),
             object: {
                 type: "error",
                 content: "error message",
@@ -275,7 +281,7 @@ export default [
         input: {
             actor: "irc://uuu@localhost",
             type: "join",
-            context: "irc",
+            "@context": ctx("irc"),
             target: "irc://irc.dooder.net/a-room",
         },
         output: {
@@ -283,7 +289,7 @@ export default [
                 id: "irc://uuu@localhost",
             },
             type: "join",
-            context: "irc",
+            "@context": ctx("irc"),
             target: {
                 id: "irc://irc.dooder.net/a-room",
             },
@@ -296,7 +302,7 @@ export default [
         input: {
             actor: "hyper_rau@localhost",
             type: "join",
-            context: "xmpp",
+            "@context": ctx("xmpp"),
             object: {},
             target: "dooder",
         },
@@ -305,7 +311,7 @@ export default [
                 id: "hyper_rau@localhost",
             },
             type: "join",
-            context: "xmpp",
+            "@context": ctx("xmpp"),
             object: {},
             target: {
                 id: "dooder",
@@ -320,7 +326,7 @@ export default [
             actor: "sh-9K3Vk@irc.freenode.net",
             target: "blah3",
             type: "send",
-            context: "irc",
+            "@context": ctx("irc"),
             object: {},
         },
         output: {
@@ -344,7 +350,7 @@ export default [
                 i: ["am", "extras"],
             },
             type: "send",
-            context: "irc",
+            "@context": ctx("irc"),
             object: {},
         },
     },

--- a/packages/server/src/middleware/expand-activity-stream.test.data.ts
+++ b/packages/server/src/middleware/expand-activity-stream.test.data.ts
@@ -1,8 +1,9 @@
-const ctx = (platform: string) => [
-    "https://www.w3.org/ns/activitystreams",
-    "https://sockethub.org/ns/context/v1.jsonld",
-    `https://sockethub.org/ns/context/platform/${platform}/v1.jsonld`,
-];
+import { buildCanonicalContext } from "@sockethub/schemas";
+
+const ctx = (platform: string) =>
+    buildCanonicalContext(
+        `https://sockethub.org/ns/context/platform/${platform}/v1.jsonld`,
+    );
 
 export default [
     {

--- a/packages/server/src/middleware/expand-activity-stream.ts
+++ b/packages/server/src/middleware/expand-activity-stream.ts
@@ -22,8 +22,11 @@ export default function expandActivityStream<T extends ActivityStream>(
 ) {
     if (!ensureObject(msg)) {
         done(new Error("message received is not an object."));
-    } else if (typeof msg.context !== "string") {
-        done(new Error("activity stream must contain a context property"));
+    } else if (
+        !Array.isArray(msg["@context"]) ||
+        !msg["@context"].every((entry) => typeof entry === "string")
+    ) {
+        done(new Error("activity stream must contain an @context array."));
     } else if (typeof msg.type !== "string") {
         done(new Error("activity stream must contain a type property."));
     } else {

--- a/packages/server/src/middleware/expand-activity-stream.ts
+++ b/packages/server/src/middleware/expand-activity-stream.ts
@@ -12,8 +12,8 @@ asConfig.failOnUnknownObjectProperties = false;
 
 const activity = ASFactory(asConfig);
 
-function ensureObject(msg: unknown) {
-    return !(typeof msg !== "object" || Array.isArray(msg));
+function ensureObject(msg: unknown): msg is Record<string, unknown> {
+    return typeof msg === "object" && msg !== null && !Array.isArray(msg);
 }
 
 export default function expandActivityStream<T extends ActivityStream>(

--- a/packages/server/src/middleware/store-credentials.test.ts
+++ b/packages/server/src/middleware/store-credentials.test.ts
@@ -6,7 +6,11 @@ import storeCredentials from "./store-credentials.js";
 
 const creds: CredentialsObject = {
     type: "credentials",
-    context: "dummy",
+    "@context": [
+        "https://www.w3.org/ns/activitystreams",
+        "https://sockethub.org/ns/context/v1.jsonld",
+        "https://sockethub.org/ns/context/platform/dummy/v1.jsonld",
+    ],
     actor: {
         id: "dood@irc.freenode.net",
         type: "person",

--- a/packages/server/src/platform-instance.test.ts
+++ b/packages/server/src/platform-instance.test.ts
@@ -173,7 +173,7 @@ describe("PlatformInstance", () => {
             sandbox.assert.calledOnce(socketMock.emit);
             sandbox.assert.calledWith(socketMock.emit, "message", {
                 foo: "this is a message object",
-                context: "a platform name",
+                platform: "a platform name",
             });
         });
 
@@ -212,6 +212,7 @@ describe("PlatformInstance", () => {
                 expect(pi.broadcastToSharedPeers.callCount).toEqual(1);
                 sandbox.assert.calledWith(pi.sendToClient, "a session id", {
                     foo: "bar",
+                    platform: "a platform name",
                 });
             });
 
@@ -225,6 +226,7 @@ describe("PlatformInstance", () => {
                 sandbox.assert.calledWith(pi.sendToClient, "a session id", {
                     foo: "bar",
                     error: "a bad result message",
+                    platform: "a platform name",
                 });
             });
         });

--- a/packages/server/src/platform-instance.test.ts
+++ b/packages/server/src/platform-instance.test.ts
@@ -1,5 +1,9 @@
 import { afterEach, beforeEach, describe, expect, it } from "bun:test";
 import * as sinon from "sinon";
+import {
+    buildCanonicalContext,
+    INTERNAL_PLATFORM_CONTEXT_URL,
+} from "@sockethub/schemas";
 import { __dirname } from "./util.js";
 const FORK_PATH = __dirname + "/platform.js";
 
@@ -174,7 +178,36 @@ describe("PlatformInstance", () => {
             sandbox.assert.calledWith(socketMock.emit, "message", {
                 foo: "this is a message object",
                 platform: "a platform name",
+                "@context": buildCanonicalContext(
+                    INTERNAL_PLATFORM_CONTEXT_URL,
+                ),
             });
+        });
+
+        it("injects platform-specific @context when contextUrl is set", async () => {
+            const testContextUrl =
+                "https://sockethub.org/ns/context/platform/dummy/v1.jsonld";
+            pi.contextUrl = testContextUrl;
+            await pi.sendToClient("my session id", {
+                type: "echo",
+                actor: { id: "test@dummy", type: "person" },
+            });
+            sandbox.assert.calledOnce(socketMock.emit);
+            const emittedMsg = socketMock.emit.firstCall.args[1];
+            expect(emittedMsg["@context"]).toEqual(
+                buildCanonicalContext(testContextUrl),
+            );
+        });
+
+        it("strips legacy context field from outbound payloads", async () => {
+            await pi.sendToClient("my session id", {
+                type: "echo",
+                context: "dummy",
+                actor: { id: "test@dummy", type: "person" },
+            });
+            const emittedMsg = socketMock.emit.firstCall.args[1];
+            expect(emittedMsg.context).toBeUndefined();
+            expect(emittedMsg["@context"]).toBeDefined();
         });
 
         it("broadcasts to peers", async () => {

--- a/packages/server/src/platform-instance.test.ts
+++ b/packages/server/src/platform-instance.test.ts
@@ -388,7 +388,7 @@ describe("PlatformInstance", () => {
                     sessionId: "session123",
                     msg: {
                         type: "connect",
-                        context: "xmpp",
+                        platform: "xmpp",
                         actor: { id: "testuser@localhost", type: "person" },
                     },
                     title: "xmpp-1",
@@ -440,7 +440,7 @@ describe("PlatformInstance", () => {
                     sessionId: "session123",
                     msg: {
                         type: "connect",
-                        context: "xmpp",
+                        platform: "xmpp",
                         actor: { id: "testuser@localhost", type: "person" },
                     },
                     title: "xmpp-1",
@@ -459,7 +459,7 @@ describe("PlatformInstance", () => {
                     sessionId: "session456",
                     msg: {
                         type: "send",
-                        context: "xmpp",
+                        platform: "xmpp",
                         actor: { id: "testuser@localhost", type: "person" },
                     },
                     title: "xmpp-2",
@@ -500,7 +500,7 @@ describe("PlatformInstance", () => {
                     sessionId: "session123",
                     msg: {
                         type: "connect",
-                        context: "xmpp",
+                        platform: "xmpp",
                         actor: { id: "testuser@localhost", type: "person" },
                     },
                     title: "xmpp-1",
@@ -549,7 +549,7 @@ describe("PlatformInstance", () => {
                     sessionId: "session123",
                     msg: {
                         type: "connect",
-                        context: "xmpp",
+                        platform: "xmpp",
                         actor: { id: "testuser@localhost", type: "person" },
                     },
                     title: "xmpp-1",

--- a/packages/server/src/platform-instance.ts
+++ b/packages/server/src/platform-instance.ts
@@ -241,11 +241,9 @@ export default class PlatformInstance {
                 try {
                     this.toExternalPayload(msg as ActivityStream);
                 } finally {
-                    if (this.contextUrl) {
-                        msg["@context"] = buildCanonicalContext(
-                            this.contextUrl,
-                        );
-                    }
+                    const contextUrl =
+                        this.contextUrl ?? INTERNAL_PLATFORM_CONTEXT_URL;
+                    msg["@context"] = buildCanonicalContext(contextUrl);
                     if (
                         msg.type === "error" &&
                         typeof msg.actor === "undefined" &&
@@ -275,8 +273,11 @@ export default class PlatformInstance {
      * Remove internal-only transport metadata before returning payloads to clients.
      */
     private toExternalPayload(payload: ActivityStream): ActivityStream {
-        const external = payload as InternalActivityStream;
+        const external = payload as InternalActivityStream & {
+            context?: unknown;
+        };
         delete external.sessionSecret;
+        delete external.context;
         if (
             typeof external.platform !== "string" ||
             external.platform.length === 0

--- a/packages/server/src/platform.test.ts
+++ b/packages/server/src/platform.test.ts
@@ -42,7 +42,11 @@ describe("platform.ts credential handling", () => {
 
         validCredentials = {
             type: "credentials",
-            context: "xmpp",
+            "@context": [
+                "https://www.w3.org/ns/activitystreams",
+                "https://sockethub.org/ns/context/v1.jsonld",
+                "https://sockethub.org/ns/context/platform/xmpp/v1.jsonld",
+            ],
             actor: {
                 id: "testuser@localhost",
                 type: "person",
@@ -75,7 +79,12 @@ describe("platform.ts credential handling", () => {
             title: "xmpp-job-1",
             msg: {
                 type: "connect",
-                context: "xmpp",
+                "@context": [
+                    "https://www.w3.org/ns/activitystreams",
+                    "https://sockethub.org/ns/context/v1.jsonld",
+                    "https://sockethub.org/ns/context/platform/xmpp/v1.jsonld",
+                ],
+                platform: "xmpp",
                 actor: { id: "testuser@localhost", type: "person" },
                 sessionSecret: "secret123",
             },

--- a/packages/server/src/platform.ts
+++ b/packages/server/src/platform.ts
@@ -25,6 +25,10 @@ import type {
     PlatformInterface,
     PlatformSession,
 } from "@sockethub/schemas";
+import {
+    buildCanonicalContext,
+    INTERNAL_PLATFORM_CONTEXT_URL,
+} from "@sockethub/schemas";
 import config from "./config";
 
 // Simple wrapper function to help with testing
@@ -55,10 +59,7 @@ async function startPlatformProcess() {
     let sentry: { readonly reportError: (err: Error) => void } = {
         reportError: (err: Error) => {
             logger.debug(
-                "Sentry not configured; error not reported to Sentry",
-                {
-                    error: err,
-                },
+                `Sentry not configured; error not reported to Sentry: ${err?.message || String(err)}`,
             );
         },
     };
@@ -166,7 +167,9 @@ async function startPlatformProcess() {
                 "heartbeat",
                 {
                     type: "heartbeat",
-                    context: "sockethub:internal",
+                    "@context": buildCanonicalContext(
+                        INTERNAL_PLATFORM_CONTEXT_URL,
+                    ),
                     actor: {
                         id: "sockethub",
                         type: "platform",

--- a/packages/server/src/platform.ts
+++ b/packages/server/src/platform.ts
@@ -59,7 +59,12 @@ async function startPlatformProcess() {
     let sentry: { readonly reportError: (err: Error) => void } = {
         reportError: (err: Error) => {
             logger.debug(
-                `Sentry not configured; error not reported to Sentry: ${err?.message || String(err)}`,
+                "Sentry not configured; error not reported to Sentry",
+                {
+                    error: err,
+                    errorMessage: err?.message ?? String(err),
+                    errorStack: err?.stack,
+                },
             );
         },
     };

--- a/packages/server/src/process-manager.ts
+++ b/packages/server/src/process-manager.ts
@@ -41,6 +41,7 @@ class ProcessManager {
             pi = this.ensureProcess(platform);
         }
         pi.config = platformDetails.config;
+        pi.contextUrl = platformDetails.contextUrl;
         return pi;
     }
 

--- a/packages/server/src/rate-limiter.ts
+++ b/packages/server/src/rate-limiter.ts
@@ -1,4 +1,8 @@
 import { createLogger } from "@sockethub/logger";
+import {
+    buildCanonicalContext,
+    ERROR_PLATFORM_CONTEXT_URL,
+} from "@sockethub/schemas";
 import type { Socket } from "socket.io";
 
 const log = createLogger("server:rate-limiter");
@@ -115,7 +119,7 @@ export function createRateLimiter(config: Partial<RateLimitConfig> = {}) {
             );
             socket.emit("error", {
                 type: "Error",
-                context: "error",
+                "@context": buildCanonicalContext(ERROR_PLATFORM_CONTEXT_URL),
                 actor: {
                     type: "Application",
                     name: "sockethub-server",

--- a/packages/server/src/sockethub.ts
+++ b/packages/server/src/sockethub.ts
@@ -274,8 +274,7 @@ class Sockethub {
                         msg: ActivityStream,
                         next: (data?: ActivityStream | Error) => void,
                     ) => {
-                        const platformId =
-                            msg.platform || resolvePlatformId(msg);
+                        const platformId = resolvePlatformId(msg);
                         if (!platformId) {
                             msg.error =
                                 "unable to resolve platform from @context";

--- a/packages/server/src/sockethub.ts
+++ b/packages/server/src/sockethub.ts
@@ -175,8 +175,7 @@ class Sockethub {
         socket.emit("schemas", platformRegistryPayload);
         socket.on("schemas", (...args: unknown[]) => {
             const ack = args.find(
-                (a): a is (payload: unknown) => void =>
-                    typeof a === "function",
+                (a): a is (payload: unknown) => void => typeof a === "function",
             );
             if (ack) {
                 ack(platformRegistryPayload);

--- a/packages/server/src/sockethub.ts
+++ b/packages/server/src/sockethub.ts
@@ -173,12 +173,16 @@ class Sockethub {
 
         // Send schema metadata to clients immediately and on-demand.
         socket.emit("schemas", platformRegistryPayload);
-        socket.on("schemas", (ack?: (payload: unknown) => void) => {
-            if (typeof ack === "function") {
+        socket.on("schemas", (...args: unknown[]) => {
+            const ack = args.find(
+                (a): a is (payload: unknown) => void =>
+                    typeof a === "function",
+            );
+            if (ack) {
                 ack(platformRegistryPayload);
-                return;
+            } else {
+                socket.emit("schemas", platformRegistryPayload);
             }
-            socket.emit("schemas", platformRegistryPayload);
         });
 
         socket.on("disconnect", () => {

--- a/packages/server/src/sockethub.ts
+++ b/packages/server/src/sockethub.ts
@@ -67,6 +67,7 @@ class Sockethub {
     status: boolean;
     processManager!: ProcessManager;
     private rateLimiter!: ReturnType<typeof createRateLimiter>;
+    private serverVersion?: string;
 
     /**
      * Build the platform registry payload sent to clients.
@@ -74,7 +75,7 @@ class Sockethub {
      */
     private buildPlatformRegistryPayload() {
         return {
-            version: this.processManager?.version,
+            version: this.serverVersion,
             contexts: {
                 as: AS2_BASE_CONTEXT_URL,
                 sockethub: SOCKETHUB_BASE_CONTEXT_URL,
@@ -122,6 +123,7 @@ class Sockethub {
             return;
         }
 
+        this.serverVersion = init.version;
         this.processManager = new ProcessManager(
             this.parentId,
             this.parentSecret1,

--- a/stress-tests/artillery/processors/activitystreams-validator.js
+++ b/stress-tests/artillery/processors/activitystreams-validator.js
@@ -3,6 +3,14 @@
  * This runs in the Artillery process (client-side), not in Sockethub
  */
 
+function contextFor(platform) {
+    return [
+        "https://www.w3.org/ns/activitystreams",
+        "https://sockethub.org/ns/context/v1.jsonld",
+        `https://sockethub.org/ns/context/platform/${platform}/v1.jsonld`,
+    ];
+}
+
 module.exports = {
     generateConnectMessage,
     generateDummyEchoMessage,
@@ -25,7 +33,7 @@ function generateConnectMessage(context, _events, done) {
 
     context.vars.connectMessage = {
         type: "credentials",
-        context: "dummy",
+        "@context": contextFor("dummy"),
         actor: actor,
         object: {
             type: "credentials",
@@ -49,7 +57,7 @@ function generateDummyEchoMessage(context, _events, done) {
 
     context.vars.echoMessage = {
         type: "echo",
-        context: "dummy",
+        "@context": contextFor("dummy"),
         actor: actor,
         object: {
             type: "message",
@@ -73,7 +81,7 @@ function generateXMPPMessage(context, _events, done) {
 
     context.vars.xmppMessage = {
         type: "send",
-        context: "xmpp",
+        "@context": contextFor("xmpp"),
         actor: actor,
         target: {
             id: "testroom@conference.localhost",
@@ -107,7 +115,7 @@ function generateFeedMessage(context, _events, done) {
 
     context.vars.feedMessage = {
         type: "fetch",
-        context: "feeds",
+        "@context": contextFor("feeds"),
         actor: actor,
         object: {
             type: "feed",

--- a/stress-tests/artillery/processors/sockethub-client.js
+++ b/stress-tests/artillery/processors/sockethub-client.js
@@ -7,6 +7,14 @@
 const SockethubClient = require("@sockethub/client").default;
 const { io } = require("socket.io-client");
 
+function contextFor(platform) {
+    return [
+        "https://www.w3.org/ns/activitystreams",
+        "https://sockethub.org/ns/context/v1.jsonld",
+        `https://sockethub.org/ns/context/platform/${platform}/v1.jsonld`,
+    ];
+}
+
 // Circuit breaker - abort test if Sockethub becomes unavailable
 const MAX_CONSECUTIVE_FAILURES = 10; // Consecutive failures before triggering circuit breaker
 const ALERT_INTERVAL_MS = 5000; // Alert every 5 seconds when circuit breaker is open
@@ -142,7 +150,7 @@ function sendCredentials(context, events, done) {
     // Send credentials message (uses 'credentials' event, not 'message')
     const credentialsMsg = {
         type: "credentials",
-        context: "dummy",
+        "@context": contextFor("dummy"),
         actor: {
             id: actorId,
             type: "person",
@@ -175,7 +183,7 @@ function sendDummyEcho(context, events, done) {
 
     const message = {
         type: "echo",
-        context: "dummy",
+        "@context": contextFor("dummy"),
         actor: {
             id: actorId,
             type: "person",
@@ -213,7 +221,7 @@ function sendXMPPMessage(context, events, done) {
 
     const message = {
         type: "send",
-        context: "xmpp",
+        "@context": contextFor("xmpp"),
         actor: {
             id: actorId,
             type: "person",
@@ -261,7 +269,7 @@ function sendFeedMessage(context, events, done) {
 
     const message = {
         type: "fetch",
-        context: "feeds",
+        "@context": contextFor("feeds"),
         actor: {
             id: actorId,
             type: "person",


### PR DESCRIPTION
## Summary
- Replace legacy `context` string routing with canonical `@context` arrays across server middleware, platform instances, job queue, and rate limiter
- Emit `schemas` registry event to clients on connection
- Update expand-activity-stream to attach `@context` arrays to outbound messages

Part of the incremental decomposition of #1038.

## Test plan
- [x] Existing unit tests pass (`job-queue`, `platform-instance`, `expand-activity-stream`)
- [x] Integration tests pass with updated fixtures (follow-up PR)
- [x] Server correctly routes messages using `@context` platform URL lookup
