### PR TITLE
fix(build): remove pre-build clean to fix race condition

### DIFF
--- a/packages/activity-streams/package.json
+++ b/packages/activity-streams/package.json
@@ -39,7 +39,7 @@
   },
   "homepage": "https://github.com/sockethub/sockethub/tree/master/packages/activity-streams",
   "scripts": {
-    "build": "bun run clean && bun run build:js && bun run build:minify",
+    "build": "bun run build:js && bun run build:minify",
     "build:js": "bun build ./src/activity-streams.ts --target=browser --sourcemap=inline --format=esm --outdir=dist/",
     "build:minify": "bun build ./src/activity-streams.ts --target=browser --sourcemap=inline --format=esm --outfile=dist/activity-streams.min.js --minify",
     "clean": "rm -rf dist",

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -38,7 +38,7 @@
     "client"
   ],
   "scripts": {
-    "build": "bun run clean && bun run build:esm && bun run build:browser && bun run build:minify",
+    "build": "bun run build:esm && bun run build:browser && bun run build:minify",
     "build:esm": "bun build ./src/sockethub-client.ts --target=browser --sourcemap=inline --format=esm --outdir=dist/ ",
     "build:browser": "bun build ./src/sockethub-client.ts --target=browser --sourcemap=inline --format=iife --global-name=SockethubClient --outfile=dist/sockethub-client.browser.js",
     "build:minify": "bun build ./src/sockethub-client.ts --target=browser --sourcemap=inline --format=iife --global-name=SockethubClient --outfile=dist/sockethub-client.min.js --minify",


### PR DESCRIPTION
## Summary
- Remove `bun run clean &&` from the `build` scripts of `activity-streams` and `client`
- `bun run --filter='*' build` runs all workspace packages in parallel; the `rm -rf dist` step created a window where dependent packages (examples → client → activity-streams) could fail to resolve entries, causing non-deterministic build failures
- `bun build` overwrites output files in place so pre-cleaning is unnecessary; `clean` scripts remain available for manual use

## Test plan
- [x] Verified `bun run build` succeeds 5/5 times (previously failed intermittently)
- [x] Verified build succeeds from a fully clean state (`rm -rf dist` first)
- [x] Lint passes