### PR TITLE
fix(irc2as): correct test loop bound and emit ISO 8601 timestamps

### DIFF
--- a/.spelling
+++ b/.spelling
@@ -93,5 +93,15 @@ namespaces
 createLogger
 timestamps
 systemd
+pre-copied
+globals
+libera.chat
+nickserv
+oauth
+SourceHut's
+soju
+hackint
+hostname
+ejabberd
  - ./README.md
 v1.2

--- a/packages/client/README.md
+++ b/packages/client/README.md
@@ -11,7 +11,7 @@ automatic reconnection and credential replay.
 - `ActivityStreams` helpers and validation utilities
 - `contextFor(platform)` builds canonical `@context` arrays from server metadata
 - `ready()` promise and `ready`/`init_error` observability events
-- Automatic outbound queueing until initialization is complete
+- Automatic outbound queuing until initialization is complete
 - Auto-replay of credentials and connections on reconnect
 - A browser-ready bundle in `dist/`
 

--- a/packages/irc2as/src/as-emitter.js
+++ b/packages/irc2as/src/as-emitter.js
@@ -15,7 +15,7 @@ export class ASEmitter {
 
     emitEvent(code, asObject) {
         if (typeof asObject === "object" && !asObject.published) {
-            asObject.published = `${Date.now()}`;
+            asObject.published = new Date().toISOString();
         }
         this.events.emit(code, asObject);
     }

--- a/packages/irc2as/src/index.js
+++ b/packages/irc2as/src/index.js
@@ -269,7 +269,8 @@ export class IrcToActivityStreams {
                     },
                 };
                 break;
-            case TOPIC_SET_BY: // current topic set by
+            case TOPIC_SET_BY: {
+                // current topic set by
                 if (!this.__buffer[TOPIC_IS]) {
                     break;
                 }
@@ -289,6 +290,7 @@ export class IrcToActivityStreams {
                 ase.emitEvent(EVENT_INCOMING, this.__buffer[TOPIC_IS]);
                 delete this.__buffer[TOPIC_IS];
                 break;
+            }
 
             /** */
             case WHO:

--- a/packages/irc2as/src/index.js
+++ b/packages/irc2as/src/index.js
@@ -279,7 +279,10 @@ export class IrcToActivityStreams {
                     id: `${nick}@${this.server}`,
                     name: nick,
                 };
-                this.__buffer[TOPIC_IS].published = msg[0];
+                // IRC RPL_TOPICWHOTIME (333) timestamp is Unix epoch seconds; normalize to ISO 8601
+                this.__buffer[TOPIC_IS].published = new Date(
+                    Number.parseInt(msg[0], 10) * 1000,
+                ).toISOString();
                 ase.emitEvent(EVENT_INCOMING, this.__buffer[TOPIC_IS]);
                 delete this.__buffer[TOPIC_IS];
                 break;

--- a/packages/irc2as/src/index.js
+++ b/packages/irc2as/src/index.js
@@ -279,10 +279,13 @@ export class IrcToActivityStreams {
                     id: `${nick}@${this.server}`,
                     name: nick,
                 };
-                // IRC RPL_TOPICWHOTIME (333) timestamp is Unix epoch seconds; normalize to ISO 8601
-                this.__buffer[TOPIC_IS].published = new Date(
-                    Number.parseInt(msg[0], 10) * 1000,
-                ).toISOString();
+                // IRC RPL_TOPICWHOTIME (333) timestamp is Unix epoch seconds; normalize when valid
+                const topicSetEpochSeconds = Number.parseInt(msg[0], 10);
+                if (Number.isFinite(topicSetEpochSeconds)) {
+                    this.__buffer[TOPIC_IS].published = new Date(
+                        topicSetEpochSeconds * 1000,
+                    ).toISOString();
+                }
                 ase.emitEvent(EVENT_INCOMING, this.__buffer[TOPIC_IS]);
                 delete this.__buffer[TOPIC_IS];
                 break;

--- a/packages/irc2as/src/index.test.js
+++ b/packages/irc2as/src/index.test.js
@@ -23,7 +23,7 @@ function matchStream(done) {
         expect(typeof stream.published).toEqual("string");
         delete stream.published;
         let matched = false;
-        for (let i = 0; i <= TestData.length; i++) {
+        for (let i = 0; i < TestData.length; i++) {
             matched = equal(stream, TestData[i]);
             if (matched) {
                 // when matched, remove output entry from list


### PR DESCRIPTION
## Findings addressed

1. \`packages/irc2as/src/index.test.js:26\`: the \`matchStream\` helper looped \`for (let i = 0; i <= TestData.length; i++)\`, performing one extra iteration that compared the incoming stream against \`TestData[length]\` (\`undefined\`). The off-by-one weakened the assertion and could allow malformed streams to pass.
2. \`packages/irc2as/src/as-emitter.js:18\`: \`published\` was set to \`\${Date.now()}\`\`, a millisecond integer rendered as a string. ActivityStreams 2.0 specifies \`published\` as an \`xsd:dateTime\`, which downstream consumers parse as ISO 8601. The non-conformant value silently produces \`Invalid Date\` in clients.
3. \`packages/irc2as/src/index.js:282\` (RPL_TOPICWHOTIME 333 handler): the original code stored the raw IRC epoch string (\`msg[0]\`) directly in \`published\`. The fix converts it to ISO 8601, but \`Number.parseInt\` returns \`NaN\` when \`msg[0]\` is absent or non-numeric, causing \`new Date(NaN).toISOString()\` to throw a \`RangeError\` that would crash the platform worker. Added a \`Number.isFinite\` guard: leave \`published\` unset on an invalid timestamp so \`emitEvent\`'s fallback supplies the current time instead.
4. \`packages/irc2as/src/index.js:272\` (\`TOPIC_SET_BY\` case): the \`const\` declaration introduced by item 3 was unscoped inside the \`switch\`, violating the \`noSwitchDeclarations\` lint rule. Wrapped the case body in a block.

## Fixes

- Tighten the loop to \`i < TestData.length\` so every iteration compares against a real fixture.
- Use \`new Date().toISOString()\` for the \`published\` timestamp fallback in \`emitEvent\`.
- Normalize the RPL_TOPICWHOTIME (333) epoch to ISO 8601; skip the assignment and fall back to current time if the epoch is not a finite number.
- Wrap the \`TOPIC_SET_BY\` case body in a block to properly scope the new \`const\` declaration.

## Issues prevented

- A test harness that quietly accepts malformed streams.
- Spec-non-compliant ActivityStreams output that breaks date parsing in downstream consumers.
- A \`RangeError\` crash in the IRC platform worker when an IRC server sends a malformed or missing 333 timestamp.
- A \`noSwitchDeclarations\` lint failure blocking CI.