### PR TITLE
docs: add AGENTS.md as canonical AI agent instructions

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,5 +1,8 @@
 # Sockethub Code Review Instructions
 
+Read and follow all project conventions in [AGENTS.md](../AGENTS.md).
+The sections below are additional Copilot-specific code review guidance.
+
 ## Review Philosophy
 
 **ONLY comment when you have HIGH CONFIDENCE (>80%) that an issue exists.**

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -21,32 +21,6 @@ DO NOT comment on:
 - Hypothetical edge cases without evidence
 - Suggestions to add comments or documentation
 
-## Architecture Principles
-
-Sockethub is a protocol gateway using ActivityStreams. Understanding these core patterns is critical:
-
-### Process Isolation
-- Each platform MUST run as a separate child process
-- Platforms communicate with the server via IPC only
-- NEVER add direct imports between server and platform code
-- Platform crashes MUST NOT affect other platforms or the server
-
-### ActivityStreams Protocol
-- All messages MUST conform to ActivityStreams format
-- Every ActivityStream requires: `type`, `context`, `actor`
-- Use proper types from `@sockethub/schemas`
-- NEVER create ad-hoc message formats
-
-### Job Queue & Redis
-- All platform communication goes through BullMQ job queues
-- Jobs MUST handle failures gracefully (retries, dead letter queues)
-- Queue operations MUST be atomic where data consistency matters
-
-### Session & Credential Management
-- Credentials MUST be encrypted before Redis storage
-- Each Socket.IO session MUST be isolated (no credential leaking)
-- NEVER log credentials or sensitive data
-
 ## Security Requirements
 
 Flag these issues with HIGH priority:
@@ -137,24 +111,3 @@ These patterns are intentional in this codebase:
 ## Platform-Specific Patterns
 
 See `platforms.instructions.md` for detailed platform development guidelines.
-
-## Monorepo Structure
-
-This is a Bun workspace monorepo managed by Lerna Lite. When reviewing changes, consider the package context:
-
-- `packages/server/` - Main server, middleware, process management
-- `packages/sockethub/` - Main executable/CLI entry point
-- `packages/client/` - JavaScript client library for browsers/apps
-- `packages/platform-*/` - Individual protocol implementations (IRC, XMPP, Feeds, Metadata, Dummy)
-- `packages/schemas/` - Type definitions and validators
-- `packages/data-layer/` - Redis, job queues, credential storage
-- `packages/activity-streams/` - ActivityStreams factory and utilities
-- `packages/crypto/` - Cryptographic utilities for credential encryption
-- `packages/irc2as/` - IRC to ActivityStreams conversion library
-- `packages/examples/` - SvelteKit demo application
-
-### Key Dependency Rules
-
-- Server MUST NOT directly import platform code (platforms are child processes)
-- All packages should use types from `@sockethub/schemas`
-- Platforms MUST implement the `PlatformInterface` from schemas

--- a/.gitignore
+++ b/.gitignore
@@ -8,7 +8,6 @@ node_modules
 .DS_Store
 sockethub.config.json
 .claude/
-CLAUDE.md
 packages/sockethub/sockethub.config.json.sentry
 test-install/
 test-results/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,141 @@
+# Sockethub - AI Agent Instructions
+
+This is the canonical source of project conventions for AI agents.
+Tool-specific files (CLAUDE.md, copilot-instructions.md) should reference this file.
+
+## Conventions (CI-Enforced)
+
+### Branch Naming
+
+Branches MUST use a conventional type prefix. CI rejects PRs with invalid branch names.
+
+```
+<type>/<short-description>
+```
+
+Valid prefixes: `feat/`, `fix/`, `docs/`, `style/`, `refactor/`, `perf/`, `test/`, `build/`,
+`ci/`, `chore/`, `revert/`, `infra/`
+
+Examples: `feat/add-matrix-platform`, `fix/irc-reconnection-loop`, `docs/update-api-guide`
+
+### Commit Messages
+
+Follow [Conventional Commits](https://www.conventionalcommits.org/):
+
+```
+<type>(<scope>): <description>
+```
+
+Types: `feat`, `fix`, `docs`, `style`, `refactor`, `perf`, `test`, `build`, `ci`, `chore`,
+`revert`
+
+Scopes (optional): package names (`client`, `server`, `data-layer`, `schemas`, `platform-irc`,
+`platform-xmpp`, `examples`, etc.) or components (`job-queue`, `credentials`, `session`,
+`middleware`, `config`). Omit scope for cross-cutting changes.
+
+Breaking changes: add `!` after type/scope (e.g. `feat(client)!: remove deprecated method`).
+
+### PR Titles
+
+PR titles follow the same conventional format. The PR title becomes the squash commit message.
+
+```
+<type>(<scope>): <description>
+```
+
+### Default Branch
+
+The default branch is `master` (not `main`).
+
+## Development
+
+### Prerequisites
+
+- Bun >= 1.2.4 (runtime and package manager)
+- This is a Bun workspace monorepo managed by Lerna Lite
+
+### Commands
+
+```bash
+bun install                 # Install dependencies
+bun test                    # Run unit tests across all packages
+bun run lint                # Run Biome linter and markdown lint
+bun run lint:fix            # Auto-fix linting issues
+bun run build               # Build all packages
+bun run clean               # Clean build artifacts
+```
+
+### Pre-Commit Checklist
+
+Before committing, run:
+
+```bash
+bun install
+bun run lint
+bun run build
+bun test
+```
+
+## Monorepo Structure
+
+```
+packages/
+  server/           - Main server, middleware, Socket.IO, process management
+  sockethub/        - CLI entry point and executable
+  client/           - JavaScript client library for browsers/apps
+  data-layer/       - Redis, BullMQ job queues, credential storage
+  schemas/          - TypeScript types and AJV validators
+  activity-streams/ - ActivityStreams factory and utilities
+  crypto/           - Cryptographic utilities for credential encryption
+  irc2as/           - IRC to ActivityStreams conversion library
+  platform-irc/     - IRC protocol platform
+  platform-xmpp/    - XMPP protocol platform
+  platform-feeds/   - RSS/Atom feeds platform
+  platform-metadata/- URL metadata extraction platform
+  platform-dummy/   - Reference/test platform implementation
+  examples/         - SvelteKit demo application
+```
+
+## Things NOT to Edit
+
+- `packages/*/API.md` - Auto-generated from JSDoc. Edit the JSDoc in `src/index.ts` instead,
+  then run the package's `doc` script.
+
+## Architecture
+
+Sockethub is a protocol gateway that translates between web applications and messaging protocols
+using ActivityStreams as the uniform message format.
+
+### Core Principles
+
+- **Process Isolation**: Each platform runs as a separate child process. Never add direct
+  imports between server and platform code. Platform crashes must not affect other platforms.
+- **ActivityStreams Protocol**: All messages must conform to ActivityStreams format with `type`,
+  `context`, and `actor` fields. Use types from `@sockethub/schemas`.
+- **Job Queue**: All platform communication goes through Redis-backed BullMQ queues.
+- **Session Isolation**: Credentials are encrypted per-session. Never log credentials.
+
+### Key Dependency Rules
+
+- Server MUST NOT directly import platform code (platforms are child processes via IPC)
+- All packages should use types from `@sockethub/schemas`
+- Platforms MUST implement `PlatformInterface` from schemas
+
+## Code Standards
+
+- **TypeScript**: Use proper types from `@sockethub/schemas`. Avoid `any`.
+- **Linting**: Biome handles formatting and style. Don't comment on style.
+- **Testing**: Test files named `*.test.ts`. Use `describe` and `test` (not `it`).
+  Mock external dependencies. Test error paths, not just happy paths.
+- **Error Handling**: Always call `done(err)` on failure. Never silently swallow errors.
+  Log errors with context (session ID, platform, action).
+
+## Platform Development
+
+See `.github/instructions/platforms.instructions.md` for detailed platform implementation
+patterns including schema definitions, credential handling, client lifecycle, and cleanup.
+
+## Full Details
+
+See `docs/CONTRIBUTING.md` for the complete contributor guide including version bump rules,
+release process, and workflow details.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -127,7 +127,7 @@ using ActivityStreams as the uniform message format.
 - **Linting**: Biome handles formatting and style. Don't comment on style.
 - **Testing**: Test files named `*.test.ts`. Use `describe` and `test` (not `it`).
   Mock external dependencies. Test error paths, not just happy paths.
-- **Error Handling**: Always call `done(err)` on failure. Never silently swallow errors.
+- **Error Handling**: Always propagate errors to the caller. Never silently swallow errors.
   Log errors with context (session ID, platform, action).
 
 ## Platform Development

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+Read and follow all instructions in [AGENTS.md](AGENTS.md).


### PR DESCRIPTION
## Summary
- Added `AGENTS.md` at the repo root as the single source of truth for AI agent conventions (branch naming, commit format, PR titles, architecture, code standards, monorepo structure).
- Added `CLAUDE.md` that points to `AGENTS.md` (previously gitignored, now tracked).
- Updated `.github/copilot-instructions.md` to reference `AGENTS.md` for shared conventions instead of duplicating them.

## Test plan
- [ ] Verify CI passes (branch name validation, lint)
- [ ] Confirm Claude Code picks up CLAUDE.md -> AGENTS.md on next session