### PR TITLE
fix(schemas): remove duplicate PlatformSession interface declaration

### DIFF
--- a/packages/schemas/src/types.ts
+++ b/packages/schemas/src/types.ts
@@ -190,9 +190,3 @@ export interface PersistentPlatformInterface extends PlatformInterface {
         done: PlatformCallback,
     ): void;
 }
-
-export interface PlatformSession {
-    log: Logger;
-    sendToClient: PlatformSendToClient;
-    updateActor: PlatformUpdateActor;
-}


### PR DESCRIPTION
## Findings addressed

`packages/schemas/src/types.ts` exported `PlatformSession` twice with identical members (lines 70 and 194). TypeScript merges duplicate exported interfaces silently, which means any future divergence between the two declarations would not produce a compile error and would mask intent.

## Fix

Remove the trailing duplicate; keep the original declaration above the `PlatformInterface`/`PlatformClass` definitions that reference it.

## Issues prevented

- Silent declaration merging hiding any future mismatch between the two definitions.
- Confusing duplicate jump-to-definition results in editors and generated docs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Minor code formatting cleanup with no impact to functionality or user experience.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sockethub/sockethub/pull/1079?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->