### PR TITLE
fix(platform-irc): return success for /me and guard PING after cleanup

### DIFF
--- a/packages/platform-irc/src/index.test.ts
+++ b/packages/platform-irc/src/index.test.ts
@@ -404,6 +404,72 @@ describe("Initialize IRC Platform", () => {
                 platform.completeJob();
             });
 
+            // Regression coverage for the /me handling: /me must report
+            // synchronous success without enqueueing a jobQueue handler.
+            // See the long comment in src/index.ts for the protocol-level
+            // reasoning (no echo-message capability => no incoming event
+            // for the sender's PRIVMSG/CTCP ACTION).
+            it("send() /me completes synchronously without queueing", async () => {
+                expect(platform.jobQueue.length).toEqual(0);
+                const meErr = await new Promise((resolve) => {
+                    platform.send(
+                        {
+                            "@context": IRC_CONTEXT,
+                            type: "send",
+                            actor: actor,
+                            object: { content: "/me waves" },
+                            target: targetRoom,
+                        } as ActivityStream,
+                        (err: unknown) => resolve(err),
+                    );
+                });
+                expect(meErr).toBeUndefined();
+                expect(platform.jobQueue.length).toEqual(0);
+            });
+
+            it("send() /me does not consume an in-flight job's handler", async () => {
+                // Queue a normal send first; do NOT complete it.
+                let normalDoneCalls = 0;
+                platform.send(
+                    {
+                        "@context": IRC_CONTEXT,
+                        type: "send",
+                        actor: actor,
+                        object: { content: "first message" },
+                        target: targetRoom,
+                    } as ActivityStream,
+                    () => {
+                        normalDoneCalls++;
+                    },
+                );
+                // Wait a tick for the async send path to push onto jobQueue.
+                await new Promise((r) => setImmediate(r));
+                expect(platform.jobQueue.length).toEqual(1);
+
+                // Now issue a /me. Its done callback should fire without
+                // touching the queued handler of the prior send.
+                const meErr = await new Promise((resolve) => {
+                    platform.send(
+                        {
+                            "@context": IRC_CONTEXT,
+                            type: "send",
+                            actor: actor,
+                            object: { content: "/me sneaks in" },
+                            target: targetRoom,
+                        } as ActivityStream,
+                        (err: unknown) => resolve(err),
+                    );
+                });
+                expect(meErr).toBeUndefined();
+                expect(normalDoneCalls).toEqual(0);
+                expect(platform.jobQueue.length).toEqual(1);
+
+                // Drain the normal send's handler explicitly.
+                platform.completeJob();
+                expect(normalDoneCalls).toEqual(1);
+                expect(platform.jobQueue.length).toEqual(0);
+            });
+
             it("update() topic", (done) => {
                 platform.update(
                     {

--- a/packages/platform-irc/src/index.ts
+++ b/packages/platform-irc/src/index.ts
@@ -243,6 +243,21 @@ export class IRC implements PersistentPlatformInterface {
                 const message = buildCommand(job.object.content);
                 // biome-ignore lint/style/useTemplate: IRC raw command formatting
                 client.raw("PRIVMSG " + job.target.name + " :" + message);
+                // /me intentionally reports synchronous success rather than
+                // going through the jobQueue + PING/PONG round-trip used by
+                // normal sends. This is safe because:
+                //   1. IRC servers do not echo PRIVMSG/CTCP ACTION back to
+                //      the sender unless the IRCv3 `echo-message` capability
+                //      is negotiated via CAP REQ.
+                //   2. This platform only requests `sasl` (see ircConnect:
+                //      `capabilities = { requires: ["sasl"] }`), so
+                //      `echo-message` is never enabled.
+                //   3. Therefore the outgoing PRIVMSG never re-enters
+                //      irc2as.input() via the `data` event, no `incoming`
+                //      event fires for the sender's actor, and completeJob
+                //      is not triggered as a side effect.
+                // If `echo-message` is ever enabled, the regular send path
+                // would also need refactoring to dedupe echoed PRIVMSGs.
                 return done();
             }
             if (job.object.type === "notice") {

--- a/packages/platform-irc/src/index.ts
+++ b/packages/platform-irc/src/index.ts
@@ -243,7 +243,7 @@ export class IRC implements PersistentPlatformInterface {
                 const message = buildCommand(job.object.content);
                 // biome-ignore lint/style/useTemplate: IRC raw command formatting
                 client.raw("PRIVMSG " + job.target.name + " :" + message);
-                return done("IRC commands temporarily disabled");
+                return done();
             }
             if (job.object.type === "notice") {
                 // attempt to send as raw command
@@ -595,7 +595,7 @@ export class IRC implements PersistentPlatformInterface {
 
         this.irc2as.events.on("ping", (timestamp: string) => {
             this.log.debug(`received PING at ${timestamp}`);
-            this.client.raw("PONG");
+            this.client?.raw("PONG");
         });
     }
 }


### PR DESCRIPTION
## Findings addressed

1. `packages/platform-irc/src/index.ts:240-246`: the `/me` branch builds a CTCP ACTION command, sends it via `client.raw(...)`, and then calls `done("IRC commands temporarily disabled")`. The message is delivered, but the caller is told the job failed. Client apps that emit /me actions see a phantom error for every successful send.
2. `packages/platform-irc/src/index.ts:596-599`: the `ping` handler attached to `irc2as.events` dereferences `this.client.raw(...)` directly. `cleanup()` (index.ts:358) sets `this.client = undefined`. A PING delivered while the underlying connection is finishing teardown therefore throws `TypeError: Cannot read properties of undefined (reading 'raw')`.

## Fixes

- Call `done()` after the raw PRIVMSG so /me reports success.
- Use `this.client?.raw("PONG")` so a late PING is a no-op instead of a crash.

## Issues prevented

- Spurious 'IRC commands temporarily disabled' errors surfaced to client apps for every working /me.
- Unhandled exception during disconnect that can take down the IRC platform child process.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * `/me`-style IRC messages no longer fail with a disabled-command error.
  * IRC ping handling is more robust when the client reference may be unset.

* **Tests**
  * Added regression tests to ensure `/me` sends complete immediately and don’t interfere with queued sends.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sockethub/sockethub/pull/1076?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->