### PR TITLE
fix: correct xmpp token auth compatibility and secret handling

### DIFF
--- a/docs/client-guide.md
+++ b/docs/client-guide.md
@@ -219,8 +219,8 @@ sc.socket.emit('message', {
 ```
 
 The XMPP platform accepts either a password or a pre-issued auth token. Supply
-exactly one — the token is sent via SASL PLAIN and is compatible with
-ejabberd's `mod_auth_token`, Prosody's `mod_tokenauth`, and similar modules.
+exactly one. Token mode reuses the SASL PLAIN password slot, so it is only
+compatible with deployments that explicitly accept bearer-style tokens there.
 See [packages/platform-xmpp/README.md](../packages/platform-xmpp/README.md#authentication)
 for the full credential reference.
 
@@ -233,7 +233,7 @@ sc.socket.emit('credentials', {
     object: {
         type: 'credentials',
         userAddress: 'user@jabber.net',
-        token: 'ejabberd-issued-auth-token',
+        token: 'pre-issued-auth-token',
         resource: 'phone'
     }
 });

--- a/packages/data-layer/src/credentials-store.test.ts
+++ b/packages/data-layer/src/credentials-store.test.ts
@@ -172,23 +172,20 @@ describe("CredentialsStore", () => {
             });
         });
 
-        it("rejects anonymous credentials for session-share validation", async () => {
+        it("allows token credentials for session-share validation", async () => {
             MockStoreGet.returns({
                 object: { type: "credentials", token: "a credential" },
             });
-            try {
-                await credentialsStore.get("an actor", undefined, {
-                    validateSessionShare: true,
-                });
-                expect(false).toEqual(true);
-            } catch (err) {
-                expect(err.toString()).toEqual("Error: username already in use");
-                expect(err).toBeInstanceOf(CredentialsNotShareableError);
-            }
+            const res = await credentialsStore.get("an actor", undefined, {
+                validateSessionShare: true,
+            });
             sinon.assert.calledOnce(MockStoreGet);
             sinon.assert.calledWith(MockStoreGet, "an actor");
             sinon.assert.notCalled(MockObjectHash);
             sinon.assert.notCalled(MockStoreSave);
+            expect(res).toEqual({
+                object: { type: "credentials", token: "a credential" },
+            });
         });
 
         it("allows password credentials for session-share validation", async () => {
@@ -205,6 +202,25 @@ describe("CredentialsStore", () => {
             expect(res).toEqual({
                 object: { type: "credentials", password: "a credential" },
             });
+        });
+
+        it("rejects credentials without password or token for session-share validation", async () => {
+            MockStoreGet.returns({
+                object: { type: "credentials" },
+            });
+            try {
+                await credentialsStore.get("an actor", undefined, {
+                    validateSessionShare: true,
+                });
+                expect(false).toEqual(true);
+            } catch (err) {
+                expect(err.toString()).toEqual("Error: username already in use");
+                expect(err).toBeInstanceOf(CredentialsNotShareableError);
+            }
+            sinon.assert.calledOnce(MockStoreGet);
+            sinon.assert.calledWith(MockStoreGet, "an actor");
+            sinon.assert.notCalled(MockObjectHash);
+            sinon.assert.notCalled(MockStoreSave);
         });
 
         it("rejects array credentials objects", async () => {

--- a/packages/data-layer/src/credentials-store.ts
+++ b/packages/data-layer/src/credentials-store.ts
@@ -218,12 +218,14 @@ export class CredentialsStore implements CredentialsStoreInterface {
 
         if (options.validateSessionShare) {
             const password = credentials.object.password;
+            const token = credentials.object.token;
             const hasPassword =
                 typeof password === "string" && password.length > 0;
+            const hasToken = typeof token === "string" && token.length > 0;
 
-            // Anonymous credentials are valid for a single session but must not
-            // be used to attach additional sessions to the same actor instance.
-            if (!hasPassword) {
+            // Credentials must include a non-empty secret before an additional
+            // session can attach to the same persistent actor instance.
+            if (!hasPassword && !hasToken) {
                 throw new CredentialsNotShareableError(
                     "username already in use",
                 );

--- a/packages/examples/src/components/Credentials.svelte
+++ b/packages/examples/src/components/Credentials.svelte
@@ -21,7 +21,6 @@ function sendCredentials(data: string) {
         actor: actor.id,
         object: JSON.parse(data),
     };
-    console.log("sending credentials: ", creds);
     sc.socket.emit("credentials", creds, (resp: SockethubResponse) => {
         if (resp?.error) {
             throw new Error(resp.error);

--- a/packages/examples/src/components/TextAreaSubmit.svelte
+++ b/packages/examples/src/components/TextAreaSubmit.svelte
@@ -19,19 +19,29 @@ let {
     submitData,
 }: Props = $props();
 
-let password = $state("unset");
+const secretFieldOrder = ["password", "token"] as const;
+type SecretField = (typeof secretFieldOrder)[number];
 
-if (obj.password) {
-    password = obj.password;
-    obj.password = undefined;
+let secretField = $state<SecretField | null>(null);
+let secretValue = $state("");
+
+for (const field of secretFieldOrder) {
+    const candidate = obj[field];
+    if (typeof candidate === "string" && candidate.length > 0) {
+        secretField = field;
+        secretValue = candidate;
+        obj[field] = undefined;
+        break;
+    }
 }
+
+const secretLabel = $derived(secretField === "token" ? "Token" : "Password");
 
 const objString = $derived(JSON.stringify(obj, null, 3));
 
 async function handleSubmit(): Promise<void> {
-    console.log("PASSWORD: ", password);
-    if (password !== "unset") {
-        obj.password = password;
+    if (secretField) {
+        obj[secretField] = secretValue;
     }
 
     submitData(JSON.stringify(obj));
@@ -42,10 +52,10 @@ async function handleSubmit(): Promise<void> {
     <label for="json-object-{title}" class="form-label inline-block text-gray-900 font-bold mb-2">{title}</label>
     <TextBox title={title} data={objString}></TextBox>
 </div>
-{#if password !== "unset"}
+{#if secretField}
     <div class="w-full p-2">
-        <label for="server" class="inline-block text-gray-900 font-bold w-32">Password</label>
-        <input id="server" bind:value={password} type="password" class="border-4" />
+        <label for="server" class="inline-block text-gray-900 font-bold w-32">{secretLabel}</label>
+        <input id="server" bind:value={secretValue} type="password" class="border-4" />
     </div>
 {/if}
 <div class="w-full text-right">

--- a/packages/examples/src/lib/types.ts
+++ b/packages/examples/src/lib/types.ts
@@ -2,6 +2,7 @@ import type { Writable } from "svelte/store";
 
 export type TextAreaObject = {
     password?: string;
+    token?: string;
     id?: string;
     type?: string;
     name?: string;

--- a/packages/examples/src/routes/xmpp/+page.svelte
+++ b/packages/examples/src/routes/xmpp/+page.svelte
@@ -18,7 +18,7 @@ const actorIdStore = writable("user@jabber.org");
 let connecting = $state(false);
 let authMode = $state<"password" | "token">("password");
 let passwordValue = $state("123456");
-let tokenValue = $state("ejabberd-issued-auth-token");
+let tokenValue = $state("pre-issued-auth-token");
 
 let actorId = $derived(`${$actorIdStore}/SockethubExample`);
 
@@ -133,11 +133,11 @@ async function connectXmpp(): Promise<void> {
                     bind:value={tokenValue}
                     disabled={$sockethubState.credentialsSet}
                     class="w-full border border-gray-300 rounded-md px-3 py-2 text-sm font-mono mb-3"
-                    placeholder="ejabberd-issued-auth-token"
+                    placeholder="pre-issued-auth-token"
                 />
                 <p class="text-gray-600 text-xs mb-3">
-                    💡 Tokens are sent via SASL PLAIN in the password slot. Supported by ejabberd
-                    (<code>mod_auth_token</code>), Prosody (<code>mod_tokenauth</code>), and similar modules.
+                    💡 This client sends the token through the SASL PLAIN password slot. Use it
+                    only with deployments that explicitly accept bearer-style tokens in that slot.
                 </p>
             {:else}
                 <label class="block text-sm font-medium text-gray-700 mb-1" for="xmpp-password-input">

--- a/packages/platform-xmpp/API.md
+++ b/packages/platform-xmpp/API.md
@@ -118,10 +118,12 @@ Valid AS object for setting XMPP credentials:
   }
 }
 
-Alternatively, a `token` may be supplied in place of `password`. The token
-is sent via SASL PLAIN in the password slot; servers such as ejabberd
-(`mod_auth_token`) and Prosody (`mod_tokenauth`) accept this for
-token-based authentication. Exactly one of `password` or `token` must be
+Alternatively, a `token` may be supplied in place of `password`. Sockethub
+copies the token into the SASL PLAIN password slot, which only works for
+deployments that explicitly accept a bearer-style token there. Dedicated
+token SASL mechanisms such as ejabberd `X-OAUTH2`, Prosody
+`OAUTHBEARER`, Prosody community `X-TOKEN`, and SASL2 FAST are not
+implemented by this client. Exactly one of `password` or `token` must be
 provided.
 ```
 **Example**  
@@ -136,7 +138,7 @@ provided.
   object: {
     type: 'credentials',
     userAddress: 'testuser@jabber.net',
-    token: 'ejabberd-issued-auth-token',
+    token: 'pre-issued-auth-token',
     resource: 'phone'
   }
 }

--- a/packages/platform-xmpp/README.md
+++ b/packages/platform-xmpp/README.md
@@ -37,7 +37,7 @@ validation.
 | `userAddress` | string | yes | Bare JID, e.g. `user@jabber.net`. |
 | `resource` | string | yes | XMPP resource identifier (e.g. `"phone"`). |
 | `password` | string | one of password/token | SASL password. |
-| `token` | string | one of password/token | Auth token sent in the SASL PLAIN slot. |
+| `token` | string | one of password/token | Token copied into the SASL PLAIN password slot. |
 | `server` | string | no | Overrides the hostname from `userAddress`. |
 | `port` | number | no | Overrides the default port. |
 
@@ -67,14 +67,9 @@ available SASL mechanism (typically SCRAM-SHA-1, falling back to PLAIN).
 ### Token authentication
 
 Supply a pre-issued authentication token in place of the password. Sockethub
-places the token in the SASL PLAIN password slot, so this mode works with any
-XMPP server whose token module accepts a token where a password would normally
-go. Examples include:
-
-* **ejabberd** — `mod_auth_token` (tokens issued via `ejabberdctl
-  oauth_issue_token` or the admin API).
-* **Prosody** — `mod_tokenauth` (and compatible community modules).
-* Any custom deployment that treats the SASL PLAIN password as a bearer token.
+places the token in the SASL PLAIN password slot. This is a narrow
+compatibility mode for deployments that explicitly accept a bearer-style token
+where a password would normally go.
 
 ```json
 {
@@ -88,17 +83,19 @@ go. Examples include:
   "object": {
     "type": "credentials",
     "userAddress": "user@jabber.net",
-    "token": "ejabberd-issued-auth-token",
+    "token": "pre-issued-auth-token",
     "resource": "phone"
   }
 }
 ```
 
-**Compatibility note**: because the token travels in the SASL PLAIN slot, the
-server must advertise the PLAIN mechanism for the session. Token-auth modules
-typically do this automatically. If a server advertises only SCRAM-SHA-1, the
-token cannot survive SCRAM's HMAC exchange and authentication will fail — this
-is a limitation of the "token-in-password-slot" approach, not of Sockethub.
+**Compatibility note**: this does not implement dedicated token SASL
+mechanisms such as ejabberd `X-OAUTH2`, Prosody `OAUTHBEARER`, Prosody
+community `X-TOKEN`, or SASL2 FAST token flows. The bundled `@xmpp/client`
+version only implements `SCRAM-SHA-1`, `PLAIN`, and `ANONYMOUS`, and prefers
+`SCRAM-SHA-1` when both SCRAM and PLAIN are offered. In practice, token auth
+through Sockethub only works when the server both advertises `PLAIN` and is
+configured to treat the PLAIN password value as the token.
 
 A failed token authentication (expired, revoked, or unrecognised token)
 surfaces the same `SASLError: not-authorized` as a bad password, and is

--- a/packages/platform-xmpp/src/index.js
+++ b/packages/platform-xmpp/src/index.js
@@ -179,10 +179,12 @@ export default class XMPP {
      *   }
      * }
      *
-     * Alternatively, a `token` may be supplied in place of `password`. The token
-     * is sent via SASL PLAIN in the password slot; servers such as ejabberd
-     * (`mod_auth_token`) and Prosody (`mod_tokenauth`) accept this for
-     * token-based authentication. Exactly one of `password` or `token` must be
+     * Alternatively, a `token` may be supplied in place of `password`. Sockethub
+     * copies the token into the SASL PLAIN password slot, which only works for
+     * deployments that explicitly accept a bearer-style token there. Dedicated
+     * token SASL mechanisms such as ejabberd `X-OAUTH2`, Prosody
+     * `OAUTHBEARER`, Prosody community `X-TOKEN`, and SASL2 FAST are not
+     * implemented by this client. Exactly one of `password` or `token` must be
      * provided.
      *
      * @example
@@ -197,7 +199,7 @@ export default class XMPP {
      *   object: {
      *     type: 'credentials',
      *     userAddress: 'testuser@jabber.net',
-     *     token: 'ejabberd-issued-auth-token',
+     *     token: 'pre-issued-auth-token',
      *     resource: 'phone'
      *   }
      * }

--- a/packages/server/README.md
+++ b/packages/server/README.md
@@ -28,7 +28,8 @@ platform instance when they target the same actor.
 Session sharing rules:
 
 - Credentials are validated in the data layer during share attempts.
-- Share is allowed only when credentials include a non-empty `password`.
+- Share is allowed only when credentials include a non-empty secret such as
+  `password` or `token`.
 - Username-only/anonymous credentials are rejected with `username already in use`.
 
 Reconnect exception for anonymous credentials:


### PR DESCRIPTION
## Summary

- allow persistent session sharing when XMPP credentials use a non-empty `token`, while still rejecting secret-less credentials
- redact XMPP tokens in the examples UI and stop logging raw credential payloads from the credentials submit path
- narrow the XMPP token-auth documentation to the flow the current client actually implements, and remove unsupported ejabberd/Prosody compatibility claims

## Details

This follow-up fixes the issues found in review of #1058:

- `CredentialsStore.get(..., { validateSessionShare: true })` now accepts either a non-empty `password` or `token`
- the examples textarea helper now treats `token` as a secret field the same way it treats `password`
- the examples XMPP page and platform docs now describe token mode as a narrow SASL `PLAIN` password-slot compatibility path instead of claiming support for ejabberd `mod_auth_token` / Prosody `mod_tokenauth`
- the generated XMPP API docs were refreshed after updating the JSDoc source comments

## Test plan

- [x] `bun test packages/data-layer/src/credentials-store.test.ts packages/platform-xmpp/src/index.test.js packages/platform-xmpp/src/schema.test.js packages/platform-xmpp/src/utils.test.js`
- [x] `bun run doc`
- [x] `bun run lint`
