### PR TITLE
docs: Update documentation for @context routing and client ready() API

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,26 +23,26 @@ Sockethub handles connections, credentials, and protocol translation.
 
 Sockethub uses ActivityStreams JSON for all platforms. Your app sends the same
 shape for IRC, XMPP, feeds, and more, and receives the same shape back. Only
-`context` changes.
+the `@context` changes.
 
 ### Side-by-side Examples
 
 <picture>
   <source
     media="(prefers-color-scheme: dark)"
-    srcset="https://sockethub.org/res/img/activitystreams-send-receive.dark.svg"
+    srcset="docs/img/activitystreams-send-receive.dark.svg"
   />
   <source
     media="(prefers-color-scheme: light)"
-    srcset="https://sockethub.org/res/img/activitystreams-send-receive.svg"
+    srcset="docs/img/activitystreams-send-receive.svg"
   />
   <img
     alt="ActivityStreams send/receive examples"
-    src="https://sockethub.org/res/img/activitystreams-send-receive.svg"
+    src="docs/img/activitystreams-send-receive.svg"
   />
 </picture>
 
-The `context` selects a platform; the rest stays consistent.
+The `@context` selects a platform; the rest stays consistent.
 
 ## About
 

--- a/SKILL.md
+++ b/SKILL.md
@@ -46,14 +46,17 @@ import SockethubClient from '@sockethub/client';
 import { io } from 'socket.io-client';
 
 const socket = io('http://localhost:10550', { path: '/sockethub' });
-const sc = new SockethubClient(socket);
+const sc = new SockethubClient(socket, { initTimeoutMs: 5000 });
 
 // Listen for messages
 sc.socket.on('message', (msg) => console.log(msg));
 
+// Wait for schema registry before using contextFor()
+await sc.ready();
+
 // Send ActivityStreams message
 sc.socket.emit('message', {
-  context: 'irc',
+  '@context': sc.contextFor('irc'),
   type: 'send',
   actor: 'myuser@irc.libera.chat',
   target: { id: '#channel@irc.libera.chat', type: 'room' },
@@ -68,7 +71,7 @@ sc.socket.emit('message', {
 ```javascript
 // Set credentials
 sc.socket.emit('credentials', {
-  context: 'irc',
+  '@context': sc.contextFor('irc'),
   type: 'credentials',
   actor: { id: 'mynick@irc.libera.chat' },
   object: {
@@ -82,14 +85,14 @@ sc.socket.emit('credentials', {
 
 // Connect
 sc.socket.emit('message', {
-  context: 'irc',
+  '@context': sc.contextFor('irc'),
   type: 'connect',
   actor: 'mynick@irc.libera.chat'
 });
 
 // Join channel
 sc.socket.emit('message', {
-  context: 'irc',
+  '@context': sc.contextFor('irc'),
   type: 'join',
   actor: 'mynick@irc.libera.chat',
   target: { id: '#sockethub@irc.libera.chat', type: 'room' }
@@ -101,7 +104,7 @@ sc.socket.emit('message', {
 ```javascript
 // Set XMPP credentials
 sc.socket.emit('credentials', {
-  context: 'xmpp',
+  '@context': sc.contextFor('xmpp'),
   type: 'credentials',
   actor: { id: 'user@jabber.org' },
   object: {
@@ -114,13 +117,13 @@ sc.socket.emit('credentials', {
 
 // Connect and send
 sc.socket.emit('message', {
-  context: 'xmpp',
+  '@context': sc.contextFor('xmpp'),
   type: 'connect',
   actor: 'user@jabber.org'
 });
 
 sc.socket.emit('message', {
-  context: 'xmpp',
+  '@context': sc.contextFor('xmpp'),
   type: 'send',
   actor: 'user@jabber.org',
   target: { id: 'friend@jabber.org', type: 'person' },
@@ -132,14 +135,14 @@ sc.socket.emit('message', {
 
 ```javascript
 sc.socket.emit('message', {
-  context: 'feeds',
+  '@context': sc.contextFor('feeds'),
   type: 'fetch',
   actor: { id: 'https://example.com/feed.rss' }
 });
 
 // Response is a Collection of Create activities with feed entries
 sc.socket.on('message', (msg) => {
-  if (msg.context === 'feeds') {
+  if (msg['@context']) {
     msg.object.items.forEach(entry => {
       console.log(entry.object.title, entry.object.url);
     });
@@ -182,7 +185,11 @@ All messages follow ActivityStreams 2.0 structure:
 
 ```javascript
 {
-  context: 'irc' | 'xmpp' | 'feeds', // Platform identifier
+  "@context": [                        // Platform context array
+    "https://www.w3.org/ns/activitystreams",
+    "https://sockethub.org/ns/context/v1.jsonld",
+    "https://sockethub.org/ns/context/platform/{platform}/v1.jsonld"
+  ],
   type: 'send' | 'join' | 'connect', // Action type
   actor: { id: 'user@server', type: 'person' }, // Who is acting
   target: { id: 'room@server', type: 'room' }, // Target of action
@@ -201,20 +208,24 @@ properties). If none exists, it expands to `{ id }`.
 ```javascript
 import SockethubClient from '@sockethub/client';
 
-const sc = new SockethubClient(socket);
+const sc = new SockethubClient(socket, { initTimeoutMs: 5000 });
 
 // Properties
 sc.socket           // Underlying Socket.IO instance
 sc.ActivityStreams  // ActivityStreams helper library
 
 // Methods
-sc.clearCredentials()  // Remove stored credentials
+await sc.ready()            // Wait for schema registry initialization
+sc.contextFor('irc')        // Build canonical @context array for a platform
+sc.isReady()                // Check whether client is initialized
+sc.getInitState()           // Return init state string
+sc.clearCredentials()       // Remove stored credentials
 
 // Events
 sc.socket.on('message', handler)      // Incoming messages
-sc.socket.on('completed', handler)    // Job completion
-sc.socket.on('failed', handler)       // Job failure
-sc.socket.emit('message', activity)   // Send message
+sc.socket.on('ready', handler)        // Initialization complete
+sc.socket.on('init_error', handler)   // Initialization issue
+sc.socket.emit('message', activity)   // Send message (queued until ready)
 sc.socket.emit('credentials', creds)  // Set credentials
 ```
 

--- a/SKILL.md
+++ b/SKILL.md
@@ -142,7 +142,7 @@ sc.socket.emit('message', {
 
 // Response is a Collection of Create activities with feed entries
 sc.socket.on('message', (msg) => {
-  if (msg['@context']) {
+  if (msg.object && Array.isArray(msg.object.items)) {
     msg.object.items.forEach(entry => {
       console.log(entry.object.title, entry.object.url);
     });
@@ -211,7 +211,7 @@ import SockethubClient from '@sockethub/client';
 const sc = new SockethubClient(socket, { initTimeoutMs: 5000 });
 
 // Properties
-sc.socket           // Underlying Socket.IO instance
+sc.socket           // Public event emitter wrapping the Socket.IO client
 sc.ActivityStreams  // ActivityStreams helper library
 
 // Methods

--- a/SKILL.md
+++ b/SKILL.md
@@ -58,9 +58,9 @@ await sc.ready();
 sc.socket.emit('message', {
   '@context': sc.contextFor('irc'),
   type: 'send',
-  actor: 'myuser@irc.libera.chat',
+  actor: { id: 'myuser@irc.libera.chat', type: 'person' },
   target: { id: '#channel@irc.libera.chat', type: 'room' },
-  object: { type: 'Note', content: 'Hello!' }
+  object: { type: 'message', content: 'Hello!' }
 });
 ```
 
@@ -73,7 +73,7 @@ sc.socket.emit('message', {
 sc.socket.emit('credentials', {
   '@context': sc.contextFor('irc'),
   type: 'credentials',
-  actor: { id: 'mynick@irc.libera.chat' },
+  actor: { id: 'mynick@irc.libera.chat', type: 'person' },
   object: {
     type: 'credentials',
     nick: 'mynick',
@@ -87,14 +87,14 @@ sc.socket.emit('credentials', {
 sc.socket.emit('message', {
   '@context': sc.contextFor('irc'),
   type: 'connect',
-  actor: 'mynick@irc.libera.chat'
+  actor: { id: 'mynick@irc.libera.chat', type: 'person' }
 });
 
 // Join channel
 sc.socket.emit('message', {
   '@context': sc.contextFor('irc'),
   type: 'join',
-  actor: 'mynick@irc.libera.chat',
+  actor: { id: 'mynick@irc.libera.chat', type: 'person' },
   target: { id: '#sockethub@irc.libera.chat', type: 'room' }
 });
 ```
@@ -106,7 +106,7 @@ sc.socket.emit('message', {
 sc.socket.emit('credentials', {
   '@context': sc.contextFor('xmpp'),
   type: 'credentials',
-  actor: { id: 'user@jabber.org' },
+  actor: { id: 'user@jabber.org', type: 'person' },
   object: {
     type: 'credentials',
     userAddress: 'user@jabber.org',
@@ -119,15 +119,15 @@ sc.socket.emit('credentials', {
 sc.socket.emit('message', {
   '@context': sc.contextFor('xmpp'),
   type: 'connect',
-  actor: 'user@jabber.org'
+  actor: { id: 'user@jabber.org', type: 'person' }
 });
 
 sc.socket.emit('message', {
   '@context': sc.contextFor('xmpp'),
   type: 'send',
-  actor: 'user@jabber.org',
+  actor: { id: 'user@jabber.org', type: 'person' },
   target: { id: 'friend@jabber.org', type: 'person' },
-  object: { type: 'Note', content: 'Hello from Sockethub!' }
+  object: { type: 'message', content: 'Hello from Sockethub!' }
 });
 ```
 
@@ -138,12 +138,10 @@ sc.socket.emit('message', {
   '@context': sc.contextFor('feeds'),
   type: 'fetch',
   actor: { id: 'https://example.com/feed.rss', type: 'feed' }
-});
-
-// Response is a Collection of Create activities with feed entries
-sc.socket.on('message', (msg) => {
-  if (msg.object && Array.isArray(msg.object.items)) {
-    msg.object.items.forEach(entry => {
+}, (response) => {
+  // Response is an ASCollection with feed entries
+  if (response.items) {
+    response.items.forEach(entry => {
       console.log(entry.object.title, entry.object.url);
     });
   }
@@ -193,7 +191,7 @@ All messages follow ActivityStreams 2.0 structure:
   type: 'send' | 'join' | 'connect', // Action type
   actor: { id: 'user@server', type: 'person' }, // Who is acting
   target: { id: 'room@server', type: 'room' }, // Target of action
-  object: { type: 'Note', content: '...' } // Payload
+  object: { type: 'message', content: '...' } // Payload
 }
 ```
 

--- a/SKILL.md
+++ b/SKILL.md
@@ -137,7 +137,7 @@ sc.socket.emit('message', {
 sc.socket.emit('message', {
   '@context': sc.contextFor('feeds'),
   type: 'fetch',
-  actor: { id: 'https://example.com/feed.rss' }
+  actor: { id: 'https://example.com/feed.rss', type: 'feed' }
 });
 
 // Response is a Collection of Create activities with feed entries

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -120,7 +120,11 @@ Redis and BullMQ provide reliable, encrypted communication between server and pl
 // 1. Client sends ActivityStreams
 {
   "type": "send",
-  "context": "irc", 
+  "@context": [
+    "https://www.w3.org/ns/activitystreams",
+    "https://sockethub.org/ns/context/v1.jsonld",
+    "https://sockethub.org/ns/context/platform/irc/v1.jsonld"
+  ],
   "actor": { "id": "mynick", "type": "person" },
   "target": { "id": "#javascript", "type": "room" },
   "object": { "type": "note", "content": "Hello!" }
@@ -200,7 +204,7 @@ IRC: ":alice!user@host PRIVMSG #room :hello world"
   ↓
 ActivityStreams: {
   "type": "send",
-  "context": "irc",
+  "@context": ["...activitystreams", "...sockethub", "...platform/irc/..."],
   "actor": { "id": "alice", "type": "person" },
   "target": { "id": "#room", "type": "room" },
   "object": { "type": "note", "content": "hello world" }
@@ -212,7 +216,7 @@ ActivityStreams: {
 ```
 ActivityStreams: {
   "type": "join",
-  "context": "irc",
+  "@context": ["...activitystreams", "...sockethub", "...platform/irc/..."],
   "actor": { "id": "mynick", "type": "person" },
   "target": { "id": "#room", "type": "room" }
 }
@@ -226,9 +230,14 @@ Web applications send the same ActivityStreams format regardless of target proto
 
 ```javascript
 // Same message format works for IRC, XMPP, or any messaging platform
+// Only the @context array changes to select the platform
 {
   "type": "send",
-  "context": "irc",  // or "xmpp" 
+  "@context": [
+    "https://www.w3.org/ns/activitystreams",
+    "https://sockethub.org/ns/context/v1.jsonld",
+    "https://sockethub.org/ns/context/platform/irc/v1.jsonld"
+  ],
   "actor": { "id": "user", "type": "person" },
   "target": { "id": "#room", "type": "room" },
   "object": { "type": "note", "content": "Hello!" }

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -127,7 +127,7 @@ Redis and BullMQ provide reliable, encrypted communication between server and pl
   ],
   "actor": { "id": "mynick", "type": "person" },
   "target": { "id": "#javascript", "type": "room" },
-  "object": { "type": "note", "content": "Hello!" }
+  "object": { "type": "message", "content": "Hello!" }
 }
 
 // 2. Server queues encrypted job for IRC platform
@@ -207,7 +207,7 @@ ActivityStreams: {
   "@context": ["...as2", "...sockethub", "...irc"],
   "actor": { "id": "alice", "type": "person" },
   "target": { "id": "#room", "type": "room" },
-  "object": { "type": "note", "content": "hello world" }
+  "object": { "type": "message", "content": "hello world" }
 }
 ```
 
@@ -240,7 +240,7 @@ Web applications send the same ActivityStreams format regardless of target proto
   ],
   "actor": { "id": "user", "type": "person" },
   "target": { "id": "#room", "type": "room" },
-  "object": { "type": "note", "content": "Hello!" }
+  "object": { "type": "message", "content": "Hello!" }
 }
 ```
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -204,7 +204,7 @@ IRC: ":alice!user@host PRIVMSG #room :hello world"
   ↓
 ActivityStreams: {
   "type": "send",
-  "@context": ["...activitystreams", "...sockethub", "...platform/irc/..."],
+  "@context": ["...as2", "...sockethub", "...irc"],
   "actor": { "id": "alice", "type": "person" },
   "target": { "id": "#room", "type": "room" },
   "object": { "type": "note", "content": "hello world" }
@@ -216,7 +216,7 @@ ActivityStreams: {
 ```
 ActivityStreams: {
   "type": "join",
-  "@context": ["...activitystreams", "...sockethub", "...platform/irc/..."],
+  "@context": ["...as2", "...sockethub", "...irc"],
   "actor": { "id": "mynick", "type": "person" },
   "target": { "id": "#room", "type": "room" }
 }

--- a/docs/client-guide.md
+++ b/docs/client-guide.md
@@ -187,6 +187,8 @@ You can still send raw ActivityStreams directly with `sc.socket.emit('message',
 ### Platforms Requiring Credentials
 
 ```javascript
+await sc.ready();
+
 // 1. Send credentials
 sc.socket.emit('credentials', {
     '@context': sc.contextFor('irc'),
@@ -227,7 +229,7 @@ sc.socket.emit('message', {
 sc.socket.emit('message', {
     type: 'fetch',
     '@context': sc.contextFor('feeds'),
-    actor: { id: 'https://example.com/feed.xml', type: 'website' }
+    actor: { id: 'https://example.com/feed.xml', type: 'feed' }
 });
 ```
 

--- a/docs/client-guide.md
+++ b/docs/client-guide.md
@@ -15,16 +15,29 @@ The client library is automatically served by the Sockethub server:
 
 ```html
 <script src="http://localhost:10550/socket.io.js"></script>
-<script src="http://localhost:10550/sockethub-client.js" type="module"></script>
+<script src="http://localhost:10550/sockethub-client.js"></script>
 ```
+
+These scripts set `io` and `SockethubClient` as globals.
 
 **From npm**: `npm install @sockethub/client socket.io-client`
 
 ### Basic Setup
 
+**Browser** (using globals from script tags):
+
 ```javascript
-import SockethubClient from '/sockethub-client.js';
-import { io } from '/socket.io.js';
+const sc = new SockethubClient(
+    io('http://localhost:10550', { path: '/sockethub' }),
+    { initTimeoutMs: 5000 },
+);
+```
+
+**Node.js / bundler** (using ESM imports):
+
+```javascript
+import SockethubClient from '@sockethub/client';
+import { io } from 'socket.io-client';
 
 const sc = new SockethubClient(
     io('http://localhost:10550', { path: '/sockethub' }),
@@ -64,8 +77,10 @@ sc.socket.emit('message', {
 });
 ```
 
-You can also emit before `ready()` resolves. SockethubClient queues outbound
-events and flushes them once initialization completes.
+**Important:** `contextFor()` requires the schema registry, so it can only be
+called after `ready()` resolves. If you need to emit before `ready()`, provide
+the `@context` array directly instead of using `contextFor()`. SockethubClient
+queues outbound events and flushes them once initialization completes.
 
 ## Checking Results (Success/Failure)
 

--- a/docs/client-guide.md
+++ b/docs/client-guide.md
@@ -27,24 +27,45 @@ import SockethubClient from '/sockethub-client.js';
 import { io } from '/socket.io.js';
 
 const sc = new SockethubClient(
-    io('http://localhost:10550', { path: '/sockethub' })
+    io('http://localhost:10550', { path: '/sockethub' }),
+    { initTimeoutMs: 5000 },
 );
 
 // Handle messages
 sc.socket.on('message', (msg) => console.log('Received:', msg));
+
+sc.socket.on('ready', (info) => {
+  console.log('Sockethub ready:', info.reason, info.sockethubVersion,
+    info.platforms.map((p) => ({ id: p.id, version: p.version })));
+});
+
+sc.socket.on('init_error', (e) => {
+  console.warn('Sockethub init issue:', e.error);
+});
 ```
 
 ### First Message
 
 ```javascript
-// Echo test with dummy platform
+// Wait for schema registry before using contextFor()
+await sc.ready();
+
 sc.socket.emit('message', {
-    type: 'echo',
-    context: 'dummy',
-    actor: { id: 'test', type: 'person' },
-    object: { type: 'note', content: 'Hello!' }
-}, (response) => console.log(response));
+  type: 'echo',
+  '@context': sc.contextFor('dummy'),
+  actor: { id: 'test', type: 'person' },
+  object: { type: 'note', content: 'Hello!' }
+}, (response) => {
+  if (response?.error) {
+    console.error('Send failed:', response.error);
+    return;
+  }
+  console.log('Ack:', response);
+});
 ```
+
+You can also emit before `ready()` resolves. SockethubClient queues outbound
+events and flushes them once initialization completes.
 
 ## Checking Results (Success/Failure)
 
@@ -56,7 +77,7 @@ with `error` as failure.
 ```javascript
 sc.socket.emit('message', {
     type: 'send',
-    context: 'irc',
+    '@context': sc.contextFor('irc'),
     actor: { id: 'mynick', type: 'person' },
     target: { id: '#sockethub', type: 'room' },
     object: { type: 'note', content: 'Hello channel' }
@@ -106,7 +127,7 @@ success/failure.
 ```javascript
 {
   "type": "send",            // Action: send, connect, join, fetch
-  "context": "irc",          // Platform: irc, xmpp, feeds, dummy  
+  "@context": sc.contextFor("irc"),  // Canonical contexts for this platform
   "actor": { "id": "user", "type": "person" },     // Who
   "target": { "id": "#room", "type": "room" },     // Where (optional)
   "object": { "type": "note", "content": "Hi!" }   // What
@@ -133,7 +154,7 @@ sc.ActivityStreams.Object.create({
 // Build a stream with string refs; they are expanded from stored objects
 const joinStream = sc.ActivityStreams.Stream({
     type: 'join',
-    context: 'irc',
+    '@context': sc.contextFor('irc'),
     actor: 'mynick',
     target: { id: '#sockethub', type: 'room' }
 });
@@ -153,7 +174,8 @@ You can still send raw ActivityStreams directly with `sc.socket.emit('message',
 ```javascript
 // 1. Send credentials
 sc.socket.emit('credentials', {
-    context: 'irc',
+    '@context': sc.contextFor('irc'),
+    type: 'credentials',
     actor: { id: 'mynick', type: 'person' },
     object: {
         type: 'credentials',
@@ -166,7 +188,7 @@ sc.socket.emit('credentials', {
 // 2. Connect
 sc.socket.emit('message', {
     type: 'connect',
-    context: 'irc',
+    '@context': sc.contextFor('irc'),
     actor: { id: 'mynick', type: 'person' }
 });
 ```
@@ -178,7 +200,7 @@ sc.socket.emit('message', {
 ```javascript
 sc.socket.emit('message', {
     type: 'echo',
-    context: 'dummy',
+    '@context': sc.contextFor('dummy'),
     actor: { id: 'test', type: 'person' },
     object: { type: 'note', content: 'test' }
 });
@@ -189,7 +211,7 @@ sc.socket.emit('message', {
 ```javascript
 sc.socket.emit('message', {
     type: 'fetch',
-    context: 'feeds',
+    '@context': sc.contextFor('feeds'),
     actor: { id: 'https://example.com/feed.xml', type: 'website' }
 });
 ```
@@ -200,7 +222,7 @@ sc.socket.emit('message', {
 // Join channel
 sc.socket.emit('message', {
     type: 'join',
-    context: 'irc',
+    '@context': sc.contextFor('irc'),
     actor: { id: 'mynick', type: 'person' },
     target: { id: '#channel', type: 'room' }
 });
@@ -208,6 +230,9 @@ sc.socket.emit('message', {
 
 ## Client Features
 
+- **Schema-driven init**: `ready()` resolves when the server's schema registry is loaded
+- **Context composition**: `contextFor(platform)` builds canonical `@context` arrays
+- **Outbound queueing**: Messages sent before `ready()` are queued and flushed automatically
 - **Auto-replay**: Credentials and connections restored on reconnect
 - **ActivityStreams**: Built-in validation and utilities via `sc.ActivityStreams`
 - **Connection state**: Check `sc.socket.connected` for status

--- a/docs/client-guide.md
+++ b/docs/client-guide.md
@@ -67,7 +67,7 @@ sc.socket.emit('message', {
   type: 'echo',
   '@context': sc.contextFor('dummy'),
   actor: { id: 'test', type: 'person' },
-  object: { type: 'note', content: 'Hello!' }
+  object: { type: 'message', content: 'Hello!' }
 }, (response) => {
   if (response?.error) {
     console.error('Send failed:', response.error);
@@ -95,7 +95,7 @@ sc.socket.emit('message', {
     '@context': sc.contextFor('irc'),
     actor: { id: 'mynick', type: 'person' },
     target: { id: '#sockethub', type: 'room' },
-    object: { type: 'note', content: 'Hello channel' }
+    object: { type: 'message', content: 'Hello channel' }
 }, (result) => {
     if (result?.error) {
         console.error('Send failed:', result.error);
@@ -145,7 +145,7 @@ success/failure.
   "@context": sc.contextFor("irc"),  // Canonical contexts for this platform
   "actor": { "id": "user", "type": "person" },     // Who
   "target": { "id": "#room", "type": "room" },     // Where (optional)
-  "object": { "type": "note", "content": "Hi!" }   // What
+  "object": { "type": "message", "content": "Hi!" }   // What
 }
 ```
 
@@ -217,7 +217,7 @@ sc.socket.emit('message', {
     type: 'echo',
     '@context': sc.contextFor('dummy'),
     actor: { id: 'test', type: 'person' },
-    object: { type: 'note', content: 'test' }
+    object: { type: 'message', content: 'test' }
 });
 ```
 

--- a/docs/client-guide.md
+++ b/docs/client-guide.md
@@ -61,7 +61,12 @@ sc.socket.on('init_error', (e) => {
 
 ```javascript
 // Wait for schema registry before using contextFor()
-await sc.ready();
+try {
+  await sc.ready();
+} catch (err) {
+  console.error('Sockethub failed to initialize:', err);
+  return;
+}
 
 sc.socket.emit('message', {
   type: 'echo',

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -74,24 +74,15 @@ Create a simple HTML file:
             // Wait for schema registry
             await sc.ready();
 
-            // Connect and send echo message
+            // Send echo message
             sc.socket.emit('message', {
-                type: 'connect',
+                type: 'echo',
                 '@context': sc.contextFor('dummy'),
-                actor: { id: 'test-user', type: 'person' }
-            }, (response) => {
-                console.log('Connect response:', response);
-
-                // Send echo message after connection
-                sc.socket.emit('message', {
-                    type: 'echo',
-                    '@context': sc.contextFor('dummy'),
-                    actor: { id: 'test-user', type: 'person' },
-                    object: { type: 'message', content: 'Hello Sockethub!' }
-                }, (echoResponse) => {
-                    document.getElementById('output').textContent =
-                        'Echo: ' + JSON.stringify(echoResponse, null, 2);
-                });
+                actor: { id: 'test-user', type: 'person' },
+                object: { type: 'message', content: 'Hello Sockethub!' }
+            }, (echoResponse) => {
+                document.getElementById('output').textContent =
+                    'Echo: ' + JSON.stringify(echoResponse, null, 2);
             });
         }
     </script>

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -72,7 +72,13 @@ Create a simple HTML file:
         // Test function
         window.testEcho = async function() {
             // Wait for schema registry
-            await sc.ready();
+            try {
+                await sc.ready();
+            } catch (err) {
+                document.getElementById('output').textContent =
+                    'Initialization failed: ' + String(err);
+                return;
+            }
 
             // Send echo message
             sc.socket.emit('message', {

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -47,44 +47,45 @@ Create a simple HTML file:
 <head>
     <title>My Sockethub App</title>
     <script src="http://localhost:10550/socket.io.js"></script>
-    <script src="http://localhost:10550/sockethub-client.js" type="module"></script>
+    <script src="http://localhost:10550/sockethub-client.js"></script>
 </head>
 <body>
     <h1>My Sockethub App</h1>
     <button onclick="testEcho()">Test Echo</button>
     <div id="output"></div>
 
-    <script type="module">
-        import SockethubClient from '/sockethub-client.js';
-        import { io } from '/socket.io.js';
-        
-        // Connect to Sockethub
+    <script>
+        // Connect to Sockethub (SockethubClient and io are globals from script tags)
         const sc = new SockethubClient(
             io('http://localhost:10550', {
                 path: '/sockethub'
-            })
+            }),
+            { initTimeoutMs: 5000 }
         );
-        
+
         // Listen for responses
         sc.socket.on('message', function(msg) {
-            document.getElementById('output').innerHTML = 
+            document.getElementById('output').innerHTML =
                 '<p>Response: ' + JSON.stringify(msg, null, 2) + '</p>';
         });
-        
+
         // Test function
-        window.testEcho = function() {
+        window.testEcho = async function() {
+            // Wait for schema registry
+            await sc.ready();
+
             // Connect and send echo message
             sc.socket.emit('message', {
                 type: 'connect',
-                context: 'dummy',
+                '@context': sc.contextFor('dummy'),
                 actor: { id: 'test-user', type: 'person' }
             }, (response) => {
                 console.log('Connect response:', response);
-                
+
                 // Send echo message after connection
                 sc.socket.emit('message', {
                     type: 'echo',
-                    context: 'dummy',
+                    '@context': sc.contextFor('dummy'),
                     actor: { id: 'test-user', type: 'person' },
                     object: { type: 'note', content: 'Hello Sockethub!' }
                 });
@@ -104,7 +105,11 @@ All communication uses ActivityStreams 2.0 format:
 ```javascript
 {
   "type": "send",            // The action to perform
-  "context": "xmpp",         // Which platform to use
+  "@context": [              // Which platform to use
+    "https://www.w3.org/ns/activitystreams",
+    "https://sockethub.org/ns/context/v1.jsonld",
+    "https://sockethub.org/ns/context/platform/xmpp/v1.jsonld"
+  ],
   "actor": {                 // Who is performing the action
     "id": "user@example.com",
     "type": "person"
@@ -123,7 +128,7 @@ All communication uses ActivityStreams 2.0 format:
 ### Core Concepts
 
 - **Platforms**: Protocol modules (dummy, feeds, irc, xmpp, metadata)
-- **Context**: Which platform to use for a message
+- **@context**: Canonical context array that selects which platform to use
 - **Actor**: The user performing the action  
 - **Verbs**: Actions like connect, send, join, fetch
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -65,8 +65,8 @@ Create a simple HTML file:
 
         // Listen for responses
         sc.socket.on('message', function(msg) {
-            document.getElementById('output').innerHTML =
-                '<p>Response: ' + JSON.stringify(msg, null, 2) + '</p>';
+            document.getElementById('output').textContent =
+                'Response: ' + JSON.stringify(msg, null, 2);
         });
 
         // Test function

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -88,6 +88,9 @@ Create a simple HTML file:
                     '@context': sc.contextFor('dummy'),
                     actor: { id: 'test-user', type: 'person' },
                     object: { type: 'note', content: 'Hello Sockethub!' }
+                }, (echoResponse) => {
+                    document.getElementById('output').textContent =
+                        'Echo: ' + JSON.stringify(echoResponse, null, 2);
                 });
             });
         }

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -87,7 +87,7 @@ Create a simple HTML file:
                     type: 'echo',
                     '@context': sc.contextFor('dummy'),
                     actor: { id: 'test-user', type: 'person' },
-                    object: { type: 'note', content: 'Hello Sockethub!' }
+                    object: { type: 'message', content: 'Hello Sockethub!' }
                 }, (echoResponse) => {
                     document.getElementById('output').textContent =
                         'Echo: ' + JSON.stringify(echoResponse, null, 2);
@@ -122,7 +122,7 @@ All communication uses ActivityStreams 2.0 format:
     "type": "person"
   },
   "object": {                // What to send
-    "type": "note",
+    "type": "message",
     "content": "Hello!"
   }
 }

--- a/docs/img/activitystreams-send-receive.dark.svg
+++ b/docs/img/activitystreams-send-receive.dark.svg
@@ -1,0 +1,62 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1200" height="462" viewBox="0 0 1200 462">
+  <defs>
+    <style><![CDATA[
+      .panel { fill: none; stroke: #7a7a7a; stroke-width: 1.2; }
+      .title { font: 600 16px "SFMono-Regular", Menlo, Consolas, "Liberation Mono", monospace; fill: #f3f4f6; }
+      .code { font: 14px "SFMono-Regular", Menlo, Consolas, "Liberation Mono", monospace; fill: #e5e7eb; }
+      .k { fill: #60a5fa; }
+      .s { fill: #34d399; }
+      .p { fill: #9ca3af; }
+    ]]></style>
+  </defs>
+
+  <rect x="20" y="20" width="560" height="422" rx="8" class="panel" />
+  <rect x="620" y="20" width="560" height="422" rx="8" class="panel" />
+
+  <text x="40" y="50" class="title">Send (web app &#x2192; Sockethub &#x2192; IRC/XMPP/etc.)</text>
+  <text x="640" y="50" class="title">Receive (IRC/XMPP/etc. &#x2192; Sockethub &#x2192; web app)</text>
+
+  <!-- Left JSON -->
+  <text x="40" y="85" class="code"><tspan class="p">{</tspan></text>
+  <text x="56" y="103" class="code"><tspan class="k">"type"</tspan><tspan class="p">: </tspan><tspan class="s">"send"</tspan><tspan class="p">,</tspan></text>
+  <text x="56" y="121" class="code"><tspan class="k">"@context"</tspan><tspan class="p">: [</tspan></text>
+  <text x="72" y="139" class="code"><tspan class="s">"https://www.w3.org/ns/activitystreams"</tspan><tspan class="p">,</tspan></text>
+  <text x="72" y="157" class="code"><tspan class="s">"https://sockethub.org/ns/context/v1.jsonld"</tspan><tspan class="p">,</tspan></text>
+  <text x="72" y="175" class="code"><tspan class="s">"https://sockethub.org/ns/context/platform/irc/v1.jsonld"</tspan></text>
+  <text x="56" y="193" class="code"><tspan class="p">],</tspan></text>
+  <text x="56" y="211" class="code"><tspan class="k">"actor"</tspan><tspan class="p">: {</tspan></text>
+  <text x="72" y="229" class="code"><tspan class="k">"id"</tspan><tspan class="p">: </tspan><tspan class="s">"alice"</tspan><tspan class="p">,</tspan></text>
+  <text x="72" y="247" class="code"><tspan class="k">"type"</tspan><tspan class="p">: </tspan><tspan class="s">"person"</tspan></text>
+  <text x="56" y="265" class="code"><tspan class="p">},</tspan></text>
+  <text x="56" y="283" class="code"><tspan class="k">"target"</tspan><tspan class="p">: {</tspan></text>
+  <text x="72" y="301" class="code"><tspan class="k">"id"</tspan><tspan class="p">: </tspan><tspan class="s">"#sockethub"</tspan><tspan class="p">,</tspan></text>
+  <text x="72" y="319" class="code"><tspan class="k">"type"</tspan><tspan class="p">: </tspan><tspan class="s">"room"</tspan></text>
+  <text x="56" y="337" class="code"><tspan class="p">},</tspan></text>
+  <text x="56" y="355" class="code"><tspan class="k">"object"</tspan><tspan class="p">: {</tspan></text>
+  <text x="72" y="373" class="code"><tspan class="k">"type"</tspan><tspan class="p">: </tspan><tspan class="s">"message"</tspan><tspan class="p">,</tspan></text>
+  <text x="72" y="391" class="code"><tspan class="k">"content"</tspan><tspan class="p">: </tspan><tspan class="s">"Hello from the browser!"</tspan></text>
+  <text x="56" y="409" class="code"><tspan class="p">}</tspan></text>
+  <text x="40" y="427" class="code"><tspan class="p">}</tspan></text>
+
+  <!-- Right JSON -->
+  <text x="640" y="85" class="code"><tspan class="p">{</tspan></text>
+  <text x="656" y="103" class="code"><tspan class="k">"type"</tspan><tspan class="p">: </tspan><tspan class="s">"send"</tspan><tspan class="p">,</tspan></text>
+  <text x="656" y="121" class="code"><tspan class="k">"@context"</tspan><tspan class="p">: [</tspan></text>
+  <text x="672" y="139" class="code"><tspan class="s">"https://www.w3.org/ns/activitystreams"</tspan><tspan class="p">,</tspan></text>
+  <text x="672" y="157" class="code"><tspan class="s">"https://sockethub.org/ns/context/v1.jsonld"</tspan><tspan class="p">,</tspan></text>
+  <text x="672" y="175" class="code"><tspan class="s">"https://sockethub.org/ns/context/platform/irc/v1.jsonld"</tspan></text>
+  <text x="656" y="193" class="code"><tspan class="p">],</tspan></text>
+  <text x="656" y="211" class="code"><tspan class="k">"actor"</tspan><tspan class="p">: {</tspan></text>
+  <text x="672" y="229" class="code"><tspan class="k">"id"</tspan><tspan class="p">: </tspan><tspan class="s">"bob"</tspan><tspan class="p">,</tspan></text>
+  <text x="672" y="247" class="code"><tspan class="k">"type"</tspan><tspan class="p">: </tspan><tspan class="s">"person"</tspan></text>
+  <text x="656" y="265" class="code"><tspan class="p">},</tspan></text>
+  <text x="656" y="283" class="code"><tspan class="k">"target"</tspan><tspan class="p">: {</tspan></text>
+  <text x="672" y="301" class="code"><tspan class="k">"id"</tspan><tspan class="p">: </tspan><tspan class="s">"#sockethub"</tspan><tspan class="p">,</tspan></text>
+  <text x="672" y="319" class="code"><tspan class="k">"type"</tspan><tspan class="p">: </tspan><tspan class="s">"room"</tspan></text>
+  <text x="656" y="337" class="code"><tspan class="p">},</tspan></text>
+  <text x="656" y="355" class="code"><tspan class="k">"object"</tspan><tspan class="p">: {</tspan></text>
+  <text x="672" y="373" class="code"><tspan class="k">"type"</tspan><tspan class="p">: </tspan><tspan class="s">"message"</tspan><tspan class="p">,</tspan></text>
+  <text x="672" y="391" class="code"><tspan class="k">"content"</tspan><tspan class="p">: </tspan><tspan class="s">"Hi Alice!"</tspan></text>
+  <text x="656" y="409" class="code"><tspan class="p">}</tspan></text>
+  <text x="640" y="427" class="code"><tspan class="p">}</tspan></text>
+</svg>

--- a/docs/img/activitystreams-send-receive.svg
+++ b/docs/img/activitystreams-send-receive.svg
@@ -1,0 +1,62 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1200" height="462" viewBox="0 0 1200 462">
+  <defs>
+    <style><![CDATA[
+      .panel { fill: none; stroke: #2f2f2f; stroke-width: 1.2; }
+      .title { font: 600 16px "SFMono-Regular", Menlo, Consolas, "Liberation Mono", monospace; fill: #1a1a1a; }
+      .code { font: 14px "SFMono-Regular", Menlo, Consolas, "Liberation Mono", monospace; fill: #1a1a1a; }
+      .k { fill: #0057ff; }
+      .s { fill: #00a36c; }
+      .p { fill: #3a3a3a; }
+    ]]></style>
+  </defs>
+
+  <rect x="20" y="20" width="560" height="422" rx="8" class="panel" />
+  <rect x="620" y="20" width="560" height="422" rx="8" class="panel" />
+
+  <text x="40" y="50" class="title">Send (web app &#x2192; Sockethub &#x2192; IRC/XMPP/etc.)</text>
+  <text x="640" y="50" class="title">Receive (IRC/XMPP/etc. &#x2192; Sockethub &#x2192; web app)</text>
+
+  <!-- Left JSON -->
+  <text x="40" y="85" class="code"><tspan class="p">{</tspan></text>
+  <text x="56" y="103" class="code"><tspan class="k">"type"</tspan><tspan class="p">: </tspan><tspan class="s">"send"</tspan><tspan class="p">,</tspan></text>
+  <text x="56" y="121" class="code"><tspan class="k">"@context"</tspan><tspan class="p">: [</tspan></text>
+  <text x="72" y="139" class="code"><tspan class="s">"https://www.w3.org/ns/activitystreams"</tspan><tspan class="p">,</tspan></text>
+  <text x="72" y="157" class="code"><tspan class="s">"https://sockethub.org/ns/context/v1.jsonld"</tspan><tspan class="p">,</tspan></text>
+  <text x="72" y="175" class="code"><tspan class="s">"https://sockethub.org/ns/context/platform/irc/v1.jsonld"</tspan></text>
+  <text x="56" y="193" class="code"><tspan class="p">],</tspan></text>
+  <text x="56" y="211" class="code"><tspan class="k">"actor"</tspan><tspan class="p">: {</tspan></text>
+  <text x="72" y="229" class="code"><tspan class="k">"id"</tspan><tspan class="p">: </tspan><tspan class="s">"alice"</tspan><tspan class="p">,</tspan></text>
+  <text x="72" y="247" class="code"><tspan class="k">"type"</tspan><tspan class="p">: </tspan><tspan class="s">"person"</tspan></text>
+  <text x="56" y="265" class="code"><tspan class="p">},</tspan></text>
+  <text x="56" y="283" class="code"><tspan class="k">"target"</tspan><tspan class="p">: {</tspan></text>
+  <text x="72" y="301" class="code"><tspan class="k">"id"</tspan><tspan class="p">: </tspan><tspan class="s">"#sockethub"</tspan><tspan class="p">,</tspan></text>
+  <text x="72" y="319" class="code"><tspan class="k">"type"</tspan><tspan class="p">: </tspan><tspan class="s">"room"</tspan></text>
+  <text x="56" y="337" class="code"><tspan class="p">},</tspan></text>
+  <text x="56" y="355" class="code"><tspan class="k">"object"</tspan><tspan class="p">: {</tspan></text>
+  <text x="72" y="373" class="code"><tspan class="k">"type"</tspan><tspan class="p">: </tspan><tspan class="s">"message"</tspan><tspan class="p">,</tspan></text>
+  <text x="72" y="391" class="code"><tspan class="k">"content"</tspan><tspan class="p">: </tspan><tspan class="s">"Hello from the browser!"</tspan></text>
+  <text x="56" y="409" class="code"><tspan class="p">}</tspan></text>
+  <text x="40" y="427" class="code"><tspan class="p">}</tspan></text>
+
+  <!-- Right JSON -->
+  <text x="640" y="85" class="code"><tspan class="p">{</tspan></text>
+  <text x="656" y="103" class="code"><tspan class="k">"type"</tspan><tspan class="p">: </tspan><tspan class="s">"send"</tspan><tspan class="p">,</tspan></text>
+  <text x="656" y="121" class="code"><tspan class="k">"@context"</tspan><tspan class="p">: [</tspan></text>
+  <text x="672" y="139" class="code"><tspan class="s">"https://www.w3.org/ns/activitystreams"</tspan><tspan class="p">,</tspan></text>
+  <text x="672" y="157" class="code"><tspan class="s">"https://sockethub.org/ns/context/v1.jsonld"</tspan><tspan class="p">,</tspan></text>
+  <text x="672" y="175" class="code"><tspan class="s">"https://sockethub.org/ns/context/platform/irc/v1.jsonld"</tspan></text>
+  <text x="656" y="193" class="code"><tspan class="p">],</tspan></text>
+  <text x="656" y="211" class="code"><tspan class="k">"actor"</tspan><tspan class="p">: {</tspan></text>
+  <text x="672" y="229" class="code"><tspan class="k">"id"</tspan><tspan class="p">: </tspan><tspan class="s">"bob"</tspan><tspan class="p">,</tspan></text>
+  <text x="672" y="247" class="code"><tspan class="k">"type"</tspan><tspan class="p">: </tspan><tspan class="s">"person"</tspan></text>
+  <text x="656" y="265" class="code"><tspan class="p">},</tspan></text>
+  <text x="656" y="283" class="code"><tspan class="k">"target"</tspan><tspan class="p">: {</tspan></text>
+  <text x="672" y="301" class="code"><tspan class="k">"id"</tspan><tspan class="p">: </tspan><tspan class="s">"#sockethub"</tspan><tspan class="p">,</tspan></text>
+  <text x="672" y="319" class="code"><tspan class="k">"type"</tspan><tspan class="p">: </tspan><tspan class="s">"room"</tspan></text>
+  <text x="656" y="337" class="code"><tspan class="p">},</tspan></text>
+  <text x="656" y="355" class="code"><tspan class="k">"object"</tspan><tspan class="p">: {</tspan></text>
+  <text x="672" y="373" class="code"><tspan class="k">"type"</tspan><tspan class="p">: </tspan><tspan class="s">"message"</tspan><tspan class="p">,</tspan></text>
+  <text x="672" y="391" class="code"><tspan class="k">"content"</tspan><tspan class="p">: </tspan><tspan class="s">"Hi Alice!"</tspan></text>
+  <text x="656" y="409" class="code"><tspan class="p">}</tspan></text>
+  <text x="640" y="427" class="code"><tspan class="p">}</tspan></text>
+</svg>

--- a/docs/platform-development.md
+++ b/docs/platform-development.md
@@ -266,6 +266,7 @@ export default class ChatBot implements PersistentPlatformInterface {
         this.client = new ChatService(credentials.object.token);
         this.client.on('message', (msg) => {
             this.sendToClient({
+                '@context': job['@context'],
                 type: 'send',
                 actor: { id: msg.from, type: 'person' },
                 object: { type: 'note', content: msg.text }

--- a/docs/platform-development.md
+++ b/docs/platform-development.md
@@ -8,7 +8,7 @@ A platform is a Node.js package that acts as a bridge between Sockethub and exte
 When a web application sends an ActivityStreams message to Sockethub, the platform translates it
 into the specific protocol's format and handles the communication.
 
-For example: A web app sends `{ type: "send", context: "irc", object: { content: "hello" } }`
+For example: A web app sends `{ type: "send", "@context": [...], object: { content: "hello" } }`
 → the IRC platform converts this to an IRC `PRIVMSG #channel :hello` command and sends it to
 the IRC server.
 
@@ -267,7 +267,6 @@ export default class ChatBot implements PersistentPlatformInterface {
         this.client.on('message', (msg) => {
             this.sendToClient({
                 type: 'send',
-                context: 'chatbot',
                 actor: { id: msg.from, type: 'person' },
                 object: { type: 'note', content: msg.text }
             });

--- a/docs/platform-development.md
+++ b/docs/platform-development.md
@@ -269,7 +269,7 @@ export default class ChatBot implements PersistentPlatformInterface {
                 '@context': job['@context'],
                 type: 'send',
                 actor: { id: msg.from, type: 'person' },
-                object: { type: 'note', content: msg.text }
+                object: { type: 'message', content: msg.text }
             });
         });
         this.initialized = true;

--- a/packages/activity-streams/README.md
+++ b/packages/activity-streams/README.md
@@ -20,6 +20,9 @@ This library helps you:
 - **Build Activity Streams** that automatically link to stored objects
 - **Listen for events** when objects are created or deleted
 
+It does not rename legacy aliases like `verb`, `objectType`, `@id`, or `@type`.
+Use canonical fields directly (`type`, `id`, and `@context`).
+
 ## Install
 
 ### Node.js
@@ -83,7 +86,11 @@ const user = ActivityStreams.Object.create({
 // Create an activity that references it
 const activity = ActivityStreams.Stream({
   type: "send",
-  context: "irc",
+  "@context": [
+    "https://www.w3.org/ns/activitystreams",
+    "https://sockethub.org/ns/context/v1.jsonld",
+    "https://sockethub.org/ns/context/platform/irc/v1.jsonld"
+  ],
   actor: "user@example.com",  // automatically expands to full object
   object: { type: "message", content: "Hello!" }
 });
@@ -108,7 +115,7 @@ const user = sockethubClient.ActivityStreams.Object.create({
 
 const activity = sockethubClient.ActivityStreams.Stream({
   type: "send",
-  context: "irc",
+  "@context": sockethubClient.contextFor("irc"),
   actor: "user@example.com",
   object: { type: "message", content: "Hello!" }
 });

--- a/packages/activity-streams/README.md
+++ b/packages/activity-streams/README.md
@@ -20,9 +20,6 @@ This library helps you:
 - **Build Activity Streams** that automatically link to stored objects
 - **Listen for events** when objects are created or deleted
 
-It does not rename legacy aliases like `verb`, `objectType`, `@id`, or `@type`.
-Use canonical fields directly (`type`, `id`, and `@context`).
-
 ## Install
 
 ### Node.js
@@ -92,31 +89,6 @@ const activity = ActivityStreams.Stream({
     "https://sockethub.org/ns/context/platform/irc/v1.jsonld"
   ],
   actor: "user@example.com",  // automatically expands to full object
-  object: { type: "message", content: "Hello!" }
-});
-```
-
-### With Sockethub Client
-
-If you're using the Sockethub client, this library is already bundled and available:
-
-```javascript
-import SockethubClient from '@sockethub/client';
-
-const socket = io('http://localhost:10550');
-const sockethubClient = new SockethubClient(socket);
-
-// Access ActivityStreams through the client
-const user = sockethubClient.ActivityStreams.Object.create({
-  id: "user@example.com", 
-  type: "person",
-  name: "John Doe"
-});
-
-const activity = sockethubClient.ActivityStreams.Stream({
-  type: "send",
-  "@context": sockethubClient.contextFor("irc"),
-  actor: "user@example.com",
   object: { type: "message", content: "Hello!" }
 });
 ```

--- a/packages/client/README.md
+++ b/packages/client/README.md
@@ -34,9 +34,13 @@ const sc = new SockethubClient(io(SOCKETHUB_SERVER));
 
 ### Browser
 
-The browser bundle is available in the dist folder. Place it somewhere
-accessible from the web, along with `socket.io-client`, and include
-both via script tags:
+Two browser builds are published in `dist/`:
+
+- `dist/sockethub-client.browser.js` is the IIFE/global build for plain `<script>` tags
+- `dist/sockethub-client.js` is the ESM build for `<script type="module">`
+
+If you are serving assets from a Sockethub server, use the pre-copied global build
+at `/sockethub-client.js` along with `/socket.io.js`:
 
 ```html
 <script src="/socket.io.js"></script>
@@ -45,8 +49,17 @@ both via script tags:
 
 These scripts set `io` and `SockethubClient` as globals.
 
-Once included in a web-page, the `SockethubClient` base object
-should be on the global scope.
+If you are hosting the package files yourself and want ESM instead, serve
+`dist/sockethub-client.js` and import it from a module script:
+
+```html
+<script type="module">
+import SockethubClient from '/dist/sockethub-client.js';
+import { io } from '/socket.io.esm.min.js';
+
+const sc = new SockethubClient(io('http://localhost:10550'));
+</script>
+```
 
 ## Quick Start
 
@@ -67,19 +80,23 @@ sc.socket.on('init_error', (e) => {
 });
 
 // Wait for schema registry, then send a message
-await sc.ready();
-sc.socket.emit('message', {
-    '@context': sc.contextFor('dummy'),
-    type: 'echo',
-    actor: { id: 'test@dummy', type: 'person' },
-    object: { type: 'message', content: 'hello world' }
-}, (ack) => {
-    if (ack?.error) {
-        console.error('Send failed:', ack.error);
-        return;
-    }
-    console.log('Ack:', ack);
-});
+try {
+    await sc.ready();
+    sc.socket.emit('message', {
+        '@context': sc.contextFor('dummy'),
+        type: 'echo',
+        actor: { id: 'test@dummy', type: 'person' },
+        object: { type: 'message', content: 'hello world' }
+    }, (ack) => {
+        if (ack?.error) {
+            console.error('Send failed:', ack.error);
+            return;
+        }
+        console.log('Ack:', ack);
+    });
+} catch (err) {
+    console.error('Sockethub failed to initialize:', err);
+}
 ```
 
 See the [Client Guide](../../docs/client-guide.md) for detailed usage and examples.

--- a/packages/client/README.md
+++ b/packages/client/README.md
@@ -29,7 +29,7 @@ automatic reconnection and credential replay.
 
 ```javascript
 const SockethubClient = require('@sockethub/client');
-const io = require('@socket.io-client');
+const io = require('socket.io-client');
 const SOCKETHUB_SERVER = 'http://localhost:10550';
 const sc = new SockethubClient(io(SOCKETHUB_SERVER));
 ```
@@ -38,25 +38,23 @@ const sc = new SockethubClient(io(SOCKETHUB_SERVER));
 
 ```javascript
 import SockethubClient from '@sockethub/client';
-import { io } from '@socket.io-client';
+import { io } from 'socket.io-client';
 const SOCKETHUB_SERVER = 'http://localhost:10550';
 const sc = new SockethubClient(io(SOCKETHUB_SERVER));
 ```
 
 ### Browser
 
-The browser bundle is available in the dist folder:
+The browser bundle is available in the dist folder. Place it somewhere
+accessible from the web, along with `socket.io-client`, and include
+both via script tags:
 
-```
-import '@sockethub/client/dist/sockethub-client.js';
+```html
+<script src="/socket.io.js"></script>
+<script src="/sockethub-client.js"></script>
 ```
 
-You can place it somewhere accessible from the web and include
-it via a `script` tag.
-
-```
-<script src="http://example.com/sockethub-client.js" type="module"></script>
-```
+These scripts set `io` and `SockethubClient` as globals.
 
 Once included in a web-page, the `SockethubClient` base object
 should be on the global scope.

--- a/packages/client/README.md
+++ b/packages/client/README.md
@@ -25,17 +25,6 @@ automatic reconnection and credential replay.
 
 `$ bun install @sockethub/client socket.io-client`
 
-#### CommonJS
-
-```javascript
-const SockethubClient = require('@sockethub/client').default;
-const { io } = require('socket.io-client');
-const SOCKETHUB_SERVER = 'http://localhost:10550';
-const sc = new SockethubClient(io(SOCKETHUB_SERVER));
-```
-
-#### ESM
-
 ```javascript
 import SockethubClient from '@sockethub/client';
 import { io } from 'socket.io-client';
@@ -121,7 +110,7 @@ sc.socket.emit("message", {
     type: "echo",
     "@context": sc.contextFor("dummy"),
     actor: { id: "test", type: "person" },
-    object: { type: "note", content: "Hello!" },
+    object: { type: "message", content: "Hello!" },
 }, (result) => {
     if (result?.error) {
         console.error("Sockethub request failed:", result.error);

--- a/packages/client/README.md
+++ b/packages/client/README.md
@@ -19,11 +19,11 @@ automatic reconnection and credential replay.
 
 ### Node.js
 
-`$ npm install @sockethub/client`
+`$ npm install @sockethub/client socket.io-client`
 
 ### Bun
 
-`$ bun install @sockethub/client`
+`$ bun install @sockethub/client socket.io-client`
 
 #### CommonJS
 

--- a/packages/client/README.md
+++ b/packages/client/README.md
@@ -28,8 +28,8 @@ automatic reconnection and credential replay.
 #### CommonJS
 
 ```javascript
-const SockethubClient = require('@sockethub/client');
-const io = require('socket.io-client');
+const SockethubClient = require('@sockethub/client').default;
+const { io } = require('socket.io-client');
 const SOCKETHUB_SERVER = 'http://localhost:10550';
 const sc = new SockethubClient(io(SOCKETHUB_SERVER));
 ```

--- a/packages/client/README.md
+++ b/packages/client/README.md
@@ -57,7 +57,7 @@ If you are hosting the package files yourself and want ESM instead, serve
 import SockethubClient from '/dist/sockethub-client.js';
 import { io } from '/socket.io.esm.min.js';
 
-const sc = new SockethubClient(io('http://localhost:10550'));
+const sc = new SockethubClient(io('http://localhost:10550', { path: '/sockethub' }));
 </script>
 ```
 

--- a/packages/client/README.md
+++ b/packages/client/README.md
@@ -9,6 +9,9 @@ automatic reconnection and credential replay.
 
 - `SockethubClient` for connection and message handling
 - `ActivityStreams` helpers and validation utilities
+- `contextFor(platform)` builds canonical `@context` arrays from server metadata
+- `ready()` promise and `ready`/`init_error` observability events
+- Automatic outbound queueing until initialization is complete
 - Auto-replay of credentials and connections on reconnect
 - A browser-ready bundle in `dist/`
 
@@ -65,17 +68,47 @@ import SockethubClient from '@sockethub/client';
 import { io } from 'socket.io-client';
 
 const socket = io('http://localhost:10550', { path: '/sockethub' });
-const sc = new SockethubClient(socket);
+const sc = new SockethubClient(socket, { initTimeoutMs: 5000 });
 
 sc.socket.on('message', (msg) => console.log(msg));
+sc.socket.on('ready', (info) => {
+    console.log('Sockethub ready:', info.reason, info.sockethubVersion,
+        info.platforms.map((p) => ({ id: p.id, version: p.version })));
+});
+sc.socket.on('init_error', (e) => {
+    console.warn('Sockethub init issue:', e.error);
+});
+
+// Wait for schema registry, then send a message
+await sc.ready();
+sc.socket.emit('message', {
+    '@context': sc.contextFor('dummy'),
+    type: 'echo',
+    actor: { id: 'test@dummy', type: 'person' },
+    object: { type: 'message', content: 'hello world' }
+}, (ack) => {
+    if (ack?.error) {
+        console.error('Send failed:', ack.error);
+        return;
+    }
+    console.log('Ack:', ack);
+});
 ```
 
 See the [Client Guide](../../docs/client-guide.md) for detailed usage and examples.
 
 ## API
 
-- **`new SockethubClient(socket)`** - Create client instance
-- **`sc.socket.emit(event, data, callback)`** - Send messages and inspect result
+- **`new SockethubClient(socket, options?)`** - Create client instance with optional init/queue settings
+- **`sc.ready(timeoutMs?)`** - Wait for initialization to complete
+- **`sc.isReady()`** - Check whether client is initialized
+- **`sc.getInitState()`** - Return `"idle" | "initializing" | "ready" | "init_error" | "closed"`
+- **`sc.contextFor(platform)`** - Build canonical `@context` for a platform from server registry
+- **`sc.getRegisteredPlatforms()`** - Get server-registered platforms/contexts
+- **`sc.getRegisteredBaseContexts()`** - Get AS2 and Sockethub base context URLs
+- **`sc.getPlatformSchema(platform, schemaType?)`** - Get platform JSON schema
+- **`sc.validateActivity(activity)`** - Validate against registered schemas
+- **`sc.socket.emit(event, data, callback)`** - Send messages (queued until ready)
 - **`sc.socket.on(event, handler)`** - Listen for messages
 - **`sc.clearCredentials()`** - Clear stored credentials
 - **`sc.ActivityStreams`** - ActivityStreams library
@@ -88,7 +121,7 @@ field as failure:
 ```javascript
 sc.socket.emit("message", {
     type: "echo",
-    context: "dummy",
+    "@context": sc.contextFor("dummy"),
     actor: { id: "test", type: "person" },
     object: { type: "note", content: "Hello!" },
 }, (result) => {
@@ -123,7 +156,7 @@ sc.ActivityStreams.Object.create({
 
 const stream = sc.ActivityStreams.Stream({
     type: "join",
-    context: "irc",
+    "@context": sc.contextFor("irc"),
     actor: "mynick",
     target: { id: "#sockethub", type: "room" },
 });

--- a/packages/irc2as/README.md
+++ b/packages/irc2as/README.md
@@ -11,8 +11,8 @@ of them, and as time goes on hopefully become more compliant (PRs & feedback wel
 ## Usage
 
 ```javascript
-    var IRC2AS = require('irc2as');
-    var irc2as = new IRC2AS({
+    import { IrcToActivityStreams } from '@sockethub/irc2as';
+    const irc2as = new IrcToActivityStreams({
       server: 'irc.freenode.net',
       contexts: [
         'https://www.w3.org/ns/activitystreams',

--- a/packages/irc2as/README.md
+++ b/packages/irc2as/README.md
@@ -14,8 +14,11 @@ of them, and as time goes on hopefully become more compliant (PRs & feedback wel
     var IRC2AS = require('irc2as');
     var irc2as = new IRC2AS({
       server: 'irc.freenode.net',
-      // optional legacy context field value for emitted activities
-      context: 'irc'
+      contexts: [
+        'https://www.w3.org/ns/activitystreams',
+        'https://sockethub.org/ns/context/v1.jsonld',
+        'https://sockethub.org/ns/context/platform/irc/v1.jsonld'
+      ]
     });
 
     irc2as.events.on('incoming', function (asObject) {

--- a/packages/platform-dummy/README.md
+++ b/packages/platform-dummy/README.md
@@ -28,9 +28,11 @@ platform communication without requiring external service connections.
     "https://sockethub.org/ns/context/platform/dummy/v1.jsonld"
   ],
   "actor": {
-    "id": "test-user"
+    "id": "test-user",
+    "type": "person"
   },
   "object": {
+    "type": "message",
     "content": "Hello World"
   }
 }
@@ -47,9 +49,15 @@ platform communication without requiring external service connections.
     "https://sockethub.org/ns/context/platform/dummy/v1.jsonld"
   ],
   "actor": {
-    "id": "test-user"
+    "id": "dummy",
+    "type": "platform"
+  },
+  "target": {
+    "id": "test-user",
+    "type": "person"
   },
   "object": {
+    "type": "message",
     "content": "Hello World"
   }
 }

--- a/packages/platform-dummy/README.md
+++ b/packages/platform-dummy/README.md
@@ -22,7 +22,11 @@ platform communication without requiring external service connections.
 ```json
 {
   "@type": "echo",
-  "context": "dummy",
+  "@context": [
+    "https://www.w3.org/ns/activitystreams",
+    "https://sockethub.org/ns/context/v1.jsonld",
+    "https://sockethub.org/ns/context/platform/dummy/v1.jsonld"
+  ],
   "actor": {
     "@id": "test-user"
   },
@@ -37,7 +41,11 @@ platform communication without requiring external service connections.
 ```json
 {
   "@type": "echo",
-  "context": "dummy",
+  "@context": [
+    "https://www.w3.org/ns/activitystreams",
+    "https://sockethub.org/ns/context/v1.jsonld",
+    "https://sockethub.org/ns/context/platform/dummy/v1.jsonld"
+  ],
   "actor": {
     "@id": "test-user"
   },

--- a/packages/platform-dummy/README.md
+++ b/packages/platform-dummy/README.md
@@ -8,7 +8,7 @@ This platform provides basic testing functionality for Sockethub development. It
 simple verbs that can be used to test ActivityStreams message flow, error handling, and
 platform communication without requiring external service connections.
 
-## Implemented Verbs (`@type`)
+## Implemented Verbs (`type`)
 
 * **echo** - Returns the received message unchanged
 * **fail** - Intentionally fails with an error message
@@ -21,14 +21,14 @@ platform communication without requiring external service connections.
 
 ```json
 {
-  "@type": "echo",
+  "type": "echo",
   "@context": [
     "https://www.w3.org/ns/activitystreams",
     "https://sockethub.org/ns/context/v1.jsonld",
     "https://sockethub.org/ns/context/platform/dummy/v1.jsonld"
   ],
   "actor": {
-    "@id": "test-user"
+    "id": "test-user"
   },
   "object": {
     "content": "Hello World"
@@ -40,14 +40,14 @@ platform communication without requiring external service connections.
 
 ```json
 {
-  "@type": "echo",
+  "type": "echo",
   "@context": [
     "https://www.w3.org/ns/activitystreams",
     "https://sockethub.org/ns/context/v1.jsonld",
     "https://sockethub.org/ns/context/platform/dummy/v1.jsonld"
   ],
   "actor": {
-    "@id": "test-user"
+    "id": "test-user"
   },
   "object": {
     "content": "Hello World"

--- a/packages/platform-feeds/MIGRATION.md
+++ b/packages/platform-feeds/MIGRATION.md
@@ -7,7 +7,7 @@
 ```javascript
 // Response was an array
 [
-  { context: "feeds", type: "post", actor: {...}, object: {...} },
+  { "@context": ["https://www.w3.org/ns/activitystreams", "..."], type: "post", actor: {...}, object: {...} },
   // ... more items
 ]
 ```
@@ -17,12 +17,12 @@
 ```javascript
 // Response is now a Collection object
 {
-  context: "feeds",
+  "@context": ["https://www.w3.org/ns/activitystreams", "..."],
   type: "collection", 
   summary: "Feed Name",
   totalItems: 20,
   items: [
-    { context: "feeds", type: "post", actor: {...}, object: {...} },
+    { "@context": ["https://www.w3.org/ns/activitystreams", "..."], type: "post", actor: {...}, object: {...} },
     // ... more items
   ]
 }

--- a/packages/platform-feeds/MIGRATION.md
+++ b/packages/platform-feeds/MIGRATION.md
@@ -5,7 +5,7 @@
 ### Before (Array)
 
 ```javascript
-// Response was an array
+// Response was an array (@context omitted for brevity)
 [
   { type: "post", actor: {...}, object: {...} },
   // ... more items
@@ -15,7 +15,7 @@
 ### After (Collection)
 
 ```javascript
-// Response is now a Collection object
+// Response is now a Collection object (@context omitted for brevity)
 {
   type: "collection",
   summary: "Feed Name",

--- a/packages/platform-feeds/MIGRATION.md
+++ b/packages/platform-feeds/MIGRATION.md
@@ -7,7 +7,7 @@
 ```javascript
 // Response was an array
 [
-  { "@context": ["https://www.w3.org/ns/activitystreams", "..."], type: "post", actor: {...}, object: {...} },
+  { type: "post", actor: {...}, object: {...} },
   // ... more items
 ]
 ```
@@ -17,12 +17,11 @@
 ```javascript
 // Response is now a Collection object
 {
-  "@context": ["https://www.w3.org/ns/activitystreams", "..."],
-  type: "collection", 
+  type: "collection",
   summary: "Feed Name",
   totalItems: 20,
   items: [
-    { "@context": ["https://www.w3.org/ns/activitystreams", "..."], type: "post", actor: {...}, object: {...} },
+    { type: "post", actor: {...}, object: {...} },
     // ... more items
   ]
 }

--- a/packages/platform-feeds/README.md
+++ b/packages/platform-feeds/README.md
@@ -25,7 +25,8 @@ web applications to consume feed content.
     "https://sockethub.org/ns/context/platform/feeds/v1.jsonld"
   ],
   "actor": {
-    "id": "https://example.com/feed.xml"
+    "id": "https://example.com/feed.xml",
+    "type": "feed"
   }
 }
 ```
@@ -49,11 +50,13 @@ Returns an ActivityStreams Collection with feed entries:
       "type": "post",
       "actor": {
         "id": "https://example.com/feed.xml",
+        "type": "feed",
         "name": "Example Blog"
       },
       "object": {
+        "id": "https://example.com/post/1",
         "type": "article",
-        "name": "Blog Post Title",
+        "title": "Blog Post Title",
         "content": "Post content...",
         "url": "https://example.com/post/1",
         "published": "2023-01-01T12:00:00Z"

--- a/packages/platform-feeds/README.md
+++ b/packages/platform-feeds/README.md
@@ -8,7 +8,7 @@ This platform fetches RSS and Atom feeds from URLs and converts feed entries int
 ActivityStreams objects. It handles various feed formats and provides structured data for
 web applications to consume feed content.
 
-## Implemented Verbs (`@type`)
+## Implemented Verbs (`type`)
 
 * **fetch** - Retrieve and parse an RSS or Atom feed
 
@@ -18,14 +18,14 @@ web applications to consume feed content.
 
 ```json
 {
-  "@type": "fetch",
+  "type": "fetch",
   "@context": [
     "https://www.w3.org/ns/activitystreams",
     "https://sockethub.org/ns/context/v1.jsonld",
     "https://sockethub.org/ns/context/platform/feeds/v1.jsonld"
   ],
   "actor": {
-    "@id": "https://example.com/feed.xml"
+    "id": "https://example.com/feed.xml"
   }
 }
 ```
@@ -36,7 +36,7 @@ Returns an ActivityStreams Collection with feed entries:
 
 ```json
 {
-  "@type": "Collection",
+  "type": "Collection",
   "@context": [
     "https://www.w3.org/ns/activitystreams",
     "https://sockethub.org/ns/context/v1.jsonld",
@@ -45,13 +45,13 @@ Returns an ActivityStreams Collection with feed entries:
   "totalItems": 10,
   "items": [
     {
-      "@type": "Create",
+      "type": "Create",
       "actor": {
-        "@id": "https://example.com/feed.xml",
+        "id": "https://example.com/feed.xml",
         "name": "Example Blog"
       },
       "object": {
-        "@type": "Article",
+        "type": "Article",
         "name": "Blog Post Title",
         "content": "Post content...",
         "url": "https://example.com/post/1",

--- a/packages/platform-feeds/README.md
+++ b/packages/platform-feeds/README.md
@@ -48,6 +48,11 @@ Returns an ActivityStreams Collection with feed entries:
   "items": [
     {
       "type": "post",
+      "@context": [
+        "https://www.w3.org/ns/activitystreams",
+        "https://sockethub.org/ns/context/v1.jsonld",
+        "https://sockethub.org/ns/context/platform/feeds/v1.jsonld"
+      ],
       "actor": {
         "id": "https://example.com/feed.xml",
         "type": "feed",

--- a/packages/platform-feeds/README.md
+++ b/packages/platform-feeds/README.md
@@ -19,7 +19,11 @@ web applications to consume feed content.
 ```json
 {
   "@type": "fetch",
-  "context": "feeds",
+  "@context": [
+    "https://www.w3.org/ns/activitystreams",
+    "https://sockethub.org/ns/context/v1.jsonld",
+    "https://sockethub.org/ns/context/platform/feeds/v1.jsonld"
+  ],
   "actor": {
     "@id": "https://example.com/feed.xml"
   }
@@ -33,7 +37,11 @@ Returns an ActivityStreams Collection with feed entries:
 ```json
 {
   "@type": "Collection",
-  "context": "feeds",
+  "@context": [
+    "https://www.w3.org/ns/activitystreams",
+    "https://sockethub.org/ns/context/v1.jsonld",
+    "https://sockethub.org/ns/context/platform/feeds/v1.jsonld"
+  ],
   "totalItems": 10,
   "items": [
     {

--- a/packages/platform-feeds/README.md
+++ b/packages/platform-feeds/README.md
@@ -36,22 +36,23 @@ Returns an ActivityStreams Collection with feed entries:
 
 ```json
 {
-  "type": "Collection",
+  "type": "collection",
   "@context": [
     "https://www.w3.org/ns/activitystreams",
     "https://sockethub.org/ns/context/v1.jsonld",
     "https://sockethub.org/ns/context/platform/feeds/v1.jsonld"
   ],
+  "summary": "Example Blog",
   "totalItems": 10,
   "items": [
     {
-      "type": "Create",
+      "type": "post",
       "actor": {
         "id": "https://example.com/feed.xml",
         "name": "Example Blog"
       },
       "object": {
-        "type": "Article",
+        "type": "article",
         "name": "Blog Post Title",
         "content": "Post content...",
         "url": "https://example.com/post/1",

--- a/packages/platform-irc/API.md
+++ b/packages/platform-irc/API.md
@@ -72,7 +72,11 @@ Valid AS object for setting IRC credentials:
 ```js
 {
    type: 'credentials',
-   context: 'irc',
+   "@context": [
+     "https://www.w3.org/ns/activitystreams",
+     "https://sockethub.org/ns/context/v1.jsonld",
+     "https://sockethub.org/ns/context/platform/irc/v1.jsonld"
+   ],
    actor: {
      id: 'testuser@irc.host.net',
      type: 'person',
@@ -144,7 +148,11 @@ Join a room or private conversation.
 **Example**  
 ```js
 {
-  context: 'irc',
+  "@context": [
+    "https://www.w3.org/ns/activitystreams",
+    "https://sockethub.org/ns/context/v1.jsonld",
+    "https://sockethub.org/ns/context/platform/irc/v1.jsonld"
+  ],
   type: 'join',
   actor: {
     id: 'slvrbckt@irc.freenode.net',
@@ -186,7 +194,11 @@ Leave a room or private conversation.
 **Example**  
 ```js
 {
-  context: 'irc',
+  "@context": [
+    "https://www.w3.org/ns/activitystreams",
+    "https://sockethub.org/ns/context/v1.jsonld",
+    "https://sockethub.org/ns/context/platform/irc/v1.jsonld"
+  ],
   type: 'leave',
   actor: {
     id: 'slvrbckt@irc.freenode.net',
@@ -228,7 +240,11 @@ Send a message to a room or private conversation.
 **Example**  
 ```js
 {
-   context: 'irc',
+   "@context": [
+     "https://www.w3.org/ns/activitystreams",
+     "https://sockethub.org/ns/context/v1.jsonld",
+     "https://sockethub.org/ns/context/platform/irc/v1.jsonld"
+   ],
    type: 'send',
    actor: {
      id: 'slvrbckt@irc.freenode.net',
@@ -279,7 +295,11 @@ Indicate a change (i.e. room topic update, or nickname change).
 change topic
 
 {
-  context: 'irc',
+  "@context": [
+    "https://www.w3.org/ns/activitystreams",
+    "https://sockethub.org/ns/context/v1.jsonld",
+    "https://sockethub.org/ns/context/platform/irc/v1.jsonld"
+  ],
   type: 'update',
   actor: {
     id: 'slvrbckt@irc.freenode.net',
@@ -302,7 +322,11 @@ change topic
 ```js
 change nickname
  {
-   context: 'irc'
+   "@context": [
+     "https://www.w3.org/ns/activitystreams",
+     "https://sockethub.org/ns/context/v1.jsonld",
+     "https://sockethub.org/ns/context/platform/irc/v1.jsonld"
+   ],
    type: 'update',
    actor: {
      id: 'slvrbckt@irc.freenode.net',
@@ -346,7 +370,11 @@ Indicate an intent to query something (e.g. get a list of users in a room).
 **Example**  
 ```js
 {
-   context: 'irc',
+   "@context": [
+     "https://www.w3.org/ns/activitystreams",
+     "https://sockethub.org/ns/context/v1.jsonld",
+     "https://sockethub.org/ns/context/platform/irc/v1.jsonld"
+   ],
    type: 'query',
    actor: {
      id: 'slvrbckt@irc.freenode.net',
@@ -367,7 +395,11 @@ Indicate an intent to query something (e.g. get a list of users in a room).
 
  // The above object might return:
  {
-   context: 'irc',
+   "@context": [
+     "https://www.w3.org/ns/activitystreams",
+     "https://sockethub.org/ns/context/v1.jsonld",
+     "https://sockethub.org/ns/context/platform/irc/v1.jsonld"
+   ],
    type: 'query',
    actor: {
      id: 'irc.freenode.net/a-room',
@@ -411,7 +443,11 @@ Disconnect IRC client
 **Example**  
 ```js
 {
-   context: 'irc',
+   "@context": [
+     "https://www.w3.org/ns/activitystreams",
+     "https://sockethub.org/ns/context/v1.jsonld",
+     "https://sockethub.org/ns/context/platform/irc/v1.jsonld"
+   ],
    type: 'disconnect',
    actor: {
      id: 'slvrbckt@irc.freenode.net',

--- a/packages/platform-irc/README.md
+++ b/packages/platform-irc/README.md
@@ -8,7 +8,7 @@ This platform provides IRC client functionality, allowing web applications to co
 IRC servers, join channels, send messages, and handle IRC events through ActivityStreams
 messages.
 
-## Implemented Verbs (`@type`)
+## Implemented Verbs (`type`)
 
 * **send** - Send messages to channels or users
 * **join** - Join IRC channels
@@ -22,20 +22,20 @@ messages.
 
 ```json
 {
-  "@type": "send",
+  "type": "send",
   "@context": [
     "https://www.w3.org/ns/activitystreams",
     "https://sockethub.org/ns/context/v1.jsonld",
     "https://sockethub.org/ns/context/platform/irc/v1.jsonld"
   ],
   "actor": {
-    "@id": "mynick@irc.libera.chat"
+    "id": "mynick@irc.libera.chat"
   },
   "target": {
-    "@id": "#general@irc.libera.chat"
+    "id": "#general@irc.libera.chat"
   },
   "object": {
-    "@type": "Note",
+    "type": "Note",
     "content": "Hello IRC channel!"
   }
 }
@@ -45,17 +45,17 @@ messages.
 
 ```json
 {
-  "@type": "join",
+  "type": "join",
   "@context": [
     "https://www.w3.org/ns/activitystreams",
     "https://sockethub.org/ns/context/v1.jsonld",
     "https://sockethub.org/ns/context/platform/irc/v1.jsonld"
   ],
   "actor": {
-    "@id": "mynick@irc.libera.chat"
+    "id": "mynick@irc.libera.chat"
   },
   "target": {
-    "@id": "#general@irc.libera.chat"
+    "id": "#general@irc.libera.chat"
   }
 }
 ```
@@ -64,20 +64,20 @@ messages.
 
 ```json
 {
-  "@type": "send",
+  "type": "send",
   "@context": [
     "https://www.w3.org/ns/activitystreams",
     "https://sockethub.org/ns/context/v1.jsonld",
     "https://sockethub.org/ns/context/platform/irc/v1.jsonld"
   ],
   "actor": {
-    "@id": "mynick@irc.libera.chat"
+    "id": "mynick@irc.libera.chat"
   },
   "target": {
-    "@id": "friend@irc.libera.chat"
+    "id": "friend@irc.libera.chat"
   },
   "object": {
-    "@type": "Note",
+    "type": "Note",
     "content": "Hello friend!"
   }
 }

--- a/packages/platform-irc/README.md
+++ b/packages/platform-irc/README.md
@@ -29,13 +29,15 @@ messages.
     "https://sockethub.org/ns/context/platform/irc/v1.jsonld"
   ],
   "actor": {
-    "id": "mynick@irc.libera.chat"
+    "id": "mynick@irc.libera.chat",
+    "type": "person"
   },
   "target": {
-    "id": "#general@irc.libera.chat"
+    "id": "#general@irc.libera.chat",
+    "type": "room"
   },
   "object": {
-    "type": "Note",
+    "type": "message",
     "content": "Hello IRC channel!"
   }
 }
@@ -52,10 +54,12 @@ messages.
     "https://sockethub.org/ns/context/platform/irc/v1.jsonld"
   ],
   "actor": {
-    "id": "mynick@irc.libera.chat"
+    "id": "mynick@irc.libera.chat",
+    "type": "person"
   },
   "target": {
-    "id": "#general@irc.libera.chat"
+    "id": "#general@irc.libera.chat",
+    "type": "room"
   }
 }
 ```
@@ -71,13 +75,15 @@ messages.
     "https://sockethub.org/ns/context/platform/irc/v1.jsonld"
   ],
   "actor": {
-    "id": "mynick@irc.libera.chat"
+    "id": "mynick@irc.libera.chat",
+    "type": "person"
   },
   "target": {
-    "id": "friend@irc.libera.chat"
+    "id": "friend@irc.libera.chat",
+    "type": "person"
   },
   "object": {
-    "type": "Note",
+    "type": "message",
     "content": "Hello friend!"
   }
 }

--- a/packages/platform-irc/README.md
+++ b/packages/platform-irc/README.md
@@ -23,7 +23,11 @@ messages.
 ```json
 {
   "@type": "send",
-  "context": "irc",
+  "@context": [
+    "https://www.w3.org/ns/activitystreams",
+    "https://sockethub.org/ns/context/v1.jsonld",
+    "https://sockethub.org/ns/context/platform/irc/v1.jsonld"
+  ],
   "actor": {
     "@id": "mynick@irc.libera.chat"
   },
@@ -42,7 +46,11 @@ messages.
 ```json
 {
   "@type": "join",
-  "context": "irc",
+  "@context": [
+    "https://www.w3.org/ns/activitystreams",
+    "https://sockethub.org/ns/context/v1.jsonld",
+    "https://sockethub.org/ns/context/platform/irc/v1.jsonld"
+  ],
   "actor": {
     "@id": "mynick@irc.libera.chat"
   },
@@ -57,7 +65,11 @@ messages.
 ```json
 {
   "@type": "send",
-  "context": "irc",
+  "@context": [
+    "https://www.w3.org/ns/activitystreams",
+    "https://sockethub.org/ns/context/v1.jsonld",
+    "https://sockethub.org/ns/context/platform/irc/v1.jsonld"
+  ],
   "actor": {
     "@id": "mynick@irc.libera.chat"
   },

--- a/packages/platform-metadata/README.md
+++ b/packages/platform-metadata/README.md
@@ -28,7 +28,8 @@ to clients through the Sockethub service.
     "https://sockethub.org/ns/context/platform/metadata/v1.jsonld"
   ],
   "actor": {
-    "id": "https://example.com/page-to-analyze"
+    "id": "https://example.com/page-to-analyze",
+    "type": "website"
   }
 }
 ```
@@ -47,6 +48,7 @@ The platform returns an ActivityStream object with extracted metadata:
   ],
   "actor": {
     "id": "https://example.com/page-to-analyze",
+    "type": "website",
     "name": "Example Site"
   },
   "object": {

--- a/packages/platform-metadata/README.md
+++ b/packages/platform-metadata/README.md
@@ -22,7 +22,11 @@ to clients through the Sockethub service.
 ```json
 {
   "@type": "fetch",
-  "context": "metadata",
+  "@context": [
+    "https://www.w3.org/ns/activitystreams",
+    "https://sockethub.org/ns/context/v1.jsonld",
+    "https://sockethub.org/ns/context/platform/metadata/v1.jsonld"
+  ],
   "actor": {
     "@id": "https://example.com/page-to-analyze"
   }
@@ -36,7 +40,11 @@ The platform returns an ActivityStream object with extracted metadata:
 ```json
 {
   "@type": "fetch",
-  "context": "metadata",
+  "@context": [
+    "https://www.w3.org/ns/activitystreams",
+    "https://sockethub.org/ns/context/v1.jsonld",
+    "https://sockethub.org/ns/context/platform/metadata/v1.jsonld"
+  ],
   "actor": {
     "@id": "https://example.com/page-to-analyze",
     "name": "Example Site"

--- a/packages/platform-metadata/README.md
+++ b/packages/platform-metadata/README.md
@@ -8,7 +8,7 @@ This platform fetches and extracts metadata from web pages, including Open Graph
 site information, images, and other structured metadata. It uses the `open-graph-scraper`
 library to analyze web pages and return structured data in ActivityStreams format.
 
-## Implemented Verbs (`@type`)
+## Implemented Verbs (`type`)
 
 * **fetch** - Extract metadata from a web page URL
 
@@ -21,14 +21,14 @@ to clients through the Sockethub service.
 
 ```json
 {
-  "@type": "fetch",
+  "type": "fetch",
   "@context": [
     "https://www.w3.org/ns/activitystreams",
     "https://sockethub.org/ns/context/v1.jsonld",
     "https://sockethub.org/ns/context/platform/metadata/v1.jsonld"
   ],
   "actor": {
-    "@id": "https://example.com/page-to-analyze"
+    "id": "https://example.com/page-to-analyze"
   }
 }
 ```
@@ -39,14 +39,14 @@ The platform returns an ActivityStream object with extracted metadata:
 
 ```json
 {
-  "@type": "fetch",
+  "type": "fetch",
   "@context": [
     "https://www.w3.org/ns/activitystreams",
     "https://sockethub.org/ns/context/v1.jsonld",
     "https://sockethub.org/ns/context/platform/metadata/v1.jsonld"
   ],
   "actor": {
-    "@id": "https://example.com/page-to-analyze",
+    "id": "https://example.com/page-to-analyze",
     "name": "Example Site"
   },
   "object": {

--- a/packages/platform-xmpp/API.md
+++ b/packages/platform-xmpp/API.md
@@ -89,7 +89,11 @@ Valid AS object for setting XMPP credentials:
 ```js
 {
   type: 'credentials',
-  context: 'xmpp',
+  "@context": [
+    "https://www.w3.org/ns/activitystreams",
+    "https://sockethub.org/ns/context/v1.jsonld",
+    "https://sockethub.org/ns/context/platform/xmpp/v1.jsonld"
+  ],
   actor: {
     id: 'testuser@jabber.net',
     type: 'person',
@@ -131,7 +135,11 @@ Connect to the XMPP server.
 **Example**  
 ```js
 {
-  context: 'xmpp',
+  "@context": [
+    "https://www.w3.org/ns/activitystreams",
+    "https://sockethub.org/ns/context/v1.jsonld",
+    "https://sockethub.org/ns/context/platform/xmpp/v1.jsonld"
+  ],
   type: 'connect',
   actor: {
     id: 'slvrbckt@jabber.net/Home',
@@ -166,7 +174,11 @@ Join a room, optionally defining a display name for that room.
 **Example**  
 ```js
 {
-  context: 'xmpp',
+  "@context": [
+    "https://www.w3.org/ns/activitystreams",
+    "https://sockethub.org/ns/context/v1.jsonld",
+    "https://sockethub.org/ns/context/platform/xmpp/v1.jsonld"
+  ],
   type: 'join',
   actor: {
     type: 'person',
@@ -204,7 +216,11 @@ Leave a room
 **Example**  
 ```js
 {
-  context: 'xmpp',
+  "@context": [
+    "https://www.w3.org/ns/activitystreams",
+    "https://sockethub.org/ns/context/v1.jsonld",
+    "https://sockethub.org/ns/context/platform/xmpp/v1.jsonld"
+  ],
   type: 'leave',
   actor: {
     type: 'person',
@@ -242,7 +258,11 @@ Send a message to a room or private conversation.
 **Example**  
 ```js
 {
-  context: 'xmpp',
+  "@context": [
+    "https://www.w3.org/ns/activitystreams",
+    "https://sockethub.org/ns/context/v1.jsonld",
+    "https://sockethub.org/ns/context/platform/xmpp/v1.jsonld"
+  ],
   type: 'send',
   actor: {
     id: 'slvrbckt@jabber.net/Home',
@@ -262,7 +282,11 @@ Send a message to a room or private conversation.
 }
 
 {
-  context: 'xmpp',
+  "@context": [
+    "https://www.w3.org/ns/activitystreams",
+    "https://sockethub.org/ns/context/v1.jsonld",
+    "https://sockethub.org/ns/context/platform/xmpp/v1.jsonld"
+  ],
   type: 'send',
   actor: {
     id: 'slvrbckt@jabber.net/Home',
@@ -306,7 +330,11 @@ Valid presence values are "away", "chat", "dnd", "xa", "offline", "online".
 **Example**  
 ```js
 {
-  context: 'xmpp',
+  "@context": [
+    "https://www.w3.org/ns/activitystreams",
+    "https://sockethub.org/ns/context/v1.jsonld",
+    "https://sockethub.org/ns/context/platform/xmpp/v1.jsonld"
+  ],
   type: 'update',
   actor: {
     id: 'user@host.org/Home'
@@ -343,7 +371,11 @@ Send friend request
 **Example**  
 ```js
 {
-  context: 'xmpp',
+  "@context": [
+    "https://www.w3.org/ns/activitystreams",
+    "https://sockethub.org/ns/context/v1.jsonld",
+    "https://sockethub.org/ns/context/platform/xmpp/v1.jsonld"
+  ],
   type: 'request-friend',
   actor: {
     id: 'user@host.org/Home'
@@ -378,7 +410,11 @@ Send a remove friend request
 **Example**  
 ```js
 {
-  context: 'xmpp',
+  "@context": [
+    "https://www.w3.org/ns/activitystreams",
+    "https://sockethub.org/ns/context/v1.jsonld",
+    "https://sockethub.org/ns/context/platform/xmpp/v1.jsonld"
+  ],
   type: 'remove-friend',
   actor: {
     id: 'user@host.org/Home'
@@ -413,7 +449,11 @@ Confirm a friend request
 **Example**  
 ```js
 {
-  context: 'xmpp',
+  "@context": [
+    "https://www.w3.org/ns/activitystreams",
+    "https://sockethub.org/ns/context/v1.jsonld",
+    "https://sockethub.org/ns/context/platform/xmpp/v1.jsonld"
+  ],
   type: 'make-friend',
   actor: {
     id: 'user@host.org/Home'
@@ -448,7 +488,11 @@ Indicate an intent to query something (i.e. get a list of users in a room).
 **Example**  
 ```js
 {
-   context: 'xmpp',
+   "@context": [
+    "https://www.w3.org/ns/activitystreams",
+    "https://sockethub.org/ns/context/v1.jsonld",
+    "https://sockethub.org/ns/context/platform/xmpp/v1.jsonld"
+  ],
    type: 'query',
    actor: {
      id: 'slvrbckt@jabber.net/Home',
@@ -465,7 +509,11 @@ Indicate an intent to query something (i.e. get a list of users in a room).
 
  // The above object might return:
  {
-   context: 'xmpp',
+   "@context": [
+    "https://www.w3.org/ns/activitystreams",
+    "https://sockethub.org/ns/context/v1.jsonld",
+    "https://sockethub.org/ns/context/platform/xmpp/v1.jsonld"
+  ],
    type: 'query',
    actor: {
      id: 'PartyChatRoom@muc.jabber.net',
@@ -511,7 +559,11 @@ Disconnect XMPP client
 **Example**  
 ```js
 {
-   context: 'xmpp',
+   "@context": [
+    "https://www.w3.org/ns/activitystreams",
+    "https://sockethub.org/ns/context/v1.jsonld",
+    "https://sockethub.org/ns/context/platform/xmpp/v1.jsonld"
+  ],
    type: 'disconnect',
    actor: {
      id: 'slvrbckt@jabber.net/Home',

--- a/packages/platform-xmpp/README.md
+++ b/packages/platform-xmpp/README.md
@@ -8,7 +8,7 @@ This platform provides XMPP client functionality, allowing web applications to c
 XMPP servers, send messages, manage contacts, join chat rooms, and handle presence
 updates through ActivityStreams messages.
 
-## Implemented Verbs (`@type`)
+## Implemented Verbs (`type`)
 
 * **send** - Send messages to contacts or chat rooms
 * **join** - Join XMPP chat rooms (MUCs)
@@ -24,20 +24,20 @@ updates through ActivityStreams messages.
 
 ```json
 {
-  "@type": "send",
+  "type": "send",
   "@context": [
     "https://www.w3.org/ns/activitystreams",
     "https://sockethub.org/ns/context/v1.jsonld",
     "https://sockethub.org/ns/context/platform/xmpp/v1.jsonld"
   ],
   "actor": {
-    "@id": "user@example.org"
+    "id": "user@example.org"
   },
   "target": {
-    "@id": "friend@jabber.net"
+    "id": "friend@jabber.net"
   },
   "object": {
-    "@type": "Note",
+    "type": "Note",
     "content": "Hello from Sockethub!"
   }
 }
@@ -47,17 +47,17 @@ updates through ActivityStreams messages.
 
 ```json
 {
-  "@type": "join",
+  "type": "join",
   "@context": [
     "https://www.w3.org/ns/activitystreams",
     "https://sockethub.org/ns/context/v1.jsonld",
     "https://sockethub.org/ns/context/platform/xmpp/v1.jsonld"
   ],
   "actor": {
-    "@id": "user@example.org"
+    "id": "user@example.org"
   },
   "target": {
-    "@id": "room@conference.example.org"
+    "id": "room@conference.example.org"
   }
 }
 ```
@@ -66,17 +66,17 @@ updates through ActivityStreams messages.
 
 ```json
 {
-  "@type": "request-friend",
+  "type": "request-friend",
   "@context": [
     "https://www.w3.org/ns/activitystreams",
     "https://sockethub.org/ns/context/v1.jsonld",
     "https://sockethub.org/ns/context/platform/xmpp/v1.jsonld"
   ],
   "actor": {
-    "@id": "user@example.org"
+    "id": "user@example.org"
   },
   "target": {
-    "@id": "friend@jabber.net"
+    "id": "friend@jabber.net"
   }
 }
 ```

--- a/packages/platform-xmpp/README.md
+++ b/packages/platform-xmpp/README.md
@@ -25,7 +25,11 @@ updates through ActivityStreams messages.
 ```json
 {
   "@type": "send",
-  "context": "xmpp",
+  "@context": [
+    "https://www.w3.org/ns/activitystreams",
+    "https://sockethub.org/ns/context/v1.jsonld",
+    "https://sockethub.org/ns/context/platform/xmpp/v1.jsonld"
+  ],
   "actor": {
     "@id": "user@example.org"
   },
@@ -44,7 +48,11 @@ updates through ActivityStreams messages.
 ```json
 {
   "@type": "join",
-  "context": "xmpp",
+  "@context": [
+    "https://www.w3.org/ns/activitystreams",
+    "https://sockethub.org/ns/context/v1.jsonld",
+    "https://sockethub.org/ns/context/platform/xmpp/v1.jsonld"
+  ],
   "actor": {
     "@id": "user@example.org"
   },
@@ -59,7 +67,11 @@ updates through ActivityStreams messages.
 ```json
 {
   "@type": "request-friend",
-  "context": "xmpp",
+  "@context": [
+    "https://www.w3.org/ns/activitystreams",
+    "https://sockethub.org/ns/context/v1.jsonld",
+    "https://sockethub.org/ns/context/platform/xmpp/v1.jsonld"
+  ],
   "actor": {
     "@id": "user@example.org"
   },

--- a/packages/platform-xmpp/README.md
+++ b/packages/platform-xmpp/README.md
@@ -31,13 +31,15 @@ updates through ActivityStreams messages.
     "https://sockethub.org/ns/context/platform/xmpp/v1.jsonld"
   ],
   "actor": {
-    "id": "user@example.org"
+    "id": "user@example.org",
+    "type": "person"
   },
   "target": {
-    "id": "friend@jabber.net"
+    "id": "friend@jabber.net",
+    "type": "person"
   },
   "object": {
-    "type": "Note",
+    "type": "message",
     "content": "Hello from Sockethub!"
   }
 }
@@ -54,10 +56,12 @@ updates through ActivityStreams messages.
     "https://sockethub.org/ns/context/platform/xmpp/v1.jsonld"
   ],
   "actor": {
-    "id": "user@example.org"
+    "id": "user@example.org",
+    "type": "person"
   },
   "target": {
-    "id": "room@conference.example.org"
+    "id": "room@conference.example.org",
+    "type": "room"
   }
 }
 ```
@@ -73,10 +77,12 @@ updates through ActivityStreams messages.
     "https://sockethub.org/ns/context/platform/xmpp/v1.jsonld"
   ],
   "actor": {
-    "id": "user@example.org"
+    "id": "user@example.org",
+    "type": "person"
   },
   "target": {
-    "id": "friend@jabber.net"
+    "id": "friend@jabber.net",
+    "type": "person"
   }
 }
 ```


### PR DESCRIPTION
## Summary

- Update client guide with `contextFor()`, `ready()`, init events, and outbound queueing examples
- Update client README with new API reference and usage examples
- Update activity-streams README with `@context` array examples and legacy alias note
- Update irc2as README with `contexts` array initialization

This is the final step of the PR #1038 decomposition (canonical @context routing). All code changes have been merged in previous PRs (#1039-#1048). This PR updates the documentation to reflect the new API patterns.

## Test plan

- [x] Lint passes (biome + markdownlint)
- [x] All 388 tests pass
- [x] No code changes, only documentation