### PR TITLE
fix(platform-xmpp): correct runtime bugs in incoming handlers, cleanup and credentials

### DIFF
--- a/packages/platform-xmpp/src/incoming-handlers.js
+++ b/packages/platform-xmpp/src/incoming-handlers.js
@@ -79,7 +79,7 @@ export class IncomingHandlers {
                 target: this.session.actor,
             });
             this.session.log.debug(
-                `**** xmpp this.session.for ${this.session.actor.id} closed`,
+                `**** xmpp session for ${this.session.actor.id} closed`,
             );
         }
         if (
@@ -297,7 +297,7 @@ export class IncomingHandlers {
             if (query) {
                 const entries = query.getChildren("item");
                 for (const e in entries) {
-                    if (!entries.hasOwn(e)) {
+                    if (!Object.hasOwn(entries, e)) {
                         continue;
                     }
                     this.session.log.debug("STANZA ATTRS: ", entries[e].attrs);

--- a/packages/platform-xmpp/src/index.js
+++ b/packages/platform-xmpp/src/index.js
@@ -536,7 +536,9 @@ export default class XMPP {
     cleanup(done) {
         this.log.debug("cleanup");
         this.__initialized = false;
-        this.__client.stop();
+        if (this.__client && typeof this.__client.stop === "function") {
+            this.__client.stop();
+        }
         done();
     }
 

--- a/packages/platform-xmpp/src/index.test.js
+++ b/packages/platform-xmpp/src/index.test.js
@@ -541,12 +541,12 @@ describe("XMPP", () => {
 
         describe("#make-friend", () => {
             it("calls xmpp.js correctly", (done) => {
-                xp["remove-friend"](job["remove-friend"], () => {
+                xp["make-friend"](job["make-friend"], () => {
                     sinon.assert.calledOnce(xp.__client.send);
                     expect(xmlFake.getCall(0).args).toEqual([
                         "presence",
                         {
-                            type: "unsubscribe",
+                            type: "subscribe",
                             to: job["make-friend"].target["id"],
                         },
                     ]);

--- a/packages/platform-xmpp/src/utils.js
+++ b/packages/platform-xmpp/src/utils.js
@@ -1,12 +1,21 @@
 export const utils = {
     buildXmppCredentials: (credentials) => {
-        const [username, server] = credentials.object.userAddress.split("@");
+        const userAddress = credentials.object.userAddress;
+        if (typeof userAddress !== "string" || !userAddress.includes("@")) {
+            throw new Error(
+                "xmpp credentials.object.userAddress must be a JID in the form 'user@server'",
+            );
+        }
+        const [username, server] = userAddress.split("@");
+        if (!username || !server) {
+            throw new Error(
+                "xmpp credentials.object.userAddress is missing the username or server portion",
+            );
+        }
         const xmpp_creds = {
             service: credentials.object.server
                 ? credentials.object.server
-                : server
-                  ? server
-                  : undefined,
+                : server,
             username: username,
             password: credentials.object.password,
         };


### PR DESCRIPTION
## Findings addressed

From a recent code review of platform-xmpp:

1. `packages/platform-xmpp/src/incoming-handlers.js:300` calls `entries.hasOwn(e)` on the array returned by `query.getChildren("item")`. Arrays do not expose a `hasOwn` method, so this throws a `TypeError` and aborts the roster update loop the first time the server returns roster items.
2. `packages/platform-xmpp/src/index.js:539` calls `this.__client.stop()` from `cleanup()` without checking that `__client` exists. The process manager can invoke cleanup after a failed/aborted connect, in which case the throw escapes and prevents an orderly shutdown.
3. `packages/platform-xmpp/src/utils.js` blindly splits `credentials.object.userAddress` on `@`. A missing or malformed JID silently produces `undefined` for username/server and a `undefined:port` service string, surfaced later as cryptic xmpp.js failures.
4. `packages/platform-xmpp/src/index.test.js:542` declared a `describe("#make-friend")` block whose body actually called `xp["remove-friend"]` and asserted a `type: "unsubscribe"` stanza. The make-friend code path was completely untested.
5. `packages/platform-xmpp/src/incoming-handlers.js:82` logged `xmpp this.session.for ${...}` — a leftover from a refactor.

## Fixes

- Switch to `Object.hasOwn(entries, e)` so the roster loop survives real IQ responses.
- Guard the `__client.stop()` call with a typeof check so cleanup is idempotent.
- Validate `userAddress` up front and throw a clear error if it is missing or unparsable. Drop the `server ? server : undefined` ternary now that the empty case is rejected earlier.
- Rewrite the `#make-friend` test to invoke `make-friend` and assert the `type: "subscribe"` stanza.
- Correct the debug log to read `xmpp session for ...`.

## Issues prevented

- Roster updates silently stop working as soon as the server returns items.
- Crashes during shutdown when the underlying xmpp.js client never came up.
- Hard-to-diagnose `undefined:5222` style errors from misconfigured credentials.
- A whole code path (make-friend) appearing covered by tests while it was not.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced XMPP session cleanup to safely handle missing or incomplete client instances
  * Improved credential validation to catch invalid address formats early with descriptive error messages

* **Tests**
  * Updated test assertions to verify correct XMPP stanza generation for friend management operations

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sockethub/sockethub/pull/1075?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->