### PR TITLE
refactor!: drop legacy platform field and string context routing

### DIFF
--- a/integration/browser/basic.integration.js
+++ b/integration/browser/basic.integration.js
@@ -6,6 +6,7 @@ import {
     emitWithAck,
     getConfig,
     joinXMPPRoom,
+    platformIdFromContext,
     sendXMPPMessage,
     setXMPPCredentials,
     validateGlobals,
@@ -230,8 +231,10 @@ describe(`Sockethub Basic Integration Tests at ${config.sockethub.url}`, () => {
                             id: actorObject.id,
                             type: actorObject.type,
                         },
-                        platform: "xmpp",
                     });
+                    expect(platformIdFromContext(msg["@context"])).to.equal(
+                        "xmpp",
+                    );
                 });
             });
 
@@ -244,12 +247,14 @@ describe(`Sockethub Basic Integration Tests at ${config.sockethub.url}`, () => {
                             id: actorObject.id,
                             type: actorObject.type,
                         },
-                        platform: "xmpp",
                         target: {
                             id: "test@prosody",
                             type: "room",
                         },
                     });
+                    expect(platformIdFromContext(msg["@context"])).to.equal(
+                        "xmpp",
+                    );
                 });
             });
 
@@ -267,7 +272,6 @@ describe(`Sockethub Basic Integration Tests at ${config.sockethub.url}`, () => {
                             id: actorObject.id,
                             type: actorObject.type,
                         },
-                        platform: "xmpp",
                         object: {
                             type: "message",
                             content: "Hello, world!",
@@ -277,6 +281,9 @@ describe(`Sockethub Basic Integration Tests at ${config.sockethub.url}`, () => {
                             type: "room",
                         },
                     });
+                    expect(platformIdFromContext(msg["@context"])).to.equal(
+                        "xmpp",
+                    );
                 });
             });
         });
@@ -392,7 +399,9 @@ describe(`Sockethub Basic Integration Tests at ${config.sockethub.url}`, () => {
                 // failed connect attempts with invalid credentials).
                 expect(incomingMessages.length).to.be.at.most(2);
                 for (const msg of incomingMessages) {
-                    expect(msg).to.have.property("platform", "xmpp");
+                    expect(platformIdFromContext(msg["@context"])).to.equal(
+                        "xmpp",
+                    );
                     expect(msg).to.have.property("error").that.is.a("string");
                 }
             });

--- a/integration/browser/irc-basic.integration.js
+++ b/integration/browser/irc-basic.integration.js
@@ -4,6 +4,7 @@ import {
     connectIRC,
     getConfig,
     joinIRCChannel,
+    platformIdFromContext,
     sendIRCMessage,
     setIRCCredentials,
     validateGlobals,
@@ -60,10 +61,8 @@ describe(`Sockethub IRC Basic Integration Tests at ${config.sockethub.url}`, () 
         describe("connect", () => {
             it("is successful", async () => {
                 const msg = await connectIRC(sc, actorId, nick);
-                expect(msg).to.deep.include({
-                    type: "connect",
-                    platform: "irc",
-                });
+                expect(msg.type).to.equal("connect");
+                expect(platformIdFromContext(msg["@context"])).to.equal("irc");
                 expect(msg.actor).to.deep.include({
                     id: actorObject.id,
                     type: actorObject.type,
@@ -79,10 +78,8 @@ describe(`Sockethub IRC Basic Integration Tests at ${config.sockethub.url}`, () 
                     nick,
                     config.irc.channel,
                 );
-                expect(msg).to.deep.include({
-                    type: "join",
-                    platform: "irc",
-                });
+                expect(msg.type).to.equal("join");
+                expect(platformIdFromContext(msg["@context"])).to.equal("irc");
                 expect(msg.target).to.deep.include({
                     id: config.irc.channel,
                     type: "room",
@@ -100,10 +97,8 @@ describe(`Sockethub IRC Basic Integration Tests at ${config.sockethub.url}`, () 
                     config.irc.channel,
                     content,
                 );
-                expect(msg).to.deep.include({
-                    type: "send",
-                    platform: "irc",
-                });
+                expect(msg.type).to.equal("send");
+                expect(platformIdFromContext(msg["@context"])).to.equal("irc");
                 expect(msg.object).to.deep.include({
                     type: "message",
                     content,
@@ -124,7 +119,7 @@ describe(`Sockethub IRC Basic Integration Tests at ${config.sockethub.url}`, () 
                 const echoes = incomingMessages.filter(
                     (m) =>
                         m.type === "send" &&
-                        m.platform === "irc" &&
+                        platformIdFromContext(m["@context"]) === "irc" &&
                         m.actor?.id === actorObject.id,
                 );
                 expect(echoes).to.have.length(0);

--- a/integration/browser/irc-nickclash.integration.js
+++ b/integration/browser/irc-nickclash.integration.js
@@ -101,8 +101,15 @@ describe(`IRC Nick Clash Integration Tests at ${config.sockethub.url}`, () => {
     describe("Same actor ID, concurrent connects", () => {
         let clientA;
         let clientB;
-        const nick = `${config.irc.testUser.nick}Shared`;
+        // Use the registered NickServ account (only `jimmy` is seeded by
+        // ergo/bootstrap.sh). Session-sharing is a credentialed operation:
+        // credential-check rejects passwordless attempts to attach a second
+        // socket to an existing persistent platform instance
+        // (CredentialsNotShareableError), so exercising the `clientConnecting`
+        // lock requires shareable credentials.
+        const nick = config.irc.testUser.nick;
         const actorId = utils.createIrcActorId(nick);
+        const password = config.irc.testUser.password;
 
         before(() => {
             clientA = new SockethubClient(
@@ -128,8 +135,8 @@ describe(`IRC Nick Clash Integration Tests at ${config.sockethub.url}`, () => {
             // should wait on the first via the `clientConnecting` lock and
             // then reuse the shared client.
             await Promise.all([
-                setIRCCredentials(clientA, actorId, nick),
-                setIRCCredentials(clientB, actorId, nick),
+                setIRCCredentials(clientA, actorId, nick, { password }),
+                setIRCCredentials(clientB, actorId, nick, { password }),
             ]);
             const actorObject = utils.createIrcActorObject(nick);
             clientA.ActivityStreams.Object.create(actorObject);

--- a/integration/browser/irc-nickclash.integration.js
+++ b/integration/browser/irc-nickclash.integration.js
@@ -3,6 +3,7 @@ import createTestUtils from "../utils.js";
 import {
     connectIRC,
     getConfig,
+    platformIdFromContext,
     setIRCCredentials,
     validateGlobals,
 } from "./shared-setup.js";
@@ -145,10 +146,10 @@ describe(`IRC Nick Clash Integration Tests at ${config.sockethub.url}`, () => {
             // connection established by the first.
             expect(fulfilled.length).to.equal(2);
             for (const r of fulfilled) {
-                expect(r.value).to.deep.include({
-                    type: "connect",
-                    platform: "irc",
-                });
+                expect(r.value.type).to.equal("connect");
+                expect(platformIdFromContext(r.value["@context"])).to.equal(
+                    "irc",
+                );
             }
         });
     });

--- a/integration/browser/irc-sasl-auth.integration.js
+++ b/integration/browser/irc-sasl-auth.integration.js
@@ -7,6 +7,7 @@ import {
     getConfig,
     joinIRCChannel,
     partIRCChannel,
+    platformIdFromContext,
     sendIRCMessage,
     setIRCCredentials,
     validateGlobals,
@@ -50,10 +51,8 @@ describe(`Sockethub IRC SASL auth at ${config.sockethub.url}`, () => {
 
             it("connects successfully", async () => {
                 const msg = await connectIRC(sc, actorId, nick);
-                expect(msg).to.deep.include({
-                    type: "connect",
-                    platform: "irc",
-                });
+                expect(msg.type).to.equal("connect");
+                expect(platformIdFromContext(msg["@context"])).to.equal("irc");
                 expect(msg.actor?.id).to.equal(actorId);
             });
 
@@ -64,10 +63,8 @@ describe(`Sockethub IRC SASL auth at ${config.sockethub.url}`, () => {
                     nick,
                     config.irc.channel,
                 );
-                expect(msg).to.deep.include({
-                    type: "join",
-                    platform: "irc",
-                });
+                expect(msg.type).to.equal("join");
+                expect(platformIdFromContext(msg["@context"])).to.equal("irc");
                 expect(msg.target?.id).to.equal(config.irc.channel);
             });
 
@@ -80,10 +77,8 @@ describe(`Sockethub IRC SASL auth at ${config.sockethub.url}`, () => {
                     config.irc.channel,
                     content,
                 );
-                expect(msg).to.deep.include({
-                    type: "send",
-                    platform: "irc",
-                });
+                expect(msg.type).to.equal("send");
+                expect(platformIdFromContext(msg["@context"])).to.equal("irc");
                 expect(msg.object?.content).to.equal(content);
             });
 
@@ -94,10 +89,8 @@ describe(`Sockethub IRC SASL auth at ${config.sockethub.url}`, () => {
                     nick,
                     config.irc.channel,
                 );
-                expect(msg).to.deep.include({
-                    type: "leave",
-                    platform: "irc",
-                });
+                expect(msg.type).to.equal("leave");
+                expect(platformIdFromContext(msg["@context"])).to.equal("irc");
             });
         });
     }

--- a/integration/browser/shared-setup.js
+++ b/integration/browser/shared-setup.js
@@ -1,10 +1,35 @@
 import { expect } from "@esm-bundle/chai";
 
+const PLATFORM_CONTEXT_PREFIX = "https://sockethub.org/ns/context/platform/";
+
 export const ctx = (platform) => [
     "https://www.w3.org/ns/activitystreams",
     "https://sockethub.org/ns/context/v1.jsonld",
-    `https://sockethub.org/ns/context/platform/${platform}/v1.jsonld`,
+    `${PLATFORM_CONTEXT_PREFIX}${platform}/v1.jsonld`,
 ];
+
+/**
+ * Extract the platform id from a canonical Sockethub @context array.
+ * Returns undefined when no platform entry is present.
+ */
+export function platformIdFromContext(context) {
+    if (!Array.isArray(context)) {
+        return undefined;
+    }
+    for (const entry of context) {
+        if (
+            typeof entry === "string" &&
+            entry.startsWith(PLATFORM_CONTEXT_PREFIX)
+        ) {
+            const rest = entry.slice(PLATFORM_CONTEXT_PREFIX.length);
+            const slashIdx = rest.indexOf("/");
+            if (slashIdx > 0) {
+                return rest.slice(0, slashIdx);
+            }
+        }
+    }
+    return undefined;
+}
 
 // sockethub-client.js and socket.io.js are loaded via <script> tags
 // in the test runner HTML (injected from the running Sockethub server)

--- a/integration/browser/shared-setup.js
+++ b/integration/browser/shared-setup.js
@@ -1,35 +1,12 @@
 import { expect } from "@esm-bundle/chai";
+import {
+    buildCanonicalContext,
+    platformIdFromContext,
+} from "@sockethub/activity-streams";
 
-const PLATFORM_CONTEXT_PREFIX = "https://sockethub.org/ns/context/platform/";
+export const ctx = (platform) => buildCanonicalContext(platform);
 
-export const ctx = (platform) => [
-    "https://www.w3.org/ns/activitystreams",
-    "https://sockethub.org/ns/context/v1.jsonld",
-    `${PLATFORM_CONTEXT_PREFIX}${platform}/v1.jsonld`,
-];
-
-/**
- * Extract the platform id from a canonical Sockethub @context array.
- * Returns undefined when no platform entry is present.
- */
-export function platformIdFromContext(context) {
-    if (!Array.isArray(context)) {
-        return undefined;
-    }
-    for (const entry of context) {
-        if (
-            typeof entry === "string" &&
-            entry.startsWith(PLATFORM_CONTEXT_PREFIX)
-        ) {
-            const rest = entry.slice(PLATFORM_CONTEXT_PREFIX.length);
-            const slashIdx = rest.indexOf("/");
-            if (slashIdx > 0) {
-                return rest.slice(0, slashIdx);
-            }
-        }
-    }
-    return undefined;
-}
+export { platformIdFromContext };
 
 // sockethub-client.js and socket.io.js are loaded via <script> tags
 // in the test runner HTML (injected from the running Sockethub server)

--- a/packages/client/src/sockethub-client.test.ts
+++ b/packages/client/src/sockethub-client.test.ts
@@ -610,6 +610,40 @@ describe("SockethubClient", () => {
             sc.socket.emit("credentials", { actor: "bar" }, callback);
         });
 
+        it("promotes string context to canonical @context via contextFor", (done) => {
+            sc.socket.connected = true;
+            socket.once("message", (data: any) => {
+                expect(data["@context"]).to.eql([
+                    "https://example.com/as2",
+                    "https://example.com/sh",
+                    "https://example.com/context/platform/xmpp/v9.jsonld",
+                ]);
+                expect(data.platform).to.equal("xmpp");
+                done();
+            });
+            sc.socket.emit("message", {
+                actor: "bar",
+                type: "send",
+                context: "xmpp",
+            });
+        });
+
+        it("rejects string context for unknown platform via contextFor error", () => {
+            sc.socket.connected = true;
+            const callback = sandbox.spy();
+            socket.emit.resetHistory();
+            sc.socket.emit(
+                "message",
+                { actor: "bar", type: "send", context: "irc" },
+                callback,
+            );
+            expect(callback.calledOnce).to.equal(true);
+            expect(callback.firstCall.args[0]?.error).to.contain(
+                "unknown platform 'irc'",
+            );
+            expect(socket.emit.calledWithMatch("message")).to.equal(false);
+        });
+
         it("queues outbound messages before ready and flushes after schemas", (done) => {
             const preReadySocket = new EventEmitter();
             preReadySocket.connected = false;

--- a/packages/client/src/sockethub-client.test.ts
+++ b/packages/client/src/sockethub-client.test.ts
@@ -610,40 +610,6 @@ describe("SockethubClient", () => {
             sc.socket.emit("credentials", { actor: "bar" }, callback);
         });
 
-        it("promotes string context to canonical @context via contextFor", (done) => {
-            sc.socket.connected = true;
-            socket.once("message", (data: any) => {
-                expect(data["@context"]).to.eql([
-                    "https://example.com/as2",
-                    "https://example.com/sh",
-                    "https://example.com/context/platform/xmpp/v9.jsonld",
-                ]);
-                expect(data.platform).to.equal("xmpp");
-                done();
-            });
-            sc.socket.emit("message", {
-                actor: "bar",
-                type: "send",
-                context: "xmpp",
-            });
-        });
-
-        it("rejects string context for unknown platform via contextFor error", () => {
-            sc.socket.connected = true;
-            const callback = sandbox.spy();
-            socket.emit.resetHistory();
-            sc.socket.emit(
-                "message",
-                { actor: "bar", type: "send", context: "irc" },
-                callback,
-            );
-            expect(callback.calledOnce).to.equal(true);
-            expect(callback.firstCall.args[0]?.error).to.contain(
-                "unknown platform 'irc'",
-            );
-            expect(socket.emit.calledWithMatch("message")).to.equal(false);
-        });
-
         it("queues outbound messages before ready and flushes after schemas", (done) => {
             const preReadySocket = new EventEmitter();
             preReadySocket.connected = false;

--- a/packages/client/src/sockethub-client.ts
+++ b/packages/client/src/sockethub-client.ts
@@ -916,25 +916,6 @@ export default class SockethubClient {
                 );
                 if (outgoing && typeof outgoing === "object") {
                     const activity = outgoing as ActivityStream;
-                    if (!activity["@context"]) {
-                        // A string `context` is just a platform-name alias for
-                        // @context — resolve it the same way as `platform`.
-                        const legacy = activity as ActivityStream & {
-                            context?: unknown;
-                        };
-                        const platformName =
-                            (typeof legacy.platform === "string" &&
-                                legacy.platform.trim()) ||
-                            (typeof legacy.context === "string" &&
-                                legacy.context.trim());
-                        if (platformName) {
-                            activity.platform = platformName;
-                            // contextFor() throws for unknown platforms; the
-                            // outer try/catch turns that into a client error.
-                            activity["@context"] =
-                                this.contextFor(platformName);
-                        }
-                    }
                     if (entry.event === "credentials" && !activity.type) {
                         activity.type = "credentials";
                     }

--- a/packages/client/src/sockethub-client.ts
+++ b/packages/client/src/sockethub-client.ts
@@ -916,14 +916,24 @@ export default class SockethubClient {
                 );
                 if (outgoing && typeof outgoing === "object") {
                     const activity = outgoing as ActivityStream;
-                    if (
-                        !activity["@context"] &&
-                        typeof activity.platform === "string" &&
-                        activity.platform.trim().length > 0
-                    ) {
-                        activity["@context"] = this.contextFor(
-                            activity.platform,
-                        );
+                    if (!activity["@context"]) {
+                        // A string `context` is just a platform-name alias for
+                        // @context — resolve it the same way as `platform`.
+                        const legacy = activity as ActivityStream & {
+                            context?: unknown;
+                        };
+                        const platformName =
+                            (typeof legacy.platform === "string" &&
+                                legacy.platform.trim()) ||
+                            (typeof legacy.context === "string" &&
+                                legacy.context.trim());
+                        if (platformName) {
+                            activity.platform = platformName;
+                            // contextFor() throws for unknown platforms; the
+                            // outer try/catch turns that into a client error.
+                            activity["@context"] =
+                                this.contextFor(platformName);
+                        }
                     }
                     if (entry.event === "credentials" && !activity.type) {
                         activity.type = "credentials";

--- a/packages/data-layer/integration/redis.integration.ts
+++ b/packages/data-layer/integration/redis.integration.ts
@@ -7,10 +7,20 @@ import {
     JobWorker,
     redisCheck,
 } from "@sockethub/data-layer";
-import type { ActivityStream, CredentialsObject } from "@sockethub/schemas";
+import {
+    type ActivityStream,
+    addPlatformContext,
+    type CredentialsObject,
+} from "@sockethub/schemas";
 
 const REDIS_HOST = process.env.REDIS_HOST || "localhost";
 const REDIS_URL = `redis://${REDIS_HOST}:6379`;
+
+const BAR_PLATFORM_CONTEXT_URL =
+    "https://sockethub.org/ns/context/platform/bar/v1.jsonld";
+// Register "bar" so resolvePlatformId() can map the @context entry back to the
+// platform id used in job titles.
+addPlatformContext("bar", BAR_PLATFORM_CONTEXT_URL);
 
 const actor = `${(Math.random() + 1).toString(36).substring(2)}`;
 const creds: CredentialsObject = {
@@ -18,7 +28,7 @@ const creds: CredentialsObject = {
     "@context": [
         "https://www.w3.org/ns/activitystreams",
         "https://sockethub.org/ns/context/v1.jsonld",
-        "https://sockethub.org/ns/context/platform/bar/v1.jsonld",
+        BAR_PLATFORM_CONTEXT_URL,
     ],
     actor: {
         type: "person",
@@ -153,9 +163,8 @@ describe("JobQueue", () => {
         "@context": [
             "https://www.w3.org/ns/activitystreams",
             "https://sockethub.org/ns/context/v1.jsonld",
-            "https://sockethub.org/ns/context/platform/bar/v1.jsonld",
+            BAR_PLATFORM_CONTEXT_URL,
         ],
-        platform: "bar",
         actor: {
             id: "bar",
             type: "person",
@@ -348,7 +357,6 @@ describe("JobQueue", () => {
                 "https://sockethub.org/ns/context/v1.jsonld",
                 "https://sockethub.org/ns/context/platform/irc/v1.jsonld",
             ],
-            platform: "irc",
             actor: { id: "user@example.com", type: "person" },
             object: {
                 type: "message",
@@ -419,9 +427,8 @@ describe.skip("Redis connection failure", () => {
             "@context": [
                 "https://www.w3.org/ns/activitystreams",
                 "https://sockethub.org/ns/context/v1.jsonld",
-                "https://sockethub.org/ns/context/platform/bar/v1.jsonld",
+                BAR_PLATFORM_CONTEXT_URL,
             ],
-            platform: "bar",
             actor: { id: "bar", type: "person" },
         };
 

--- a/packages/data-layer/src/job-queue.test.ts
+++ b/packages/data-layer/src/job-queue.test.ts
@@ -1,7 +1,11 @@
 import { expect } from "chai";
 import * as sinon from "sinon";
 
-import type { Logger } from "@sockethub/schemas";
+import {
+    addPlatformContext,
+    buildCanonicalContext,
+    type Logger,
+} from "@sockethub/schemas";
 
 import { JobQueue } from "./index";
 
@@ -11,6 +15,13 @@ const mockLogger: Logger = {
     info: () => {},
     debug: () => {},
 };
+
+const TEST_PLATFORM_ID = "test-platform";
+const TEST_PLATFORM_CONTEXT_URL =
+    "https://sockethub.org/ns/context/platform/test-platform/v1.jsonld";
+const TEST_CONTEXT = buildCanonicalContext(TEST_PLATFORM_CONTEXT_URL);
+
+addPlatformContext(TEST_PLATFORM_ID, TEST_PLATFORM_CONTEXT_URL);
 
 describe("JobQueue", () => {
     let MockBull, jobQueue, cryptoMocks, sandbox;
@@ -108,11 +119,11 @@ describe("JobQueue", () => {
         it("returns expected job format", () => {
             cryptoMocks.encrypt.returns("an encrypted message");
             const job = jobQueue.createJob("a socket id", {
-                platform: "some context",
+                "@context": TEST_CONTEXT,
                 id: "an identifier",
             });
             expect(job).to.eql({
-                title: "some context-an identifier",
+                title: `${TEST_PLATFORM_ID}-an identifier`,
                 msg: "an encrypted message",
                 sessionId: "a socket id",
             });
@@ -121,18 +132,30 @@ describe("JobQueue", () => {
         it("uses counter when no id provided", () => {
             cryptoMocks.encrypt.returns("an encrypted message");
             let job = jobQueue.createJob("a socket id", {
-                platform: "some context",
+                "@context": TEST_CONTEXT,
             });
             expect(job).to.eql({
-                title: "some context-0",
+                title: `${TEST_PLATFORM_ID}-0`,
                 msg: "an encrypted message",
                 sessionId: "a socket id",
             });
             job = jobQueue.createJob("a socket id", {
-                platform: "some context",
+                "@context": TEST_CONTEXT,
             });
             expect(job).to.eql({
-                title: "some context-1",
+                title: `${TEST_PLATFORM_ID}-1`,
+                msg: "an encrypted message",
+                sessionId: "a socket id",
+            });
+        });
+
+        it("falls back to `unknown` when no platform context is registered", () => {
+            cryptoMocks.encrypt.returns("an encrypted message");
+            const job = jobQueue.createJob("a socket id", {
+                id: "an identifier",
+            });
+            expect(job).to.eql({
+                title: "unknown-an identifier",
                 msg: "an encrypted message",
                 sessionId: "a socket id",
             });
@@ -195,20 +218,21 @@ describe("JobQueue", () => {
         it("stores encrypted job", async () => {
             cryptoMocks.encrypt.returns("encrypted foo");
             jobQueue.queue.isPaused.returns(false);
+            const title = `${TEST_PLATFORM_ID}-an identifier`;
             const resultJob = {
-                title: "a platform-an identifier",
+                title,
                 sessionId: "a socket id",
                 msg: "encrypted foo",
             };
             const res = await jobQueue.add("a socket id", {
-                platform: "a platform",
+                "@context": TEST_CONTEXT,
                 id: "an identifier",
             });
             sinon.assert.calledOnce(jobQueue.queue.isPaused);
             sinon.assert.notCalled(jobQueue.queue.emit);
             sinon.assert.calledOnceWithExactly(
                 jobQueue.queue.add,
-                "a platform-an identifier",
+                title,
                 resultJob,
                 {
                     removeOnComplete: { age: 300 },
@@ -222,7 +246,7 @@ describe("JobQueue", () => {
             jobQueue.queue.isPaused.returns(true);
             try {
                 await jobQueue.add("a socket id", {
-                    platform: "a platform",
+                    "@context": TEST_CONTEXT,
                     id: "an identifier",
                 });
             } catch (err) {

--- a/packages/platform-feeds/src/index.ts
+++ b/packages/platform-feeds/src/index.ts
@@ -122,13 +122,21 @@ export default class Feeds implements PlatformInterface {
      *  // Example of the resulting JSON AS Object:
      *
      *   {
-     *     context: 'feeds',
+     *     '@context': [
+     *       'https://www.w3.org/ns/activitystreams',
+     *       'https://sockethub.org/ns/context/v1.jsonld',
+     *       'https://sockethub.org/ns/context/platform/feeds/v1.jsonld'
+     *     ],
      *     type: 'collection',
      *     summary: 'Best Feed Inc.'
      *     totalItems: 10,
      *     items: [
      *       {
-     *         context: 'feeds',
+     *         '@context': [
+     *           'https://www.w3.org/ns/activitystreams',
+     *           'https://sockethub.org/ns/context/v1.jsonld',
+     *           'https://sockethub.org/ns/context/platform/feeds/v1.jsonld'
+     *         ],
      *         type: 'post',
      *         actor: {
      *           type: 'feed',

--- a/packages/platform-irc/src/index.ts
+++ b/packages/platform-irc/src/index.ts
@@ -126,8 +126,12 @@ export default class IRC implements PersistentPlatformInterface {
      * @example
      *
      *  {
+     *    '@context': [
+     *      'https://www.w3.org/ns/activitystreams',
+     *      'https://sockethub.org/ns/context/v1.jsonld',
+     *      'https://sockethub.org/ns/context/platform/irc/v1.jsonld'
+     *    ],
      *    type: 'credentials',
-     *    context: 'irc',
      *    actor: {
      *      id: 'testuser@irc.host.net',
      *      type: 'person',
@@ -150,8 +154,12 @@ export default class IRC implements PersistentPlatformInterface {
      * @example
      *
      *  {
+     *    '@context': [
+     *      'https://www.w3.org/ns/activitystreams',
+     *      'https://sockethub.org/ns/context/v1.jsonld',
+     *      'https://sockethub.org/ns/context/platform/irc/v1.jsonld'
+     *    ],
      *    type: 'credentials',
-     *    context: 'irc',
      *    actor: {
      *      id: 'testuser@irc.libera.chat',
      *      type: 'person',
@@ -172,8 +180,12 @@ export default class IRC implements PersistentPlatformInterface {
      * @example
      *
      *  {
+     *    '@context': [
+     *      'https://www.w3.org/ns/activitystreams',
+     *      'https://sockethub.org/ns/context/v1.jsonld',
+     *      'https://sockethub.org/ns/context/platform/irc/v1.jsonld'
+     *    ],
      *    type: 'credentials',
-     *    context: 'irc',
      *    actor: {
      *      id: 'testuser@chat.sr.ht',
      *      type: 'person',
@@ -239,7 +251,11 @@ export default class IRC implements PersistentPlatformInterface {
      * @example
      *
      * {
-     *   context: 'irc',
+     *   '@context': [
+     *     'https://www.w3.org/ns/activitystreams',
+     *     'https://sockethub.org/ns/context/v1.jsonld',
+     *     'https://sockethub.org/ns/context/platform/irc/v1.jsonld'
+     *   ],
      *   type: 'join',
      *   actor: {
      *     id: 'slvrbckt@irc.freenode.net',
@@ -286,7 +302,11 @@ export default class IRC implements PersistentPlatformInterface {
      *
      * @example
      * {
-     *   context: 'irc',
+     *   '@context': [
+     *     'https://www.w3.org/ns/activitystreams',
+     *     'https://sockethub.org/ns/context/v1.jsonld',
+     *     'https://sockethub.org/ns/context/platform/irc/v1.jsonld'
+     *   ],
      *   type: 'leave',
      *   actor: {
      *     id: 'slvrbckt@irc.freenode.net',
@@ -326,7 +346,11 @@ export default class IRC implements PersistentPlatformInterface {
      * @example
      *
      *  {
-     *    context: 'irc',
+     *    '@context': [
+     *      'https://www.w3.org/ns/activitystreams',
+     *      'https://sockethub.org/ns/context/v1.jsonld',
+     *      'https://sockethub.org/ns/context/platform/irc/v1.jsonld'
+     *    ],
      *    type: 'send',
      *    actor: {
      *      id: 'slvrbckt@irc.freenode.net',
@@ -417,7 +441,11 @@ export default class IRC implements PersistentPlatformInterface {
      * @example change topic
      *
      * {
-     *   context: 'irc',
+     *   '@context': [
+     *     'https://www.w3.org/ns/activitystreams',
+     *     'https://sockethub.org/ns/context/v1.jsonld',
+     *     'https://sockethub.org/ns/context/platform/irc/v1.jsonld'
+     *   ],
      *   type: 'update',
      *   actor: {
      *     id: 'slvrbckt@irc.freenode.net',
@@ -438,7 +466,11 @@ export default class IRC implements PersistentPlatformInterface {
      *
      * @example change nickname
      *  {
-     *    context: 'irc'
+     *    '@context': [
+     *      'https://www.w3.org/ns/activitystreams',
+     *      'https://sockethub.org/ns/context/v1.jsonld',
+     *      'https://sockethub.org/ns/context/platform/irc/v1.jsonld'
+     *    ],
      *    type: 'update',
      *    actor: {
      *      id: 'slvrbckt@irc.freenode.net',
@@ -506,7 +538,11 @@ export default class IRC implements PersistentPlatformInterface {
      * @example
      *
      *  {
-     *    context: 'irc',
+     *    '@context': [
+     *      'https://www.w3.org/ns/activitystreams',
+     *      'https://sockethub.org/ns/context/v1.jsonld',
+     *      'https://sockethub.org/ns/context/platform/irc/v1.jsonld'
+     *    ],
      *    type: 'query',
      *    actor: {
      *      id: 'slvrbckt@irc.freenode.net',
@@ -527,7 +563,11 @@ export default class IRC implements PersistentPlatformInterface {
      *
      *  // The above object might return:
      *  {
-     *    context: 'irc',
+     *    '@context': [
+     *      'https://www.w3.org/ns/activitystreams',
+     *      'https://sockethub.org/ns/context/v1.jsonld',
+     *      'https://sockethub.org/ns/context/platform/irc/v1.jsonld'
+     *    ],
      *    type: 'query',
      *    actor: {
      *      id: 'irc.freenode.net/a-room',
@@ -575,7 +615,11 @@ export default class IRC implements PersistentPlatformInterface {
      * @example
      *
      * {
-     *    context: 'irc',
+     *    '@context': [
+     *      'https://www.w3.org/ns/activitystreams',
+     *      'https://sockethub.org/ns/context/v1.jsonld',
+     *      'https://sockethub.org/ns/context/platform/irc/v1.jsonld'
+     *    ],
      *    type: 'disconnect',
      *    actor: {
      *      id: 'slvrbckt@irc.freenode.net',

--- a/packages/platform-xmpp/API.md
+++ b/packages/platform-xmpp/API.md
@@ -114,8 +114,12 @@ Valid AS object for setting XMPP credentials:
 **Example**  
 ```js
 {
+  '@context': [
+    'https://www.w3.org/ns/activitystreams',
+    'https://sockethub.org/ns/context/v1.jsonld',
+    'https://sockethub.org/ns/context/platform/xmpp/v1.jsonld'
+  ],
   type: 'credentials',
-  context: 'xmpp',
   actor: {
     id: 'testuser@jabber.net',
     type: 'person',
@@ -213,7 +217,11 @@ Connect to the XMPP server.
 **Example**  
 ```js
 {
-  context: 'xmpp',
+  '@context': [
+    'https://www.w3.org/ns/activitystreams',
+    'https://sockethub.org/ns/context/v1.jsonld',
+    'https://sockethub.org/ns/context/platform/xmpp/v1.jsonld'
+  ],
   type: 'connect',
   actor: {
     id: 'slvrbckt@jabber.net/Home',
@@ -248,7 +256,11 @@ Join a room, optionally defining a display name for that room.
 **Example**  
 ```js
 {
-  context: 'xmpp',
+  '@context': [
+    'https://www.w3.org/ns/activitystreams',
+    'https://sockethub.org/ns/context/v1.jsonld',
+    'https://sockethub.org/ns/context/platform/xmpp/v1.jsonld'
+  ],
   type: 'join',
   actor: {
     type: 'person',
@@ -286,7 +298,11 @@ Leave a room
 **Example**  
 ```js
 {
-  context: 'xmpp',
+  '@context': [
+    'https://www.w3.org/ns/activitystreams',
+    'https://sockethub.org/ns/context/v1.jsonld',
+    'https://sockethub.org/ns/context/platform/xmpp/v1.jsonld'
+  ],
   type: 'leave',
   actor: {
     type: 'person',
@@ -324,7 +340,11 @@ Send a message to a room or private conversation.
 **Example**  
 ```js
 {
-  context: 'xmpp',
+  '@context': [
+    'https://www.w3.org/ns/activitystreams',
+    'https://sockethub.org/ns/context/v1.jsonld',
+    'https://sockethub.org/ns/context/platform/xmpp/v1.jsonld'
+  ],
   type: 'send',
   actor: {
     id: 'slvrbckt@jabber.net/Home',
@@ -344,7 +364,11 @@ Send a message to a room or private conversation.
 }
 
 {
-  context: 'xmpp',
+  '@context': [
+    'https://www.w3.org/ns/activitystreams',
+    'https://sockethub.org/ns/context/v1.jsonld',
+    'https://sockethub.org/ns/context/platform/xmpp/v1.jsonld'
+  ],
   type: 'send',
   actor: {
     id: 'slvrbckt@jabber.net/Home',
@@ -388,7 +412,11 @@ Valid presence values are "away", "chat", "dnd", "xa", "offline", "online".
 **Example**  
 ```js
 {
-  context: 'xmpp',
+  '@context': [
+    'https://www.w3.org/ns/activitystreams',
+    'https://sockethub.org/ns/context/v1.jsonld',
+    'https://sockethub.org/ns/context/platform/xmpp/v1.jsonld'
+  ],
   type: 'update',
   actor: {
     id: 'user@host.org/Home'
@@ -425,7 +453,11 @@ Send friend request
 **Example**  
 ```js
 {
-  context: 'xmpp',
+  '@context': [
+    'https://www.w3.org/ns/activitystreams',
+    'https://sockethub.org/ns/context/v1.jsonld',
+    'https://sockethub.org/ns/context/platform/xmpp/v1.jsonld'
+  ],
   type: 'request-friend',
   actor: {
     id: 'user@host.org/Home'
@@ -460,7 +492,11 @@ Send a remove friend request
 **Example**  
 ```js
 {
-  context: 'xmpp',
+  '@context': [
+    'https://www.w3.org/ns/activitystreams',
+    'https://sockethub.org/ns/context/v1.jsonld',
+    'https://sockethub.org/ns/context/platform/xmpp/v1.jsonld'
+  ],
   type: 'remove-friend',
   actor: {
     id: 'user@host.org/Home'
@@ -495,7 +531,11 @@ Confirm a friend request
 **Example**  
 ```js
 {
-  context: 'xmpp',
+  '@context': [
+    'https://www.w3.org/ns/activitystreams',
+    'https://sockethub.org/ns/context/v1.jsonld',
+    'https://sockethub.org/ns/context/platform/xmpp/v1.jsonld'
+  ],
   type: 'make-friend',
   actor: {
     id: 'user@host.org/Home'
@@ -530,7 +570,11 @@ Indicate an intent to query something (i.e. get a list of users in a room).
 **Example**  
 ```js
 {
-   context: 'xmpp',
+   '@context': [
+     'https://www.w3.org/ns/activitystreams',
+     'https://sockethub.org/ns/context/v1.jsonld',
+     'https://sockethub.org/ns/context/platform/xmpp/v1.jsonld'
+   ],
    type: 'query',
    actor: {
      id: 'slvrbckt@jabber.net/Home',
@@ -547,7 +591,11 @@ Indicate an intent to query something (i.e. get a list of users in a room).
 
  // The above object might return:
  {
-   context: 'xmpp',
+   '@context': [
+     'https://www.w3.org/ns/activitystreams',
+     'https://sockethub.org/ns/context/v1.jsonld',
+     'https://sockethub.org/ns/context/platform/xmpp/v1.jsonld'
+   ],
    type: 'query',
    actor: {
      id: 'PartyChatRoom@muc.jabber.net',
@@ -593,7 +641,11 @@ Disconnect XMPP client
 **Example**  
 ```js
 {
-   context: 'xmpp',
+   '@context': [
+     'https://www.w3.org/ns/activitystreams',
+     'https://sockethub.org/ns/context/v1.jsonld',
+     'https://sockethub.org/ns/context/platform/xmpp/v1.jsonld'
+   ],
    type: 'disconnect',
    actor: {
      id: 'slvrbckt@jabber.net/Home',

--- a/packages/platform-xmpp/src/index.js
+++ b/packages/platform-xmpp/src/index.js
@@ -170,8 +170,12 @@ export default class XMPP {
      * @example
      *
      * {
+     *   '@context': [
+     *     'https://www.w3.org/ns/activitystreams',
+     *     'https://sockethub.org/ns/context/v1.jsonld',
+     *     'https://sockethub.org/ns/context/platform/xmpp/v1.jsonld'
+     *   ],
      *   type: 'credentials',
-     *   context: 'xmpp',
      *   actor: {
      *     id: 'testuser@jabber.net',
      *     type: 'person',
@@ -210,7 +214,11 @@ export default class XMPP {
      * @example
      *
      * {
-     *   context: 'xmpp',
+     *   '@context': [
+     *     'https://www.w3.org/ns/activitystreams',
+     *     'https://sockethub.org/ns/context/v1.jsonld',
+     *     'https://sockethub.org/ns/context/platform/xmpp/v1.jsonld'
+     *   ],
      *   type: 'connect',
      *   actor: {
      *     id: 'slvrbckt@jabber.net/Home',
@@ -301,8 +309,9 @@ export default class XMPP {
 
             const errorType = this.__classifyError(err);
 
+            // `@context` is stamped by PlatformInstance.sendToClient before the
+            // payload leaves the platform process; platforms don't set it here.
             const as = {
-                context: "xmpp",
                 type: "connect",
                 actor: { id: job.actor.id },
             };
@@ -377,7 +386,11 @@ export default class XMPP {
      * @example
      *
      * {
-     *   context: 'xmpp',
+     *   '@context': [
+     *     'https://www.w3.org/ns/activitystreams',
+     *     'https://sockethub.org/ns/context/v1.jsonld',
+     *     'https://sockethub.org/ns/context/platform/xmpp/v1.jsonld'
+     *   ],
      *   type: 'join',
      *   actor: {
      *     type: 'person',
@@ -420,7 +433,11 @@ export default class XMPP {
      * @example
      *
      * {
-     *   context: 'xmpp',
+     *   '@context': [
+     *     'https://www.w3.org/ns/activitystreams',
+     *     'https://sockethub.org/ns/context/v1.jsonld',
+     *     'https://sockethub.org/ns/context/platform/xmpp/v1.jsonld'
+     *   ],
      *   type: 'leave',
      *   actor: {
      *     type: 'person',
@@ -464,7 +481,11 @@ export default class XMPP {
      * @example
      *
      * {
-     *   context: 'xmpp',
+     *   '@context': [
+     *     'https://www.w3.org/ns/activitystreams',
+     *     'https://sockethub.org/ns/context/v1.jsonld',
+     *     'https://sockethub.org/ns/context/platform/xmpp/v1.jsonld'
+     *   ],
      *   type: 'send',
      *   actor: {
      *     id: 'slvrbckt@jabber.net/Home',
@@ -484,7 +505,11 @@ export default class XMPP {
      * }
      *
      * {
-     *   context: 'xmpp',
+     *   '@context': [
+     *     'https://www.w3.org/ns/activitystreams',
+     *     'https://sockethub.org/ns/context/v1.jsonld',
+     *     'https://sockethub.org/ns/context/platform/xmpp/v1.jsonld'
+     *   ],
      *   type: 'send',
      *   actor: {
      *     id: 'slvrbckt@jabber.net/Home',
@@ -535,7 +560,11 @@ export default class XMPP {
      * @example
      *
      * {
-     *   context: 'xmpp',
+     *   '@context': [
+     *     'https://www.w3.org/ns/activitystreams',
+     *     'https://sockethub.org/ns/context/v1.jsonld',
+     *     'https://sockethub.org/ns/context/platform/xmpp/v1.jsonld'
+     *   ],
      *   type: 'update',
      *   actor: {
      *     id: 'user@host.org/Home'
@@ -581,7 +610,11 @@ export default class XMPP {
      * @example
      *
      * {
-     *   context: 'xmpp',
+     *   '@context': [
+     *     'https://www.w3.org/ns/activitystreams',
+     *     'https://sockethub.org/ns/context/v1.jsonld',
+     *     'https://sockethub.org/ns/context/platform/xmpp/v1.jsonld'
+     *   ],
      *   type: 'request-friend',
      *   actor: {
      *     id: 'user@host.org/Home'
@@ -613,7 +646,11 @@ export default class XMPP {
      * @example
      *
      * {
-     *   context: 'xmpp',
+     *   '@context': [
+     *     'https://www.w3.org/ns/activitystreams',
+     *     'https://sockethub.org/ns/context/v1.jsonld',
+     *     'https://sockethub.org/ns/context/platform/xmpp/v1.jsonld'
+     *   ],
      *   type: 'remove-friend',
      *   actor: {
      *     id: 'user@host.org/Home'
@@ -645,7 +682,11 @@ export default class XMPP {
      * @example
      *
      * {
-     *   context: 'xmpp',
+     *   '@context': [
+     *     'https://www.w3.org/ns/activitystreams',
+     *     'https://sockethub.org/ns/context/v1.jsonld',
+     *     'https://sockethub.org/ns/context/platform/xmpp/v1.jsonld'
+     *   ],
      *   type: 'make-friend',
      *   actor: {
      *     id: 'user@host.org/Home'
@@ -676,7 +717,11 @@ export default class XMPP {
      * @example
      *
      *  {
-     *    context: 'xmpp',
+     *    '@context': [
+     *      'https://www.w3.org/ns/activitystreams',
+     *      'https://sockethub.org/ns/context/v1.jsonld',
+     *      'https://sockethub.org/ns/context/platform/xmpp/v1.jsonld'
+     *    ],
      *    type: 'query',
      *    actor: {
      *      id: 'slvrbckt@jabber.net/Home',
@@ -693,7 +738,11 @@ export default class XMPP {
      *
      *  // The above object might return:
      *  {
-     *    context: 'xmpp',
+     *    '@context': [
+     *      'https://www.w3.org/ns/activitystreams',
+     *      'https://sockethub.org/ns/context/v1.jsonld',
+     *      'https://sockethub.org/ns/context/platform/xmpp/v1.jsonld'
+     *    ],
      *    type: 'query',
      *    actor: {
      *      id: 'PartyChatRoom@muc.jabber.net',
@@ -745,7 +794,11 @@ export default class XMPP {
      * @example
      *
      * {
-     *    context: 'xmpp',
+     *    '@context': [
+     *      'https://www.w3.org/ns/activitystreams',
+     *      'https://sockethub.org/ns/context/v1.jsonld',
+     *      'https://sockethub.org/ns/context/platform/xmpp/v1.jsonld'
+     *    ],
      *    type: 'disconnect',
      *    actor: {
      *      id: 'slvrbckt@jabber.net/Home',

--- a/packages/schemas/src/types.ts
+++ b/packages/schemas/src/types.ts
@@ -13,7 +13,6 @@ export interface ActivityStream {
     "@context": JsonLdContext;
     id?: string;
     type: string;
-    platform?: string;
     actor: ActivityActor;
     object?: ActivityObject;
     target?: ActivityActor;

--- a/packages/schemas/src/validator.ts
+++ b/packages/schemas/src/validator.ts
@@ -196,12 +196,8 @@ export function addPlatformContext(
 
 export function resolvePlatformId(msg: ActivityStream): string | null {
     const platformContextUrl = resolvePlatformContextUrl(msg);
-    if (platformContextUrl) {
-        const id = getPlatformIdByContextUrl(platformContextUrl);
-        if (id) return id;
+    if (!platformContextUrl) {
+        return null;
     }
-    if (typeof msg.platform === "string" && msg.platform) {
-        return msg.platform;
-    }
-    return null;
+    return getPlatformIdByContextUrl(platformContextUrl) ?? null;
 }

--- a/packages/server/src/middleware/create-activity-object.test.ts
+++ b/packages/server/src/middleware/create-activity-object.test.ts
@@ -13,14 +13,12 @@ describe("Middleware: createActivityObject", () => {
         createActivityObject(
             {
                 id: "test",
-                context: "foo",
                 type: "bar",
                 content: "some text",
             },
             (o) => {
                 expect(o).toEqual({
                     id: "test",
-                    context: "foo",
                     type: "bar",
                     content: "some text",
                 });

--- a/packages/server/src/middleware/credential-check.test.ts
+++ b/packages/server/src/middleware/credential-check.test.ts
@@ -1,17 +1,26 @@
-import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { afterEach, beforeAll, beforeEach, describe, expect, test } from "bun:test";
 import {
     CredentialsNotShareableError,
     type CredentialsStoreInterface,
     type CredentialsValidationOptions,
 } from "@sockethub/data-layer";
-import type { ActivityStream, CredentialsObject } from "@sockethub/schemas";
+import {
+    type ActivityStream,
+    addPlatformContext,
+    buildCanonicalContext,
+    type CredentialsObject,
+    resolvePlatformId,
+} from "@sockethub/schemas";
 
 import { getPlatformId } from "@sockethub/crypto";
 import { platformInstances } from "../platform-instance.js";
 import credentialCheck from "./credential-check.js";
 
+const IRC_CONTEXT_URL =
+    "https://sockethub.org/ns/context/platform/irc/v1.jsonld";
+
 const baseMessage: ActivityStream = {
-    context: "irc",
+    "@context": buildCanonicalContext(IRC_CONTEXT_URL),
     type: "connect",
     actor: { id: "nick@irc.example.com", type: "person" },
 };
@@ -20,7 +29,7 @@ function makeCredentials(
     object: CredentialsObject["object"],
 ): CredentialsObject {
     return {
-        context: "irc",
+        "@context": buildCanonicalContext(IRC_CONTEXT_URL),
         type: "credentials",
         actor: baseMessage.actor,
         object,
@@ -31,6 +40,15 @@ describe("Middleware: credentialCheck", () => {
     const socketId = "socket-1";
     const clientIp = "203.0.113.10";
     let store: CredentialsStoreInterface;
+    let platformKey: string;
+
+    beforeAll(() => {
+        addPlatformContext("irc", IRC_CONTEXT_URL);
+        platformKey = getPlatformId(
+            resolvePlatformId(baseMessage) ?? "",
+            baseMessage.actor.id,
+        );
+    });
 
     beforeEach(() => {
         platformInstances.clear();
@@ -67,9 +85,8 @@ describe("Middleware: credentialCheck", () => {
             expect(options).toEqual({ validateSessionShare: true });
             return makeCredentials({ type: "credentials", password: "abc123" });
         };
-        const key = getPlatformId(baseMessage.context, baseMessage.actor.id);
         platformInstances.set(
-            key,
+            platformKey,
             {
                 sessions: new Set(["socket-2"]),
                 sessionIps: new Map([["socket-2", clientIp]]),
@@ -86,9 +103,8 @@ describe("Middleware: credentialCheck", () => {
     test("allows when only this session is attached", async () => {
         store.get = async () =>
             makeCredentials({ type: "credentials", password: "abc123" });
-        const key = getPlatformId(baseMessage.context, baseMessage.actor.id);
         platformInstances.set(
-            key,
+            platformKey,
             {
                 sessions: new Set([socketId]),
                 sessionIps: new Map([[socketId, clientIp]]),
@@ -105,9 +121,8 @@ describe("Middleware: credentialCheck", () => {
     test("allows anonymous reconnect when prior session is stale and IP matches", async () => {
         store.get = async () =>
             Promise.reject(new CredentialsNotShareableError("username already in use"));
-        const key = getPlatformId(baseMessage.context, baseMessage.actor.id);
         platformInstances.set(
-            key,
+            platformKey,
             {
                 sessions: new Set(["socket-2"]),
                 sessionIps: new Map([["socket-2", clientIp]]),
@@ -129,9 +144,8 @@ describe("Middleware: credentialCheck", () => {
     test("blocks anonymous reconnect when prior session IP differs", async () => {
         store.get = async () =>
             Promise.reject(new CredentialsNotShareableError("username already in use"));
-        const key = getPlatformId(baseMessage.context, baseMessage.actor.id);
         platformInstances.set(
-            key,
+            platformKey,
             {
                 sessions: new Set(["socket-2"]),
                 sessionIps: new Map([["socket-2", "198.51.100.7"]]),
@@ -154,9 +168,8 @@ describe("Middleware: credentialCheck", () => {
     test("blocks anonymous reconnect when prior session is still active", async () => {
         store.get = async () =>
             Promise.reject(new CredentialsNotShareableError("username already in use"));
-        const key = getPlatformId(baseMessage.context, baseMessage.actor.id);
         platformInstances.set(
-            key,
+            platformKey,
             {
                 sessions: new Set(["socket-2"]),
                 sessionIps: new Map([["socket-2", clientIp]]),

--- a/packages/server/src/middleware/credential-check.ts
+++ b/packages/server/src/middleware/credential-check.ts
@@ -5,7 +5,7 @@ import {
     type CredentialsStoreInterface,
 } from "@sockethub/data-layer";
 import { createLogger } from "@sockethub/logger";
-import type { ActivityStream } from "@sockethub/schemas";
+import { type ActivityStream, resolvePlatformId } from "@sockethub/schemas";
 import type { MiddlewareNext } from "../middleware.js";
 import { platformInstances } from "../platform-instance.js";
 
@@ -25,8 +25,12 @@ export default function credentialCheck(
     );
 
     return (msg: ActivityStream, next: MiddlewareNext<ActivityStream>) => {
+        // `@context` is canonical by the time validate middleware has run.
+        // Fall back to an empty string so the lookup deterministically misses
+        // rather than blowing up on unresolved platform IDs.
+        const platformId = resolvePlatformId(msg) ?? "";
         const existing = platformInstances.get(
-            getPlatformId(msg.context, msg.actor.id),
+            getPlatformId(platformId, msg.actor.id),
         );
         const hasOtherSession =
             !!existing &&
@@ -62,7 +66,7 @@ export default function credentialCheck(
                     return;
                 }
 
-                const scope = `${msg.context}:${msg.actor.id}`;
+                const scope = `${platformId}:${msg.actor.id}`;
                 if (isExpectedCredentialValidationError(err)) {
                     sessionLog.info(
                         `credential share validation rejected for ${scope} (socketId=${socketId}, validateSessionShare=true)`,

--- a/packages/server/src/middleware/validate.test.data.ts
+++ b/packages/server/src/middleware/validate.test.data.ts
@@ -332,8 +332,12 @@ export default [
         },
     },
     {
-        name: "legacy context overrides unregistered @context",
-        valid: true,
+        // String `context` is only promoted to @context when @context is
+        // missing. If @context is present but unregistered, validation fails
+        // with the standard "not registered" error — legacy context no longer
+        // shadows an explicit @context.
+        name: "legacy context does not override unregistered @context",
+        valid: false,
         type: "message",
         input: {
             type: "echo",
@@ -345,17 +349,10 @@ export default [
             ],
             actor: { id: "irc://uuu@localhost", type: "person" },
         },
-        output: {
-            type: "echo",
-            context: "fakeplatform",
-            "@context": [
-                "https://www.w3.org/ns/activitystreams",
-                "https://sockethub.org/ns/context/v1.jsonld",
-                "https://sockethub.org/ns/context/platform/fakeplatform/v1.jsonld",
-            ],
-            platform: "fakeplatform",
-            actor: { id: "irc://uuu@localhost", type: "person" },
-        },
+        error:
+            "Error: platform context URL not registered with this Sockethub instance." +
+            " Unregistered platform @context value: " +
+            "https://sockethub.org/ns/context/platform/unknown/v1.jsonld",
     },
     {
         name: "message with wrong type",

--- a/packages/server/src/middleware/validate.test.data.ts
+++ b/packages/server/src/middleware/validate.test.data.ts
@@ -55,47 +55,6 @@ export default [
         output: "same",
     },
     {
-        name: "legacy context credentials",
-        valid: true,
-        type: "credentials",
-        input: {
-            id: "legacy-creds",
-            type: "credentials",
-            context: "fakeplatform",
-            actor: {
-                id: "dood@irc.freenode.net",
-                type: "person",
-                name: "dood",
-            },
-            object: {
-                type: "credentials",
-                user: "foo",
-                pass: "bar",
-            },
-        },
-        output: {
-            id: "legacy-creds",
-            type: "credentials",
-            context: "fakeplatform",
-            "@context": [
-                "https://www.w3.org/ns/activitystreams",
-                "https://sockethub.org/ns/context/v1.jsonld",
-                "https://sockethub.org/ns/context/platform/fakeplatform/v1.jsonld",
-            ],
-            platform: "fakeplatform",
-            actor: {
-                id: "dood@irc.freenode.net",
-                type: "person",
-                name: "dood",
-            },
-            object: {
-                type: "credentials",
-                user: "foo",
-                pass: "bar",
-            },
-        },
-    },
-    {
         name: "no type specified",
         valid: false,
         type: "credentials",
@@ -330,29 +289,6 @@ export default [
             ],
             actor: { id: "irc://uuu@localhost", type: "person" },
         },
-    },
-    {
-        // String `context` is only promoted to @context when @context is
-        // missing. If @context is present but unregistered, validation fails
-        // with the standard "not registered" error — legacy context no longer
-        // shadows an explicit @context.
-        name: "legacy context does not override unregistered @context",
-        valid: false,
-        type: "message",
-        input: {
-            type: "echo",
-            context: "fakeplatform",
-            "@context": [
-                "https://www.w3.org/ns/activitystreams",
-                "https://sockethub.org/ns/context/v1.jsonld",
-                "https://sockethub.org/ns/context/platform/unknown/v1.jsonld",
-            ],
-            actor: { id: "irc://uuu@localhost", type: "person" },
-        },
-        error:
-            "Error: platform context URL not registered with this Sockethub instance." +
-            " Unregistered platform @context value: " +
-            "https://sockethub.org/ns/context/platform/unknown/v1.jsonld",
     },
     {
         name: "message with wrong type",

--- a/packages/server/src/middleware/validate.ts
+++ b/packages/server/src/middleware/validate.ts
@@ -40,51 +40,16 @@ export default function validate(
         SOCKETHUB_BASE_CONTEXT_URL,
     ]);
 
-    const getLegacyContext = (stream: ActivityStream): string | undefined => {
-        const legacyContext = (stream as ActivityStream & { context?: unknown })
-            .context;
-        return typeof legacyContext === "string" ? legacyContext : undefined;
-    };
-
-    const getContextValues = (stream: ActivityStream): Array<string> => {
+    const getPlatformContextCandidates = (
+        stream: ActivityStream,
+    ): Array<string> => {
         if (!Array.isArray(stream["@context"])) {
             return [];
         }
         return stream["@context"].filter(
-            (value): value is string => typeof value === "string",
+            (value): value is string =>
+                typeof value === "string" && !baseContextUrls.has(value),
         );
-    };
-
-    const getPlatformContextCandidates = (
-        stream: ActivityStream,
-    ): Array<string> => {
-        return getContextValues(stream).filter(
-            (value) => !baseContextUrls.has(value),
-        );
-    };
-
-    const normalizeLegacyContext = (
-        stream: ActivityStream,
-        initObj: IInitObject,
-    ) => {
-        if (resolvePlatformId(stream)) {
-            return;
-        }
-        const legacyContext = getLegacyContext(stream);
-        if (!legacyContext) {
-            return;
-        }
-        const platformMeta = initObj.platforms.get(legacyContext);
-        if (!platformMeta) {
-            return;
-        }
-        const platformContextUrl =
-            platformMeta.contextUrl ||
-            `https://sockethub.org/ns/context/platform/${legacyContext}/v1.jsonld`;
-        // Intentionally mutate the incoming stream so legacy `context` payloads
-        // continue through canonical @context/platform validation paths.
-        stream["@context"] = buildCanonicalContext(platformContextUrl);
-        stream.platform = legacyContext;
     };
 
     let initObj = passedInitObj;
@@ -118,8 +83,25 @@ export default function validate(
                 );
             }
             const stream = msg as ActivityStream;
-            // Intentional mutation for backward compatibility with legacy `context`.
-            normalizeLegacyContext(stream, initObj);
+            // A string `context` is a platform-name alias for @context.
+            // Only promote it when @context is missing so an unregistered
+            // legacy name falls through to the standard "not registered"
+            // error below rather than shadowing a real @context.
+            if (!Array.isArray(stream["@context"])) {
+                const legacy = (
+                    stream as ActivityStream & { context?: unknown }
+                ).context;
+                if (typeof legacy === "string" && legacy.trim().length > 0) {
+                    const platformName = legacy.trim();
+                    const platformMeta = initObj.platforms.get(platformName);
+                    if (platformMeta) {
+                        stream["@context"] = buildCanonicalContext(
+                            platformMeta.contextUrl,
+                        );
+                        stream.platform = platformName;
+                    }
+                }
+            }
             const platformId = resolvePlatformId(stream);
             if (!platformId) {
                 const platformContextCandidates =

--- a/packages/server/src/middleware/validate.ts
+++ b/packages/server/src/middleware/validate.ts
@@ -7,7 +7,6 @@ import {
     type ActivityObject,
     type ActivityStream,
     AS2_BASE_CONTEXT_URL,
-    buildCanonicalContext,
     resolvePlatformId,
     SOCKETHUB_BASE_CONTEXT_URL,
     validateActivityObject,
@@ -83,25 +82,6 @@ export default function validate(
                 );
             }
             const stream = msg as ActivityStream;
-            // A string `context` is a platform-name alias for @context.
-            // Only promote it when @context is missing so an unregistered
-            // legacy name falls through to the standard "not registered"
-            // error below rather than shadowing a real @context.
-            if (!Array.isArray(stream["@context"])) {
-                const legacy = (
-                    stream as ActivityStream & { context?: unknown }
-                ).context;
-                if (typeof legacy === "string" && legacy.trim().length > 0) {
-                    const platformName = legacy.trim();
-                    const platformMeta = initObj.platforms.get(platformName);
-                    if (platformMeta) {
-                        stream["@context"] = buildCanonicalContext(
-                            platformMeta.contextUrl,
-                        );
-                        stream.platform = platformName;
-                    }
-                }
-            }
             const platformId = resolvePlatformId(stream);
             if (!platformId) {
                 const platformContextCandidates =
@@ -125,7 +105,6 @@ export default function validate(
                     ),
                 );
             }
-            stream.platform = platformId;
             if (type === "credentials") {
                 const err = validateCredentials(stream);
                 if (err) {

--- a/packages/server/src/platform-instance.test.ts
+++ b/packages/server/src/platform-instance.test.ts
@@ -177,7 +177,6 @@ describe("PlatformInstance", () => {
             sandbox.assert.calledOnce(socketMock.emit);
             sandbox.assert.calledWith(socketMock.emit, "message", {
                 foo: "this is a message object",
-                platform: "a platform name",
                 "@context": buildCanonicalContext(
                     INTERNAL_PLATFORM_CONTEXT_URL,
                 ),
@@ -197,17 +196,6 @@ describe("PlatformInstance", () => {
             expect(emittedMsg["@context"]).toEqual(
                 buildCanonicalContext(testContextUrl),
             );
-        });
-
-        it("strips legacy context field from outbound payloads", async () => {
-            await pi.sendToClient("my session id", {
-                type: "echo",
-                context: "dummy",
-                actor: { id: "test@dummy", type: "person" },
-            });
-            const emittedMsg = socketMock.emit.firstCall.args[1];
-            expect(emittedMsg.context).toBeUndefined();
-            expect(emittedMsg["@context"]).toBeDefined();
         });
 
         it("broadcasts to peers", async () => {
@@ -245,7 +233,9 @@ describe("PlatformInstance", () => {
                 expect(pi.broadcastToSharedPeers.callCount).toEqual(1);
                 sandbox.assert.calledWith(pi.sendToClient, "a session id", {
                     foo: "bar",
-                    platform: "a platform name",
+                    "@context": buildCanonicalContext(
+                        INTERNAL_PLATFORM_CONTEXT_URL,
+                    ),
                 });
             });
 
@@ -259,7 +249,9 @@ describe("PlatformInstance", () => {
                 sandbox.assert.calledWith(pi.sendToClient, "a session id", {
                     foo: "bar",
                     error: "a bad result message",
-                    platform: "a platform name",
+                    "@context": buildCanonicalContext(
+                        INTERNAL_PLATFORM_CONTEXT_URL,
+                    ),
                 });
             });
         });
@@ -388,7 +380,6 @@ describe("PlatformInstance", () => {
                     sessionId: "session123",
                     msg: {
                         type: "connect",
-                        platform: "xmpp",
                         actor: { id: "testuser@localhost", type: "person" },
                     },
                     title: "xmpp-1",
@@ -440,7 +431,6 @@ describe("PlatformInstance", () => {
                     sessionId: "session123",
                     msg: {
                         type: "connect",
-                        platform: "xmpp",
                         actor: { id: "testuser@localhost", type: "person" },
                     },
                     title: "xmpp-1",
@@ -459,7 +449,6 @@ describe("PlatformInstance", () => {
                     sessionId: "session456",
                     msg: {
                         type: "send",
-                        platform: "xmpp",
                         actor: { id: "testuser@localhost", type: "person" },
                     },
                     title: "xmpp-2",
@@ -500,7 +489,6 @@ describe("PlatformInstance", () => {
                     sessionId: "session123",
                     msg: {
                         type: "connect",
-                        platform: "xmpp",
                         actor: { id: "testuser@localhost", type: "person" },
                     },
                     title: "xmpp-1",
@@ -549,7 +537,6 @@ describe("PlatformInstance", () => {
                     sessionId: "session123",
                     msg: {
                         type: "connect",
-                        platform: "xmpp",
                         actor: { id: "testuser@localhost", type: "person" },
                     },
                     title: "xmpp-1",

--- a/packages/server/src/platform-instance.test.ts
+++ b/packages/server/src/platform-instance.test.ts
@@ -198,6 +198,17 @@ describe("PlatformInstance", () => {
             );
         });
 
+        it("strips legacy context field from outbound payloads", async () => {
+            await pi.sendToClient("my session id", {
+                type: "echo",
+                context: "dummy",
+                actor: { id: "test@dummy", type: "person" },
+            });
+            const emittedMsg = socketMock.emit.firstCall.args[1];
+            expect(emittedMsg.context).toBeUndefined();
+            expect(emittedMsg["@context"]).toBeDefined();
+        });
+
         it("broadcasts to peers", async () => {
             pi.sessions.add("other peer");
             pi.sessions.add("another peer");

--- a/packages/server/src/platform-instance.ts
+++ b/packages/server/src/platform-instance.ts
@@ -273,9 +273,17 @@ export default class PlatformInstance {
      * Strip internal-only transport metadata and stamp the canonical `@context`
      * before returning payloads to clients. Platforms may emit payloads without
      * a `@context`; the instance always knows which platform it represents.
+     *
+     * Any legacy `context` field is removed so outbound payloads carry only
+     * `@context` as the routing signal, regardless of what an internal platform
+     * emits.
      */
     private toExternalPayload(payload: ActivityStream): ActivityStream {
-        delete (payload as InternalActivityStream).sessionSecret;
+        const external = payload as InternalActivityStream & {
+            context?: unknown;
+        };
+        delete external.sessionSecret;
+        delete external.context;
         const contextUrl = this.contextUrl ?? INTERNAL_PLATFORM_CONTEXT_URL;
         payload["@context"] = buildCanonicalContext(contextUrl);
         return payload;

--- a/packages/server/src/platform-instance.ts
+++ b/packages/server/src/platform-instance.ts
@@ -244,22 +244,16 @@ export default class PlatformInstance {
     public async sendToClient(sessionId: string, msg: InternalActivityStream) {
         return this.getSocket(sessionId).then(
             (socket: Socket) => {
-                try {
-                    this.toExternalPayload(msg as ActivityStream);
-                } finally {
-                    const contextUrl =
-                        this.contextUrl ?? INTERNAL_PLATFORM_CONTEXT_URL;
-                    msg["@context"] = buildCanonicalContext(contextUrl);
-                    if (
-                        msg.type === "error" &&
-                        typeof msg.actor === "undefined" &&
-                        this.actor
-                    ) {
-                        // ensure an actor is present if not otherwise defined
-                        msg.actor = { id: this.actor, type: "unknown" };
-                    }
-                    socket.emit("message", msg as ActivityStream);
+                this.toExternalPayload(msg);
+                if (
+                    msg.type === "error" &&
+                    typeof msg.actor === "undefined" &&
+                    this.actor
+                ) {
+                    // ensure an actor is present if not otherwise defined
+                    msg.actor = { id: this.actor, type: "unknown" };
                 }
+                socket.emit("message", msg as ActivityStream);
             },
             (err) => this.log.error(`sendToClient ${String(err)}`),
         );
@@ -276,20 +270,14 @@ export default class PlatformInstance {
     }
 
     /**
-     * Remove internal-only transport metadata before returning payloads to clients.
+     * Strip internal-only transport metadata and stamp the canonical `@context`
+     * before returning payloads to clients. Platforms may emit payloads without
+     * a `@context`; the instance always knows which platform it represents.
      */
     private toExternalPayload(payload: ActivityStream): ActivityStream {
-        const external = payload as InternalActivityStream & {
-            context?: unknown;
-        };
-        delete external.sessionSecret;
-        delete external.context;
-        if (
-            typeof external.platform !== "string" ||
-            external.platform.length === 0
-        ) {
-            external.platform = this.name;
-        }
+        delete (payload as InternalActivityStream).sessionSecret;
+        const contextUrl = this.contextUrl ?? INTERNAL_PLATFORM_CONTEXT_URL;
+        payload["@context"] = buildCanonicalContext(contextUrl);
         return payload;
     }
 

--- a/packages/server/src/platform.test.ts
+++ b/packages/server/src/platform.test.ts
@@ -84,7 +84,6 @@ describe("platform.ts credential handling", () => {
                     "https://sockethub.org/ns/context/v1.jsonld",
                     "https://sockethub.org/ns/context/platform/xmpp/v1.jsonld",
                 ],
-                platform: "xmpp",
                 actor: { id: "testuser@localhost", type: "person" },
                 sessionSecret: "secret123",
             },


### PR DESCRIPTION
## Summary

Go fully canonical on `@context`. After this change, `@context` is the only platform-routing signal across the wire and inside internal activity streams — the legacy `platform` field and string `context` alias are removed entirely.

- **Schema (`@sockethub/schemas`)** — Drop `platform?: string` from `ActivityStream`. `resolvePlatformId()` only resolves via a registered `@context` URL; the `msg.platform` fallback is gone.
- **Server `validate` middleware** — Remove the inline string-context promotion and the `stream.platform = platformId` assignment. `@context` is the only accepted routing signal.
- **Server `credential-check` middleware** — Read the platform id via `resolvePlatformId(msg)` instead of `msg.context`.
- **Server `PlatformInstance.toExternalPayload`** — Always stamp the canonical `@context` from the instance's known `contextUrl`; no longer deletes a legacy `context` field or fills in a `platform` fallback. `sendToClient` simplified accordingly (no more try/finally).
- **Client `sendOutbound`** — Remove the promotion of `activity.platform` or string `activity.context` to `@context`. Callers that don't set `@context` must call `sockethub.contextFor(platform)` themselves (or rely on the schema-driven init from #1048).
- **Platform code** — XMPP stops setting `context: "xmpp"` on its internal error emission (the instance stamps `@context` before it leaves the process). JSDoc examples in IRC, XMPP, and feeds are updated to canonical `@context` arrays; `packages/platform-xmpp/API.md` is regenerated.
- **Browser integration tests** — New `platformIdFromContext()` helper in `shared-setup.js` extracts the platform id from `@context` arrays; assertions no longer read `msg.platform`.
- **Test data cleanup** — Remove the "legacy context credentials" fixture and the "legacy context does not override unregistered @context" case from `validate.test.data.ts`; remove the two client tests that covered string-context promotion.

Closes #1067.

## Breaking change

Outbound payloads must carry a canonical `@context` array. A string `context` is no longer promoted to `@context`, and the `platform` field is no longer part of the `ActivityStream` shape. Migration paths:

- Use `SockethubClient.contextFor(platform)` to build the canonical `@context` manually.
- Or rely on the schema-driven init introduced in #1048 to populate `@context` automatically.

## Test plan

- [x] `bun run lint` clean (Biome + markdownlint)
- [x] `bun run build` — all packages build
- [x] `bun test` — 413 pass, 0 fail
- [x] Integration tests updated to assert platform identity via `@context` (run in CI; local docker is non-functional)
- [x] `packages/platform-xmpp/API.md` regenerated from JSDoc