### PR TITLE
fix(examples): use two-way binding for room prop

### DIFF
--- a/packages/examples/src/components/chat/Room.svelte
+++ b/packages/examples/src/components/chat/Room.svelte
@@ -17,6 +17,14 @@ interface Props {
 let { room = $bindable(), actor, context, sockethubState }: Props = $props();
 
 let joining = $state(false);
+let lastJoinedRoom = $state("");
+
+// Reset joined state when room changes so the user can join the new room
+$effect(() => {
+    if (room !== lastJoinedRoom) {
+        $sockethubState.joined = false;
+    }
+});
 
 async function joinRoom(): Promise<void> {
     joining = true;
@@ -39,7 +47,7 @@ async function joinRoom(): Promise<void> {
             joining = false;
         })
         .then(() => {
-            // $actor.roomId = room;
+            lastJoinedRoom = room;
             $sockethubState.joined = true;
             joining = false;
         });

--- a/packages/examples/src/routes/irc/+page.svelte
+++ b/packages/examples/src/routes/irc/+page.svelte
@@ -20,7 +20,7 @@ const actorIdStore = writable(
 
 let server = $state("chat.freenode.net");
 let port = $state(6697);
-let room = "#sh-random";
+let room = $state("#sh-random");
 let connecting = $state(false);
 
 const sockethubState = writable({
@@ -151,7 +151,7 @@ async function connectIrc(): Promise<void> {
                     Join Channel and Chat
                 </h4>
                 <div class="space-y-6">
-                    <Room {actor} {sockethubState} {room} context="irc" />
+                    <Room {actor} {sockethubState} bind:room context="irc" />
                     <IncomingMessage />
                     <SendMessage context="irc" {actor} {sockethubState} {room} />
                 </div>

--- a/packages/examples/src/routes/xmpp/+page.svelte
+++ b/packages/examples/src/routes/xmpp/+page.svelte
@@ -20,7 +20,7 @@ let passwordValue = $state("123456");
 
 let actorId = $derived(`${$actorIdStore}/SockethubExample`);
 
-const room = "kosmos-random@kosmos.chat";
+let room = $state("kosmos-random@kosmos.chat");
 
 const sockethubState = writable({
     actorSet: false,
@@ -131,7 +131,7 @@ async function connectXmpp(): Promise<void> {
             <div class="bg-white border border-gray-200 rounded-lg p-4">
                 <h4 class="font-semibold text-gray-800 mb-3">Step 4 & 5: Join Room and Chat</h4>
                 <div class="space-y-4">
-                    <Room {actor} {sockethubState} {room} context="xmpp" />
+                    <Room {actor} {sockethubState} bind:room context="xmpp" />
                     <IncomingMessage />
                     <SendMessage context="xmpp" {actor} {sockethubState} {room} />
                 </div>


### PR DESCRIPTION
## Summary
- The Room component's input updated its local `room` value, but without `bind:room` the change never propagated back to the parent (IRC/XMPP pages). `SendMessage` kept using the original default room (`#sh-random` / `kosmos-random@kosmos.chat`), causing "cannot send message to a channel of which you've not first joined" errors whenever the user changed the room name before joining.
- Made `room` reactive with `$state()` in both IRC and XMPP pages, and switched to `bind:room` so Room and SendMessage always agree on which room is active.
- Added `lastJoinedRoom` tracking in the Room component so changing the room input resets the joined state, re-enabling the Join button.

## Test plan
- [ ] Open IRC example, change room name, join, then send a message — message should target the joined room
- [ ] Change room name again — Join button should re-enable
- [ ] Verify XMPP example has the same behavior