### PR TITLE
fix(activity-streams): correct global ASFactory name and remove stray console.log

### DIFF
--- a/packages/activity-streams/src/activity-streams.ts
+++ b/packages/activity-streams/src/activity-streams.ts
@@ -183,7 +183,6 @@ function validateObject(
         if (!specialObjs.includes(ao.type)) {
             // not defined as a special prop
             // don't know what to do with it, so throw error
-            console.log(ao);
             const receivedValue =
                 typeof ao[key] === "string" ? `"${ao[key]}"` : String(ao[key]);
             const err = `ActivityStreams validation failed: property "${key}" with value ${receivedValue} is not allowed on the "${type}" object of type "${ao.type}".`;
@@ -326,7 +325,7 @@ export function ASFactory(opts: ASFactoryOptions = {}): ASManager {
 }
 
 ((global: Record<string, unknown>) => {
-    global.ASFactor = ASFactory;
+    global.ASFactory = ASFactory;
 })(
     typeof globalThis === "object"
         ? (globalThis as Record<string, unknown>)


### PR DESCRIPTION
## Findings addressed

1. `packages/activity-streams/src/activity-streams.ts:329`: the browser global was assigned as `global.ASFactor = ASFactory` (missing trailing `y`). Any consumer relying on the documented global name resolved it to `undefined`.
2. `packages/activity-streams/src/activity-streams.ts:186`: a leftover `console.log(ao)` ran in the validation error path, dumping the offending object to stdout before throwing the descriptive error.

## Fixes

- Assign to `global.ASFactory`.
- Drop the stray `console.log`.

## Issues prevented

- Silent breakage of the browser-global usage pattern.
- Noisy log output on every validation failure.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Fixed a typo in global factory function registration that prevented proper initialization
* Removed debug logging from validation process to reduce unnecessary console output

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sockethub/sockethub/pull/1078?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->