### PR TITLE
fix(platform-xmpp): correct xmpp token auth compatibility and secret handling

### DIFF
--- a/docs/client-guide.md
+++ b/docs/client-guide.md
@@ -218,14 +218,15 @@ sc.socket.emit('message', {
 });
 ```
 
-The XMPP platform accepts either a password or a pre-issued auth token. Supply
-exactly one. Token mode reuses the SASL PLAIN password slot, so it is only
-compatible with deployments that explicitly accept bearer-style tokens there.
+The XMPP platform accepts a single `password` field. If your deployment expects
+a pre-issued auth token in the SASL PLAIN password slot, pass that token
+string as `password`. This is only compatible with deployments that explicitly
+accept bearer-style tokens there.
 See [packages/platform-xmpp/README.md](../packages/platform-xmpp/README.md#authentication)
 for the full credential reference.
 
 ```javascript
-// XMPP with a token instead of a password
+// XMPP using a bearer-style token string in the password slot
 sc.socket.emit('credentials', {
     '@context': sc.contextFor('xmpp'),
     type: 'credentials',
@@ -233,7 +234,7 @@ sc.socket.emit('credentials', {
     object: {
         type: 'credentials',
         userAddress: 'user@jabber.net',
-        token: 'pre-issued-auth-token',
+        password: 'pre-issued-auth-token',
         resource: 'phone'
     }
 });

--- a/docs/client-guide.md
+++ b/docs/client-guide.md
@@ -219,8 +219,8 @@ sc.socket.emit('message', {
 ```
 
 The XMPP platform accepts either a password or a pre-issued auth token. Supply
-exactly one — the token is sent via SASL PLAIN and is compatible with
-ejabberd's `mod_auth_token`, Prosody's `mod_tokenauth`, and similar modules.
+exactly one. Token mode reuses the SASL PLAIN password slot, so it is only
+compatible with deployments that explicitly accept bearer-style tokens there.
 See [packages/platform-xmpp/README.md](../packages/platform-xmpp/README.md#authentication)
 for the full credential reference.
 
@@ -233,7 +233,7 @@ sc.socket.emit('credentials', {
     object: {
         type: 'credentials',
         userAddress: 'user@jabber.net',
-        token: 'ejabberd-issued-auth-token',
+        token: 'pre-issued-auth-token',
         resource: 'phone'
     }
 });

--- a/integration/browser/multiclient.integration.js
+++ b/integration/browser/multiclient.integration.js
@@ -35,6 +35,54 @@ async function ensureSocketsConnected(records) {
     );
 }
 
+async function waitForStableRoomDelivery(records, messageLog) {
+    const sender = records[records.length - 1];
+    const maxAttempts = 3;
+
+    for (let attempt = 1; attempt <= maxAttempts; attempt++) {
+        const syncMessage = `Room sync ${attempt} at ${Date.now()}`;
+        messageLog.length = 0;
+
+        await sendXMPPMessage(
+            sender.sockethubClient,
+            sender.jid,
+            config.prosody.room,
+            syncMessage,
+        );
+
+        try {
+            await waitFor(
+                () =>
+                    messageLog.filter(
+                        (log) =>
+                            log.message?.object?.content === syncMessage &&
+                            log.message?.type === "send" &&
+                            log.clientId !== sender.jid,
+                    ).length >=
+                    CLIENT_COUNT - 1,
+                Math.min(config.timeouts.multiClientMessage, 4000),
+                50,
+                () => {
+                    const received = messageLog.filter(
+                        (log) =>
+                            log.message?.object?.content === syncMessage &&
+                            log.message?.type === "send" &&
+                            log.clientId !== sender.jid,
+                    ).length;
+                    return `sync attempt ${attempt}: ${received}/${CLIENT_COUNT - 1}`;
+                },
+            );
+            messageLog.length = 0;
+            return;
+        } catch (error) {
+            if (attempt === maxAttempts) {
+                throw error;
+            }
+            await new Promise((resolve) => setTimeout(resolve, 500 * attempt));
+        }
+    }
+}
+
 describe(`Multi-Client XMPP Integration Tests at ${config.sockethub.url}`, () => {
     validateGlobals();
 
@@ -140,9 +188,9 @@ describe(`Multi-Client XMPP Integration Tests at ${config.sockethub.url}`, () =>
             // Verify all clients joined successfully
             expect(results).to.have.length(CLIENT_COUNT);
 
-            // Wait for XMPP presence to propagate after all joins
-            // This ensures all clients know about each other before message tests
-            await new Promise((resolve) => setTimeout(resolve, 1000));
+            // Joining a MUC is only half the story; CI is still flaky if the
+            // first test message races ahead of room presence propagation.
+            await waitForStableRoomDelivery(records, messageLog);
         });
     });
 

--- a/packages/data-layer/src/credentials-store.test.ts
+++ b/packages/data-layer/src/credentials-store.test.ts
@@ -172,23 +172,20 @@ describe("CredentialsStore", () => {
             });
         });
 
-        it("rejects anonymous credentials for session-share validation", async () => {
+        it("allows token credentials for session-share validation", async () => {
             MockStoreGet.returns({
                 object: { type: "credentials", token: "a credential" },
             });
-            try {
-                await credentialsStore.get("an actor", undefined, {
-                    validateSessionShare: true,
-                });
-                expect(false).toEqual(true);
-            } catch (err) {
-                expect(err.toString()).toEqual("Error: username already in use");
-                expect(err).toBeInstanceOf(CredentialsNotShareableError);
-            }
+            const res = await credentialsStore.get("an actor", undefined, {
+                validateSessionShare: true,
+            });
             sinon.assert.calledOnce(MockStoreGet);
             sinon.assert.calledWith(MockStoreGet, "an actor");
             sinon.assert.notCalled(MockObjectHash);
             sinon.assert.notCalled(MockStoreSave);
+            expect(res).toEqual({
+                object: { type: "credentials", token: "a credential" },
+            });
         });
 
         it("allows password credentials for session-share validation", async () => {
@@ -205,6 +202,25 @@ describe("CredentialsStore", () => {
             expect(res).toEqual({
                 object: { type: "credentials", password: "a credential" },
             });
+        });
+
+        it("rejects credentials without password or token for session-share validation", async () => {
+            MockStoreGet.returns({
+                object: { type: "credentials" },
+            });
+            try {
+                await credentialsStore.get("an actor", undefined, {
+                    validateSessionShare: true,
+                });
+                expect(false).toEqual(true);
+            } catch (err) {
+                expect(err.toString()).toEqual("Error: username already in use");
+                expect(err).toBeInstanceOf(CredentialsNotShareableError);
+            }
+            sinon.assert.calledOnce(MockStoreGet);
+            sinon.assert.calledWith(MockStoreGet, "an actor");
+            sinon.assert.notCalled(MockObjectHash);
+            sinon.assert.notCalled(MockStoreSave);
         });
 
         it("rejects array credentials objects", async () => {

--- a/packages/data-layer/src/credentials-store.ts
+++ b/packages/data-layer/src/credentials-store.ts
@@ -218,12 +218,14 @@ export class CredentialsStore implements CredentialsStoreInterface {
 
         if (options.validateSessionShare) {
             const password = credentials.object.password;
+            const token = credentials.object.token;
             const hasPassword =
                 typeof password === "string" && password.length > 0;
+            const hasToken = typeof token === "string" && token.length > 0;
 
-            // Anonymous credentials are valid for a single session but must not
-            // be used to attach additional sessions to the same actor instance.
-            if (!hasPassword) {
+            // Credentials must include a non-empty secret before an additional
+            // session can attach to the same persistent actor instance.
+            if (!hasPassword && !hasToken) {
                 throw new CredentialsNotShareableError(
                     "username already in use",
                 );

--- a/packages/examples/src/components/Credentials.svelte
+++ b/packages/examples/src/components/Credentials.svelte
@@ -21,7 +21,6 @@ function sendCredentials(data: string) {
         actor: actor.id,
         object: JSON.parse(data),
     };
-    console.log("sending credentials: ", creds);
     sc.socket.emit("credentials", creds, (resp: SockethubResponse) => {
         if (resp?.error) {
             throw new Error(resp.error);

--- a/packages/examples/src/components/TextAreaSubmit.svelte
+++ b/packages/examples/src/components/TextAreaSubmit.svelte
@@ -13,54 +13,27 @@ interface Props {
 
 let { buttonText = "Send", disabled, obj, title, submitData }: Props = $props();
 
-const secretFieldOrder = ["password", "token"] as const;
-type SecretField = (typeof secretFieldOrder)[number];
-
-let secretField = $state<SecretField | null>(null);
-let secretValue = $state("");
-
-function getSecretState(source: TextAreaObject): {
-    field: SecretField | null;
-    value: string;
-} {
-    for (const field of secretFieldOrder) {
-        const candidate = source[field];
-        if (typeof candidate === "string" && candidate.length > 0) {
-            return { field, value: candidate };
-        }
-    }
-
-    return { field: null, value: "" };
-}
+let password = $state("");
 
 let secretInputId = $derived(
     `secret-input-${title.toLowerCase().replace(/\s+/g, "-")}`,
 );
-const secretLabel = $derived(secretField === "token" ? "Token" : "Password");
 
 $effect(() => {
-    const nextSecret = getSecretState(obj);
-    secretField = nextSecret.field;
-    secretValue = nextSecret.value;
+    password = typeof obj.password === "string" ? obj.password : "";
 });
 
 const objString = $derived.by(() => {
     const redacted = { ...obj };
-
-    for (const field of secretFieldOrder) {
-        delete redacted[field];
-    }
-
+    delete redacted.password;
     return JSON.stringify(redacted, null, 3);
 });
 
 async function handleSubmit(): Promise<void> {
     const payload = { ...obj };
-
-    if (secretField) {
-        payload[secretField] = secretValue;
+    if (password.length > 0) {
+        payload.password = password;
     }
-
     submitData(JSON.stringify(payload));
 }
 </script>
@@ -69,10 +42,10 @@ async function handleSubmit(): Promise<void> {
     <label for="json-object-{title}" class="form-label inline-block text-gray-900 font-bold mb-2">{title}</label>
     <TextBox title={title} data={objString}></TextBox>
 </div>
-{#if secretField}
+{#if typeof obj.password === "string"}
     <div class="w-full p-2">
-        <label for={secretInputId} class="inline-block text-gray-900 font-bold w-32">{secretLabel}</label>
-        <input id={secretInputId} bind:value={secretValue} type="password" class="border-4" />
+        <label for={secretInputId} class="inline-block text-gray-900 font-bold w-32">Password</label>
+        <input id={secretInputId} bind:value={password} type="password" class="border-4" />
     </div>
 {/if}
 <div class="w-full text-right">

--- a/packages/examples/src/components/TextAreaSubmit.svelte
+++ b/packages/examples/src/components/TextAreaSubmit.svelte
@@ -11,13 +11,7 @@ interface Props {
     submitData: (text: string) => void;
 }
 
-let {
-    buttonText = "Send",
-    disabled,
-    obj = $bindable(),
-    title,
-    submitData,
-}: Props = $props();
+let { buttonText = "Send", disabled, obj, title, submitData }: Props = $props();
 
 const secretFieldOrder = ["password", "token"] as const;
 type SecretField = (typeof secretFieldOrder)[number];
@@ -25,26 +19,49 @@ type SecretField = (typeof secretFieldOrder)[number];
 let secretField = $state<SecretField | null>(null);
 let secretValue = $state("");
 
-for (const field of secretFieldOrder) {
-    const candidate = obj[field];
-    if (typeof candidate === "string" && candidate.length > 0) {
-        secretField = field;
-        secretValue = candidate;
-        obj[field] = undefined;
-        break;
+function getSecretState(source: TextAreaObject): {
+    field: SecretField | null;
+    value: string;
+} {
+    for (const field of secretFieldOrder) {
+        const candidate = source[field];
+        if (typeof candidate === "string" && candidate.length > 0) {
+            return { field, value: candidate };
+        }
     }
+
+    return { field: null, value: "" };
 }
 
+let secretInputId = $derived(
+    `secret-input-${title.toLowerCase().replace(/\s+/g, "-")}`,
+);
 const secretLabel = $derived(secretField === "token" ? "Token" : "Password");
 
-const objString = $derived(JSON.stringify(obj, null, 3));
+$effect(() => {
+    const nextSecret = getSecretState(obj);
+    secretField = nextSecret.field;
+    secretValue = nextSecret.value;
+});
 
-async function handleSubmit(): Promise<void> {
-    if (secretField) {
-        obj[secretField] = secretValue;
+const objString = $derived.by(() => {
+    const redacted = { ...obj };
+
+    for (const field of secretFieldOrder) {
+        delete redacted[field];
     }
 
-    submitData(JSON.stringify(obj));
+    return JSON.stringify(redacted, null, 3);
+});
+
+async function handleSubmit(): Promise<void> {
+    const payload = { ...obj };
+
+    if (secretField) {
+        payload[secretField] = secretValue;
+    }
+
+    submitData(JSON.stringify(payload));
 }
 </script>
 
@@ -54,8 +71,8 @@ async function handleSubmit(): Promise<void> {
 </div>
 {#if secretField}
     <div class="w-full p-2">
-        <label for="server" class="inline-block text-gray-900 font-bold w-32">{secretLabel}</label>
-        <input id="server" bind:value={secretValue} type="password" class="border-4" />
+        <label for={secretInputId} class="inline-block text-gray-900 font-bold w-32">{secretLabel}</label>
+        <input id={secretInputId} bind:value={secretValue} type="password" class="border-4" />
     </div>
 {/if}
 <div class="w-full text-right">

--- a/packages/examples/src/components/TextAreaSubmit.svelte
+++ b/packages/examples/src/components/TextAreaSubmit.svelte
@@ -19,19 +19,29 @@ let {
     submitData,
 }: Props = $props();
 
-let password = $state("unset");
+const secretFieldOrder = ["password", "token"] as const;
+type SecretField = (typeof secretFieldOrder)[number];
 
-if (obj.password) {
-    password = obj.password;
-    obj.password = undefined;
+let secretField = $state<SecretField | null>(null);
+let secretValue = $state("");
+
+for (const field of secretFieldOrder) {
+    const candidate = obj[field];
+    if (typeof candidate === "string" && candidate.length > 0) {
+        secretField = field;
+        secretValue = candidate;
+        obj[field] = undefined;
+        break;
+    }
 }
+
+const secretLabel = $derived(secretField === "token" ? "Token" : "Password");
 
 const objString = $derived(JSON.stringify(obj, null, 3));
 
 async function handleSubmit(): Promise<void> {
-    console.log("PASSWORD: ", password);
-    if (password !== "unset") {
-        obj.password = password;
+    if (secretField) {
+        obj[secretField] = secretValue;
     }
 
     submitData(JSON.stringify(obj));
@@ -42,10 +52,10 @@ async function handleSubmit(): Promise<void> {
     <label for="json-object-{title}" class="form-label inline-block text-gray-900 font-bold mb-2">{title}</label>
     <TextBox title={title} data={objString}></TextBox>
 </div>
-{#if password !== "unset"}
+{#if secretField}
     <div class="w-full p-2">
-        <label for="server" class="inline-block text-gray-900 font-bold w-32">Password</label>
-        <input id="server" bind:value={password} type="password" class="border-4" />
+        <label for="server" class="inline-block text-gray-900 font-bold w-32">{secretLabel}</label>
+        <input id="server" bind:value={secretValue} type="password" class="border-4" />
     </div>
 {/if}
 <div class="w-full text-right">

--- a/packages/examples/src/lib/sockethub.ts
+++ b/packages/examples/src/lib/sockethub.ts
@@ -83,9 +83,7 @@ type XmppCredentialsBase = {
     userAddress: string;
 };
 
-export type XmppCredentials =
-    | (XmppCredentialsBase & { password: string; token?: never })
-    | (XmppCredentialsBase & { token: string; password?: never });
+export type XmppCredentials = XmppCredentialsBase & { password: string };
 
 export type CredentialData = {
     isSet: boolean;

--- a/packages/examples/src/lib/types.ts
+++ b/packages/examples/src/lib/types.ts
@@ -2,7 +2,6 @@ import type { Writable } from "svelte/store";
 
 export type TextAreaObject = {
     password?: string;
-    token?: string;
     id?: string;
     type?: string;
     name?: string;

--- a/packages/examples/src/lib/types.ts
+++ b/packages/examples/src/lib/types.ts
@@ -2,6 +2,7 @@ import type { Writable } from "svelte/store";
 
 export type TextAreaObject = {
     password?: string;
+    token?: string;
     id?: string;
     type?: string;
     name?: string;

--- a/packages/examples/src/routes/xmpp/+page.svelte
+++ b/packages/examples/src/routes/xmpp/+page.svelte
@@ -18,7 +18,7 @@ const actorIdStore = writable("user@jabber.org");
 let connecting = $state(false);
 let authMode = $state<"password" | "token">("password");
 let passwordValue = $state("123456");
-let tokenValue = $state("ejabberd-issued-auth-token");
+let tokenValue = $state("pre-issued-auth-token");
 
 let actorId = $derived(`${$actorIdStore}/SockethubExample`);
 
@@ -133,11 +133,11 @@ async function connectXmpp(): Promise<void> {
                     bind:value={tokenValue}
                     disabled={$sockethubState.credentialsSet}
                     class="w-full border border-gray-300 rounded-md px-3 py-2 text-sm font-mono mb-3"
-                    placeholder="ejabberd-issued-auth-token"
+                    placeholder="pre-issued-auth-token"
                 />
                 <p class="text-gray-600 text-xs mb-3">
-                    💡 Tokens are sent via SASL PLAIN in the password slot. Supported by ejabberd
-                    (<code>mod_auth_token</code>), Prosody (<code>mod_tokenauth</code>), and similar modules.
+                    💡 This client sends the token through the SASL PLAIN password slot. Use it
+                    only with deployments that explicitly accept bearer-style tokens in that slot.
                 </p>
             {:else}
                 <label class="block text-sm font-medium text-gray-700 mb-1" for="xmpp-password-input">

--- a/packages/examples/src/routes/xmpp/+page.svelte
+++ b/packages/examples/src/routes/xmpp/+page.svelte
@@ -16,9 +16,7 @@ import { writable } from "svelte/store";
 
 const actorIdStore = writable("user@jabber.org");
 let connecting = $state(false);
-let authMode = $state<"password" | "token">("password");
 let passwordValue = $state("123456");
-let tokenValue = $state("pre-issued-auth-token");
 
 let actorId = $derived(`${$actorIdStore}/SockethubExample`);
 
@@ -41,7 +39,7 @@ let credentials = $derived({
     type: "credentials" as CredentialName,
     userAddress: $actorIdStore,
     resource: "SockethubExample",
-    password: authMode === "token" ? tokenValue : passwordValue,
+    password: passwordValue,
 });
 
 async function connectXmpp(): Promise<void> {
@@ -96,65 +94,25 @@ async function connectXmpp(): Promise<void> {
         <!-- Step 2: Credentials -->
         <div class="bg-white border border-gray-200 rounded-lg p-4">
             <h4 class="font-semibold text-gray-800 mb-3">Step 2: Set Your Credentials</h4>
-            <div class="mb-3">
-                <span class="text-sm text-gray-700 font-medium mr-3">Authentication method:</span>
-                <label class="inline-flex items-center mr-4 text-sm text-gray-700">
-                    <input
-                        type="radio"
-                        name="xmpp-auth-mode"
-                        value="password"
-                        bind:group={authMode}
-                        disabled={$sockethubState.credentialsSet}
-                        class="mr-2"
-                    />
-                    Password
-                </label>
-                <label class="inline-flex items-center text-sm text-gray-700">
-                    <input
-                        type="radio"
-                        name="xmpp-auth-mode"
-                        value="token"
-                        bind:group={authMode}
-                        disabled={$sockethubState.credentialsSet}
-                        class="mr-2"
-                    />
-                    Token
-                </label>
-            </div>
-            {#if authMode === "token"}
-                <label class="block text-sm font-medium text-gray-700 mb-1" for="xmpp-token-input">
-                    Auth token
-                </label>
-                <input
-                    id="xmpp-token-input"
-                    type="password"
-                    bind:value={tokenValue}
-                    disabled={$sockethubState.credentialsSet}
-                    class="w-full border border-gray-300 rounded-md px-3 py-2 text-sm font-mono mb-3"
-                    placeholder="pre-issued-auth-token"
-                />
-                <p class="text-gray-600 text-xs mb-3">
-                    💡 This example labels the secret as a token, but it still submits it as
-                    <code>password</code>. Use it only with deployments that explicitly accept
-                    bearer-style tokens in the SASL PLAIN password slot.
-                </p>
-            {:else}
-                <label class="block text-sm font-medium text-gray-700 mb-1" for="xmpp-password-input">
-                    Password
-                </label>
-                <input
-                    id="xmpp-password-input"
-                    type="password"
-                    bind:value={passwordValue}
-                    disabled={$sockethubState.credentialsSet}
-                    class="w-full border border-gray-300 rounded-md px-3 py-2 text-sm mb-3"
-                    placeholder="your XMPP account password"
-                />
-            {/if}
+            <label class="block text-sm font-medium text-gray-700 mb-1" for="xmpp-password-input">
+                Password
+            </label>
+            <input
+                id="xmpp-password-input"
+                type="password"
+                bind:value={passwordValue}
+                disabled={$sockethubState.credentialsSet}
+                class="w-full border border-gray-300 rounded-md px-3 py-2 text-sm mb-3"
+                placeholder="your XMPP password or compatible bearer token"
+            />
+            <p class="text-gray-600 text-xs mb-3">
+                💡 If your deployment accepts a bearer-style token in the SASL PLAIN password
+                slot, enter that token here. Sockethub's XMPP platform still submits it as
+                <code>password</code>.
+            </p>
             <Credentials context="xmpp" {credentials} {actor} {sockethubState} />
             <p class="text-gray-600 text-sm mt-2">
-                🔐 Sockethub's XMPP platform accepts a single <code>password</code> field. This
-                example can label that secret as either a password or a token.
+                🔐 Sockethub's XMPP platform accepts a single <code>password</code> field.
             </p>
         </div>
 

--- a/packages/examples/src/routes/xmpp/+page.svelte
+++ b/packages/examples/src/routes/xmpp/+page.svelte
@@ -129,7 +129,7 @@ async function connectXmpp(): Promise<void> {
                 </label>
                 <input
                     id="xmpp-token-input"
-                    type="text"
+                    type="password"
                     bind:value={tokenValue}
                     disabled={$sockethubState.credentialsSet}
                     class="w-full border border-gray-300 rounded-md px-3 py-2 text-sm font-mono mb-3"

--- a/packages/examples/src/routes/xmpp/+page.svelte
+++ b/packages/examples/src/routes/xmpp/+page.svelte
@@ -41,9 +41,7 @@ let credentials = $derived({
     type: "credentials" as CredentialName,
     userAddress: $actorIdStore,
     resource: "SockethubExample",
-    ...(authMode === "token"
-        ? { token: tokenValue }
-        : { password: passwordValue }),
+    password: authMode === "token" ? tokenValue : passwordValue,
 });
 
 async function connectXmpp(): Promise<void> {
@@ -77,7 +75,7 @@ async function connectXmpp(): Promise<void> {
         </p>
         <div class="text-indigo-700 text-sm space-y-1">
             <div><strong>1. 🎭 Set Actor:</strong> Your XMPP address (e.g., user@jabber.org)</div>
-            <div><strong>2. 🔐 Set Credentials:</strong> Your XMPP login with a password <em>or</em> auth token</div>
+            <div><strong>2. 🔐 Set Credentials:</strong> Your XMPP login secret, sent through the password field</div>
             <div><strong>3. 🔌 Connect:</strong> Establish connection to XMPP server</div>
             <div><strong>4. 🏠 Join Room:</strong> Enter a multi-user chat room</div>
             <div><strong>5. 💬 Send Messages:</strong> Chat with other users in real-time</div>
@@ -136,8 +134,9 @@ async function connectXmpp(): Promise<void> {
                     placeholder="pre-issued-auth-token"
                 />
                 <p class="text-gray-600 text-xs mb-3">
-                    💡 This client sends the token through the SASL PLAIN password slot. Use it
-                    only with deployments that explicitly accept bearer-style tokens in that slot.
+                    💡 This example labels the secret as a token, but it still submits it as
+                    <code>password</code>. Use it only with deployments that explicitly accept
+                    bearer-style tokens in the SASL PLAIN password slot.
                 </p>
             {:else}
                 <label class="block text-sm font-medium text-gray-700 mb-1" for="xmpp-password-input">
@@ -154,7 +153,8 @@ async function connectXmpp(): Promise<void> {
             {/if}
             <Credentials context="xmpp" {credentials} {actor} {sockethubState} />
             <p class="text-gray-600 text-sm mt-2">
-                🔐 Exactly one of <code>password</code> or <code>token</code> must be provided.
+                🔐 Sockethub's XMPP platform accepts a single <code>password</code> field. This
+                example can label that secret as either a password or a token.
             </p>
         </div>
 

--- a/packages/platform-xmpp/API.md
+++ b/packages/platform-xmpp/API.md
@@ -15,6 +15,11 @@ object.</p>
 <code>types</code> portion of the schema object (should be an array of type names).</p>
 <p><strong>NOTE</strong>: For more information on using the credentials object from a client,
 see <a href="https://github.com/sockethub/sockethub/wiki/Sockethub-Client">Sockethub Client</a></p>
+<p>Deployments that accept a bearer-style token in the SASL PLAIN password
+slot should still pass that token string as <code>password</code>. Dedicated token
+SASL mechanisms such as ejabberd <code>X-OAUTH2</code>, Prosody <code>OAUTHBEARER</code>,
+Prosody community <code>X-TOKEN</code>, and SASL2 FAST are not implemented by this
+client.</p>
 <p>Valid AS object for setting XMPP credentials:</p>
 </dd>
 </dl>
@@ -97,6 +102,12 @@ It will also check if the incoming AS object uses a type which exists in the
 **NOTE**: For more information on using the credentials object from a client,
 see [Sockethub Client](https://github.com/sockethub/sockethub/wiki/Sockethub-Client)
 
+Deployments that accept a bearer-style token in the SASL PLAIN password
+slot should still pass that token string as `password`. Dedicated token
+SASL mechanisms such as ejabberd `X-OAUTH2`, Prosody `OAUTHBEARER`,
+Prosody community `X-TOKEN`, and SASL2 FAST are not implemented by this
+client.
+
 Valid AS object for setting XMPP credentials:
 
 **Kind**: global variable  
@@ -117,12 +128,6 @@ Valid AS object for setting XMPP credentials:
     resource: 'phone'
   }
 }
-
-Deployments that accept a bearer-style token in the SASL PLAIN password
-slot should still pass that token string as `password`. Dedicated token
-SASL mechanisms such as ejabberd `X-OAUTH2`, Prosody `OAUTHBEARER`,
-Prosody community `X-TOKEN`, and SASL2 FAST are not implemented by this
-client.
 ```
 <a name="__markDisconnected"></a>
 

--- a/packages/platform-xmpp/API.md
+++ b/packages/platform-xmpp/API.md
@@ -118,10 +118,12 @@ Valid AS object for setting XMPP credentials:
   }
 }
 
-Alternatively, a `token` may be supplied in place of `password`. The token
-is sent via SASL PLAIN in the password slot; servers such as ejabberd
-(`mod_auth_token`) and Prosody (`mod_tokenauth`) accept this for
-token-based authentication. Exactly one of `password` or `token` must be
+Alternatively, a `token` may be supplied in place of `password`. Sockethub
+copies the token into the SASL PLAIN password slot, which only works for
+deployments that explicitly accept a bearer-style token there. Dedicated
+token SASL mechanisms such as ejabberd `X-OAUTH2`, Prosody
+`OAUTHBEARER`, Prosody community `X-TOKEN`, and SASL2 FAST are not
+implemented by this client. Exactly one of `password` or `token` must be
 provided.
 ```
 **Example**  
@@ -136,7 +138,7 @@ provided.
   object: {
     type: 'credentials',
     userAddress: 'testuser@jabber.net',
-    token: 'ejabberd-issued-auth-token',
+    token: 'pre-issued-auth-token',
     resource: 'phone'
   }
 }

--- a/packages/platform-xmpp/API.md
+++ b/packages/platform-xmpp/API.md
@@ -118,30 +118,11 @@ Valid AS object for setting XMPP credentials:
   }
 }
 
-Alternatively, a `token` may be supplied in place of `password`. Sockethub
-copies the token into the SASL PLAIN password slot, which only works for
-deployments that explicitly accept a bearer-style token there. Dedicated
-token SASL mechanisms such as ejabberd `X-OAUTH2`, Prosody
-`OAUTHBEARER`, Prosody community `X-TOKEN`, and SASL2 FAST are not
-implemented by this client. Exactly one of `password` or `token` must be
-provided.
-```
-**Example**  
-```js
-{
-  type: 'credentials',
-  context: 'xmpp',
-  actor: {
-    id: 'testuser@jabber.net',
-    type: 'person'
-  },
-  object: {
-    type: 'credentials',
-    userAddress: 'testuser@jabber.net',
-    token: 'pre-issued-auth-token',
-    resource: 'phone'
-  }
-}
+Deployments that accept a bearer-style token in the SASL PLAIN password
+slot should still pass that token string as `password`. Dedicated token
+SASL mechanisms such as ejabberd `X-OAUTH2`, Prosody `OAUTHBEARER`,
+Prosody community `X-TOKEN`, and SASL2 FAST are not implemented by this
+client.
 ```
 <a name="__markDisconnected"></a>
 

--- a/packages/platform-xmpp/README.md
+++ b/packages/platform-xmpp/README.md
@@ -24,10 +24,7 @@ updates through ActivityStreams messages.
 ## Authentication
 
 Credentials are sent to Sockethub via a `credentials` message before the
-`connect` verb. The XMPP platform supports two equally first-class
-authentication modes: **password** and **token**. Exactly one of `password` or
-`token` must be provided — supplying both, or neither, will fail schema
-validation.
+`connect` verb. The XMPP platform accepts a single `password` field.
 
 ### Credentials object
 
@@ -36,8 +33,7 @@ validation.
 | `type` | string | yes | Must be `"credentials"`. |
 | `userAddress` | string | yes | Bare JID, e.g. `user@jabber.net`. |
 | `resource` | string | yes | XMPP resource identifier (e.g. `"phone"`). |
-| `password` | string | one of password/token | SASL password. |
-| `token` | string | one of password/token | Token copied into the SASL PLAIN password slot. |
+| `password` | string | yes | SASL password. Use this field for PLAIN-slot tokens too. |
 | `server` | string | no | Overrides the hostname from `userAddress`. |
 | `port` | number | no | Overrides the default port. |
 
@@ -62,38 +58,17 @@ instance named `sc`.
 }
 ```
 
-### Token authentication
+If your deployment expects a bearer-style token in the SASL PLAIN password
+slot, pass that token string as `password`. This is only a narrow
+compatibility mode. Dedicated token SASL mechanisms such as ejabberd
+`X-OAUTH2`, Prosody `OAUTHBEARER`, Prosody community `X-TOKEN`, and SASL2 FAST
+are not implemented by the bundled `@xmpp/client`, which only supports
+`SCRAM-SHA-1`, `PLAIN`, and `ANONYMOUS` and prefers `SCRAM-SHA-1` when both
+SCRAM and PLAIN are offered.
 
-Supply a pre-issued authentication token in place of the password. Sockethub
-places the token in the SASL PLAIN password slot. This is a narrow
-compatibility mode for deployments that explicitly accept a bearer-style token
-where a password would normally go.
-
-```javascript
-{
-  type: "credentials",
-  "@context": sc.contextFor("xmpp"),
-  actor: { id: "user@jabber.net", type: "person" },
-  object: {
-    type: "credentials",
-    userAddress: "user@jabber.net",
-    token: "pre-issued-auth-token",
-    resource: "phone"
-  }
-}
-```
-
-**Compatibility note**: this does not implement dedicated token SASL
-mechanisms such as ejabberd `X-OAUTH2`, Prosody `OAUTHBEARER`, Prosody
-community `X-TOKEN`, or SASL2 FAST token flows. The bundled `@xmpp/client`
-version only implements `SCRAM-SHA-1`, `PLAIN`, and `ANONYMOUS`, and prefers
-`SCRAM-SHA-1` when both SCRAM and PLAIN are offered. In practice, token auth
-through Sockethub only works when the server both advertises `PLAIN` and is
-configured to treat the PLAIN password value as the token.
-
-A failed token authentication (expired, revoked, or unrecognised token)
-surfaces the same `SASLError: not-authorized` as a bad password, and is
-treated as a non-recoverable connection error.
+A failed authentication with either a traditional password or a token string
+surfaces the same `SASLError: not-authorized` and is treated as a
+non-recoverable connection error.
 
 ## Usage
 

--- a/packages/platform-xmpp/README.md
+++ b/packages/platform-xmpp/README.md
@@ -45,21 +45,19 @@ validation.
 
 Use a standard XMPP account password. The server negotiates the strongest
 available SASL mechanism (typically SCRAM-SHA-1, falling back to PLAIN).
+The examples below assume you already have an initialized Sockethub client
+instance named `sc`.
 
-```json
+```javascript
 {
-  "type": "credentials",
-  "@context": [
-    "https://www.w3.org/ns/activitystreams",
-    "https://sockethub.org/ns/context/v1.jsonld",
-    "https://sockethub.org/ns/context/platform/xmpp/v1.jsonld"
-  ],
-  "actor": { "id": "user@jabber.net", "type": "person" },
-  "object": {
-    "type": "credentials",
-    "userAddress": "user@jabber.net",
-    "password": "s3cret",
-    "resource": "phone"
+  type: "credentials",
+  "@context": sc.contextFor("xmpp"),
+  actor: { id: "user@jabber.net", type: "person" },
+  object: {
+    type: "credentials",
+    userAddress: "user@jabber.net",
+    password: "s3cret",
+    resource: "phone"
   }
 }
 ```
@@ -71,20 +69,16 @@ places the token in the SASL PLAIN password slot. This is a narrow
 compatibility mode for deployments that explicitly accept a bearer-style token
 where a password would normally go.
 
-```json
+```javascript
 {
-  "type": "credentials",
-  "@context": [
-    "https://www.w3.org/ns/activitystreams",
-    "https://sockethub.org/ns/context/v1.jsonld",
-    "https://sockethub.org/ns/context/platform/xmpp/v1.jsonld"
-  ],
-  "actor": { "id": "user@jabber.net", "type": "person" },
-  "object": {
-    "type": "credentials",
-    "userAddress": "user@jabber.net",
-    "token": "pre-issued-auth-token",
-    "resource": "phone"
+  type: "credentials",
+  "@context": sc.contextFor("xmpp"),
+  actor: { id: "user@jabber.net", type: "person" },
+  object: {
+    type: "credentials",
+    userAddress: "user@jabber.net",
+    token: "pre-issued-auth-token",
+    resource: "phone"
   }
 }
 ```
@@ -105,67 +99,55 @@ treated as a non-recoverable connection error.
 
 ### Send Message Example
 
-```json
+```javascript
 {
-  "type": "send",
-  "@context": [
-    "https://www.w3.org/ns/activitystreams",
-    "https://sockethub.org/ns/context/v1.jsonld",
-    "https://sockethub.org/ns/context/platform/xmpp/v1.jsonld"
-  ],
-  "actor": {
-    "id": "user@example.org",
-    "type": "person"
+  type: "send",
+  "@context": sc.contextFor("xmpp"),
+  actor: {
+    id: "user@example.org",
+    type: "person"
   },
-  "target": {
-    "id": "friend@jabber.net",
-    "type": "person"
+  target: {
+    id: "friend@jabber.net",
+    type: "person"
   },
-  "object": {
-    "type": "message",
-    "content": "Hello from Sockethub!"
+  object: {
+    type: "message",
+    content: "Hello from Sockethub!"
   }
 }
 ```
 
 ### Join Chat Room Example
 
-```json
+```javascript
 {
-  "type": "join",
-  "@context": [
-    "https://www.w3.org/ns/activitystreams",
-    "https://sockethub.org/ns/context/v1.jsonld",
-    "https://sockethub.org/ns/context/platform/xmpp/v1.jsonld"
-  ],
-  "actor": {
-    "id": "user@example.org",
-    "type": "person"
+  type: "join",
+  "@context": sc.contextFor("xmpp"),
+  actor: {
+    id: "user@example.org",
+    type: "person"
   },
-  "target": {
-    "id": "room@conference.example.org",
-    "type": "room"
+  target: {
+    id: "room@conference.example.org",
+    type: "room"
   }
 }
 ```
 
 ### Request Friend Example
 
-```json
+```javascript
 {
-  "type": "request-friend",
-  "@context": [
-    "https://www.w3.org/ns/activitystreams",
-    "https://sockethub.org/ns/context/v1.jsonld",
-    "https://sockethub.org/ns/context/platform/xmpp/v1.jsonld"
-  ],
-  "actor": {
-    "id": "user@example.org",
-    "type": "person"
+  type: "request-friend",
+  "@context": sc.contextFor("xmpp"),
+  actor: {
+    id: "user@example.org",
+    type: "person"
   },
-  "target": {
-    "id": "friend@jabber.net",
-    "type": "person"
+  target: {
+    id: "friend@jabber.net",
+    type: "person"
   }
 }
 ```

--- a/packages/platform-xmpp/README.md
+++ b/packages/platform-xmpp/README.md
@@ -37,7 +37,7 @@ validation.
 | `userAddress` | string | yes | Bare JID, e.g. `user@jabber.net`. |
 | `resource` | string | yes | XMPP resource identifier (e.g. `"phone"`). |
 | `password` | string | one of password/token | SASL password. |
-| `token` | string | one of password/token | Auth token sent in the SASL PLAIN slot. |
+| `token` | string | one of password/token | Token copied into the SASL PLAIN password slot. |
 | `server` | string | no | Overrides the hostname from `userAddress`. |
 | `port` | number | no | Overrides the default port. |
 
@@ -67,14 +67,9 @@ available SASL mechanism (typically SCRAM-SHA-1, falling back to PLAIN).
 ### Token authentication
 
 Supply a pre-issued authentication token in place of the password. Sockethub
-places the token in the SASL PLAIN password slot, so this mode works with any
-XMPP server whose token module accepts a token where a password would normally
-go. Examples include:
-
-* **ejabberd** — `mod_auth_token` (tokens issued via `ejabberdctl
-  oauth_issue_token` or the admin API).
-* **Prosody** — `mod_tokenauth` (and compatible community modules).
-* Any custom deployment that treats the SASL PLAIN password as a bearer token.
+places the token in the SASL PLAIN password slot. This is a narrow
+compatibility mode for deployments that explicitly accept a bearer-style token
+where a password would normally go.
 
 ```json
 {
@@ -88,17 +83,19 @@ go. Examples include:
   "object": {
     "type": "credentials",
     "userAddress": "user@jabber.net",
-    "token": "ejabberd-issued-auth-token",
+    "token": "pre-issued-auth-token",
     "resource": "phone"
   }
 }
 ```
 
-**Compatibility note**: because the token travels in the SASL PLAIN slot, the
-server must advertise the PLAIN mechanism for the session. Token-auth modules
-typically do this automatically. If a server advertises only SCRAM-SHA-1, the
-token cannot survive SCRAM's HMAC exchange and authentication will fail — this
-is a limitation of the "token-in-password-slot" approach, not of Sockethub.
+**Compatibility note**: this does not implement dedicated token SASL
+mechanisms such as ejabberd `X-OAUTH2`, Prosody `OAUTHBEARER`, Prosody
+community `X-TOKEN`, or SASL2 FAST token flows. The bundled `@xmpp/client`
+version only implements `SCRAM-SHA-1`, `PLAIN`, and `ANONYMOUS`, and prefers
+`SCRAM-SHA-1` when both SCRAM and PLAIN are offered. In practice, token auth
+through Sockethub only works when the server both advertises `PLAIN` and is
+configured to treat the PLAIN password value as the token.
 
 A failed token authentication (expired, revoked, or unrecognised token)
 surfaces the same `SASLError: not-authorized` as a bad password, and is

--- a/packages/platform-xmpp/src/index.js
+++ b/packages/platform-xmpp/src/index.js
@@ -159,6 +159,12 @@ export default class XMPP {
      * **NOTE**: For more information on using the credentials object from a client,
      * see [Sockethub Client](https://github.com/sockethub/sockethub/wiki/Sockethub-Client)
      *
+     * Deployments that accept a bearer-style token in the SASL PLAIN password
+     * slot should still pass that token string as `password`. Dedicated token
+     * SASL mechanisms such as ejabberd `X-OAUTH2`, Prosody `OAUTHBEARER`,
+     * Prosody community `X-TOKEN`, and SASL2 FAST are not implemented by this
+     * client.
+     *
      * Valid AS object for setting XMPP credentials:
      *
      * @example
@@ -178,12 +184,6 @@ export default class XMPP {
      *     resource: 'phone'
      *   }
      * }
-     *
-     * Deployments that accept a bearer-style token in the SASL PLAIN password
-     * slot should still pass that token string as `password`. Dedicated token
-     * SASL mechanisms such as ejabberd `X-OAUTH2`, Prosody `OAUTHBEARER`,
-     * Prosody community `X-TOKEN`, and SASL2 FAST are not implemented by this
-     * client.
      **/
     get schema() {
         return PlatformSchema;

--- a/packages/platform-xmpp/src/index.js
+++ b/packages/platform-xmpp/src/index.js
@@ -179,30 +179,11 @@ export default class XMPP {
      *   }
      * }
      *
-     * Alternatively, a `token` may be supplied in place of `password`. Sockethub
-     * copies the token into the SASL PLAIN password slot, which only works for
-     * deployments that explicitly accept a bearer-style token there. Dedicated
-     * token SASL mechanisms such as ejabberd `X-OAUTH2`, Prosody
-     * `OAUTHBEARER`, Prosody community `X-TOKEN`, and SASL2 FAST are not
-     * implemented by this client. Exactly one of `password` or `token` must be
-     * provided.
-     *
-     * @example
-     *
-     * {
-     *   type: 'credentials',
-     *   context: 'xmpp',
-     *   actor: {
-     *     id: 'testuser@jabber.net',
-     *     type: 'person'
-     *   },
-     *   object: {
-     *     type: 'credentials',
-     *     userAddress: 'testuser@jabber.net',
-     *     token: 'pre-issued-auth-token',
-     *     resource: 'phone'
-     *   }
-     * }
+     * Deployments that accept a bearer-style token in the SASL PLAIN password
+     * slot should still pass that token string as `password`. Dedicated token
+     * SASL mechanisms such as ejabberd `X-OAUTH2`, Prosody `OAUTHBEARER`,
+     * Prosody community `X-TOKEN`, and SASL2 FAST are not implemented by this
+     * client.
      **/
     get schema() {
         return PlatformSchema;

--- a/packages/platform-xmpp/src/index.js
+++ b/packages/platform-xmpp/src/index.js
@@ -179,10 +179,12 @@ export default class XMPP {
      *   }
      * }
      *
-     * Alternatively, a `token` may be supplied in place of `password`. The token
-     * is sent via SASL PLAIN in the password slot; servers such as ejabberd
-     * (`mod_auth_token`) and Prosody (`mod_tokenauth`) accept this for
-     * token-based authentication. Exactly one of `password` or `token` must be
+     * Alternatively, a `token` may be supplied in place of `password`. Sockethub
+     * copies the token into the SASL PLAIN password slot, which only works for
+     * deployments that explicitly accept a bearer-style token there. Dedicated
+     * token SASL mechanisms such as ejabberd `X-OAUTH2`, Prosody
+     * `OAUTHBEARER`, Prosody community `X-TOKEN`, and SASL2 FAST are not
+     * implemented by this client. Exactly one of `password` or `token` must be
      * provided.
      *
      * @example
@@ -197,7 +199,7 @@ export default class XMPP {
      *   object: {
      *     type: 'credentials',
      *     userAddress: 'testuser@jabber.net',
-     *     token: 'ejabberd-issued-auth-token',
+     *     token: 'pre-issued-auth-token',
      *     resource: 'phone'
      *   }
      * }

--- a/packages/platform-xmpp/src/index.test.js
+++ b/packages/platform-xmpp/src/index.test.js
@@ -21,16 +21,6 @@ const credentials = {
     },
 };
 
-const tokenCredentials = {
-    actor: actor,
-    object: {
-        type: "credentials",
-        userAddress: "testingham@jabber.net",
-        token: "ejabberd-issued-auth-token",
-        resource: "home",
-    },
-};
-
 const target = {
     mrfoobar: {
         type: "person",
@@ -221,20 +211,6 @@ describe("XMPP", () => {
                 expect(xp.__client.start).toBeDefined();
                 expect(xp.__client.send).toBeDefined();
                 expect(xp.__client.send.callCount).toEqual(0);
-                sinon.assert.calledOnce(clientObjectFake.start);
-                sinon.assert.notCalled(xp.sendToClient);
-                done();
-            });
-        });
-    });
-
-    describe("Token-based initialization", () => {
-        it("passes the token in the password slot to the xmpp client", (done) => {
-            xp.connect(job.connect, tokenCredentials, () => {
-                sinon.assert.calledOnce(clientFake);
-                expect(clientFake.getCall(0).args[0].password).toEqual(
-                    "ejabberd-issued-auth-token",
-                );
                 sinon.assert.calledOnce(clientObjectFake.start);
                 sinon.assert.notCalled(xp.sendToClient);
                 done();

--- a/packages/platform-xmpp/src/schema.js
+++ b/packages/platform-xmpp/src/schema.js
@@ -36,7 +36,7 @@ export const PlatformSchema = {
             },
             object: {
                 type: "object",
-                required: ["type", "userAddress", "resource"],
+                required: ["type", "userAddress", "resource", "password"],
                 additionalProperties: false,
                 properties: {
                     type: {
@@ -46,9 +46,6 @@ export const PlatformSchema = {
                         type: "string",
                     },
                     password: {
-                        type: "string",
-                    },
-                    token: {
                         type: "string",
                     },
                     server: {
@@ -61,7 +58,6 @@ export const PlatformSchema = {
                         type: "string",
                     },
                 },
-                oneOf: [{ required: ["password"] }, { required: ["token"] }],
             },
         },
     },

--- a/packages/platform-xmpp/src/schema.test.js
+++ b/packages/platform-xmpp/src/schema.test.js
@@ -24,17 +24,7 @@ describe("PlatformSchema.credentials", () => {
         expect(validate(withObject({ password: "hunter2" }))).toBe(true);
     });
 
-    it("accepts token-only credentials", () => {
-        expect(validate(withObject({ token: "t0k3n" }))).toBe(true);
-    });
-
-    it("rejects credentials with both password and token", () => {
-        expect(
-            validate(withObject({ password: "hunter2", token: "t0k3n" })),
-        ).toBe(false);
-    });
-
-    it("rejects credentials with neither password nor token", () => {
+    it("rejects credentials without a password", () => {
         expect(validate(base)).toBe(false);
     });
 });

--- a/packages/platform-xmpp/src/utils.js
+++ b/packages/platform-xmpp/src/utils.js
@@ -8,7 +8,7 @@ export const utils = {
                   ? server
                   : undefined,
             username: username,
-            password: credentials.object.token || credentials.object.password,
+            password: credentials.object.password,
         };
         if (credentials.object.port) {
             xmpp_creds.service = `${xmpp_creds.service}:${credentials.object.port}`;

--- a/packages/platform-xmpp/src/utils.test.js
+++ b/packages/platform-xmpp/src/utils.test.js
@@ -20,42 +20,6 @@ describe("Utils", () => {
                 resource: "Home",
             });
         });
-        it("uses token in the password slot when token is provided", () => {
-            expect(
-                utils.buildXmppCredentials({
-                    object: {
-                        userAddress: "barney@dinosaur.com.au",
-                        token: "t0k3n",
-                        resource: "Home",
-                    },
-                }),
-            ).toEqual({
-                password: "t0k3n",
-                service: "dinosaur.com.au",
-                username: "barney",
-                resource: "Home",
-            });
-        });
-        // Schema validation rejects dual-secret credentials before runtime,
-        // but the helper still behaves deterministically if malformed input
-        // slips through a lower-level unit test.
-        it("defensively prefers token over password when handed invalid dual-secret input", () => {
-            expect(
-                utils.buildXmppCredentials({
-                    object: {
-                        userAddress: "barney@dinosaur.com.au",
-                        token: "t0k3n",
-                        password: "bar",
-                        resource: "Home",
-                    },
-                }),
-            ).toEqual({
-                password: "t0k3n",
-                service: "dinosaur.com.au",
-                username: "barney",
-                resource: "Home",
-            });
-        });
     });
     it("allows overriding server value", () => {
         expect(

--- a/packages/platform-xmpp/src/utils.test.js
+++ b/packages/platform-xmpp/src/utils.test.js
@@ -36,7 +36,10 @@ describe("Utils", () => {
                 resource: "Home",
             });
         });
-        it("prefers token over password when both are present", () => {
+        // Schema validation rejects dual-secret credentials before runtime,
+        // but the helper still behaves deterministically if malformed input
+        // slips through a lower-level unit test.
+        it("defensively prefers token over password when handed invalid dual-secret input", () => {
             expect(
                 utils.buildXmppCredentials({
                     object: {

--- a/packages/server/README.md
+++ b/packages/server/README.md
@@ -28,7 +28,8 @@ platform instance when they target the same actor.
 Session sharing rules:
 
 - Credentials are validated in the data layer during share attempts.
-- Share is allowed only when credentials include a non-empty `password`.
+- Share is allowed only when credentials include a non-empty secret such as
+  `password` or `token`.
 - Username-only/anonymous credentials are rejected with `username already in use`.
 
 Reconnect exception for anonymous credentials:

--- a/packages/server/README.md
+++ b/packages/server/README.md
@@ -28,10 +28,9 @@ platform instance when they target the same actor.
 Session sharing rules:
 
 - Credentials are validated in the data layer during share attempts.
-- Share is allowed only when credentials include a non-empty secret such as
-  `password` or `token`.
-  XMPP now uses `password` only; `token` here refers to other platform
-  credential shapes such as IRC OAuth-style secrets.
+- Share is allowed only when credentials include a non-empty `password` or
+  `token` field (e.g. IRC OAuth). Credential objects with neither are treated
+  as anonymous and cannot be shared across connections.
 - Username-only/anonymous credentials are rejected with `username already in use`.
 
 Reconnect exception for anonymous credentials:

--- a/packages/server/README.md
+++ b/packages/server/README.md
@@ -30,6 +30,8 @@ Session sharing rules:
 - Credentials are validated in the data layer during share attempts.
 - Share is allowed only when credentials include a non-empty secret such as
   `password` or `token`.
+  XMPP now uses `password` only; `token` here refers to other platform
+  credential shapes such as IRC OAuth-style secrets.
 - Username-only/anonymous credentials are rejected with `username already in use`.
 
 Reconnect exception for anonymous credentials:


### PR DESCRIPTION
## Summary

- remove the XMPP-specific `token` credential alias and collapse the platform back to a single `password` field
- simplify the examples UI so XMPP now uses one password input, with a note for deployments that accept bearer-style tokens in the SASL `PLAIN` password slot
- preserve generic session-share support for non-XMPP credentials that still legitimately use `token`
- tighten the XMPP docs so they only describe the compatibility path the current client actually implements

## Details

This follow-up addresses the review of #1058 by simplifying the XMPP contract instead of treating `token` as a first-class XMPP authentication mode:

- `packages/platform-xmpp/src/schema.js` now requires `password` and no longer accepts `token`
- `packages/platform-xmpp/src/utils.js` now forwards only `object.password` to the xmpp.js client
- the XMPP example page now has a single password field instead of a misleading password/token toggle
- `TextAreaSubmit.svelte` is back to password-only secret handling for the examples app
- `CredentialsStore.get(..., { validateSessionShare: true })` still allows non-empty `password` or `token` secrets for other persistent platforms that use generic token credentials
- the server README now clarifies that XMPP uses `password` while generic `token` session sharing still matters for other platforms such as IRC OAuth flows
- the generated XMPP API docs were refreshed from the updated JSDoc source comments
- the flaky browser XMPP multiclient test now waits for stable room delivery before asserting fan-out

## Test plan

- [x] `bun test packages/platform-xmpp/src/schema.test.js packages/platform-xmpp/src/utils.test.js packages/platform-xmpp/src/index.test.js`
- [x] `bun test packages/data-layer/src/credentials-store.test.ts`
- [x] `bun run doc`
- [x] `bun run lint`
