### PR TITLE
fix(server): correct shutdown, init retry, sentry log order, type cast, and test assertions

### DIFF
--- a/packages/data-layer/integration/redis.integration.ts
+++ b/packages/data-layer/integration/redis.integration.ts
@@ -51,10 +51,9 @@ describe("CredentialsStore", () => {
     });
 
     it("get non-existent value", async () => {
-        expect(async () => {
-            await store.get(actor, credsHash);
-            expect(false).toEqual(true);
-        }).toThrow(`credentials not found for ${actor}`);
+        await expect(store.get(actor, credsHash)).rejects.toThrow(
+            `credentials not found for ${actor}`,
+        );
     });
 
     it("save", async () => {

--- a/packages/server/src/bootstrap/init.ts
+++ b/packages/server/src/bootstrap/init.ts
@@ -86,7 +86,10 @@ export function printSettingsInfo(
 let initCalled = false;
 let initWaitCount = 0;
 let cancelWait: NodeJS.Timeout | undefined;
-const resolveQueue: Array<(init: IInitObject) => void> = [];
+const resolveQueue: Array<{
+    resolve: (init: IInitObject) => void;
+    reject: (reason?: unknown) => void;
+}> = [];
 
 export default async function getInitObject(
     initFunc: () => Promise<IInitObject> = __loadInit,
@@ -101,7 +104,12 @@ export default async function getInitObject(
                         if (initWaitCount > 10) {
                             clearInterval(cancelWait);
                             cancelWait = undefined;
-                            reject(new Error("failed to initialize"));
+                            const err = new Error("failed to initialize");
+                            reject(err);
+                            for (const queued of resolveQueue) {
+                                queued.reject(err);
+                            }
+                            resolveQueue.length = 0;
                             return;
                         }
                         initWaitCount++;
@@ -109,13 +117,14 @@ export default async function getInitObject(
                         clearInterval(cancelWait);
                         cancelWait = undefined;
                         resolve(init);
-                        for (const resolve of resolveQueue) {
-                            resolve(init);
+                        for (const queued of resolveQueue) {
+                            queued.resolve(init);
                         }
+                        resolveQueue.length = 0;
                     }
                 }, 1000);
             } else {
-                resolveQueue.push(resolve);
+                resolveQueue.push({ resolve, reject });
             }
         } else {
             initCalled = true;

--- a/packages/server/src/bootstrap/init.ts
+++ b/packages/server/src/bootstrap/init.ts
@@ -99,11 +99,15 @@ export default async function getInitObject(
                 cancelWait = setInterval(() => {
                     if (!init) {
                         if (initWaitCount > 10) {
-                            reject("failed to initialize");
+                            clearInterval(cancelWait);
+                            cancelWait = undefined;
+                            reject(new Error("failed to initialize"));
+                            return;
                         }
                         initWaitCount++;
                     } else {
                         clearInterval(cancelWait);
+                        cancelWait = undefined;
                         resolve(init);
                         for (const resolve of resolveQueue) {
                             resolve(init);

--- a/packages/server/src/config.test.ts
+++ b/packages/server/src/config.test.ts
@@ -1,8 +1,19 @@
-import { describe, expect, it } from "bun:test";
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
 
 import { Config } from "./config.js";
 
 describe("config", () => {
+    let originalEnv: NodeJS.ProcessEnv;
+
+    beforeEach(() => {
+        originalEnv = process.env;
+        process.env = { ...originalEnv };
+    });
+
+    afterEach(() => {
+        process.env = originalEnv;
+    });
+
     it("loads default values", () => {
         const config = new Config();
         expect(config).toHaveProperty("get");
@@ -11,14 +22,14 @@ describe("config", () => {
 
     it("host overrides from env", () => {
         const hostname = "a host string";
-        process.env = { HOST: hostname };
+        process.env.HOST = hostname;
         const config = new Config();
         expect(config).toHaveProperty("get");
         expect(config.get("sockethub:host")).toEqual(hostname);
     });
 
     it("defaults to redis config", () => {
-        process.env = { REDIS_URL: "" };
+        process.env.REDIS_URL = "";
         const config = new Config();
         expect(config).toHaveProperty("get");
         expect(config.get("redis")).toEqual({
@@ -30,7 +41,7 @@ describe("config", () => {
     });
 
     // it("redis url overridden by env var", () => {
-    //     process.env = { REDIS_URL: "foobar83" };
+    //     process.env.REDIS_URL = "foobar83";
     //     const config = new Config();
     //     expect(config).toHaveProperty("get");
     //     expect(config.get("redis")).toEqual({ url: "foobar83" });

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -58,20 +58,25 @@ export async function server() {
         process.exit(1);
     });
 
+    const gracefulShutdown = async (signal: string) => {
+        console.log(`Received ${signal} signal. Shutting down sockethub...`);
+        try {
+            await sockethub.shutdown();
+            process.exit(0);
+        } catch (err) {
+            const error = err instanceof Error ? err : new Error(String(err));
+            sentry.reportError(error);
+            console.error(error);
+            process.exit(1);
+        }
+    };
+
     process.once("SIGTERM", () => {
-        console.log("Received TERM signal. Exiting.");
-        process.exit(0);
+        gracefulShutdown("TERM");
     });
 
     process.once("SIGINT", () => {
-        console.log("Received INT signal. Exiting.");
-        process.exit(0);
-    });
-
-    process.once("exit", async () => {
-        console.log("sockethub shutdown...");
-        await sockethub.shutdown();
-        process.exit(0);
+        gracefulShutdown("INT");
     });
 
     try {

--- a/packages/server/src/listener.ts
+++ b/packages/server/src/listener.ts
@@ -129,7 +129,7 @@ class Listener {
     private startHttp() {
         this.http.listen(
             config.get("sockethub:port"),
-            config.get("sockethub:host") as number,
+            config.get("sockethub:host") as string,
             () => {
                 log.info(
                     `sockethub listening on ws://${config.get("sockethub:host")}:${config.get(

--- a/packages/server/src/middleware.test.ts
+++ b/packages/server/src/middleware.test.ts
@@ -56,7 +56,9 @@ describe("Middleware", () => {
             funcs.unshift(callback);
             for (let i = 1; i < funcs.length; i++) {
                 expect(funcs[i].calledOnce).toBeTrue();
-                expect(funcs[i].calledWith("foobar981", funcs[i - 1]));
+                expect(
+                    funcs[i].calledWith("some data", sinon.match.func),
+                ).toBeTrue();
             }
             done();
         });
@@ -175,7 +177,9 @@ describe("Middleware", () => {
             funcs.unshift(callback);
             for (let i = 1; i < funcs.length; i++) {
                 expect(funcs[i].calledOnce).toBeTrue();
-                expect(funcs[i].calledWith("foo", funcs[i - 1]));
+                expect(
+                    funcs[i].calledWith("some data", sinon.match.func),
+                ).toBeTrue();
             }
             expect(errorHandlerCalled).toBeFalse();
             done();

--- a/packages/server/src/middleware/create-activity-object.test.ts
+++ b/packages/server/src/middleware/create-activity-object.test.ts
@@ -3,11 +3,13 @@ import createActivityObject from "./create-activity-object.js";
 
 describe("Middleware: createActivityObject", () => {
     it("Calls activity.Object.create and fails with invalid property", async () => {
+        let callbackInvoked = false;
         expect(() => {
-            createActivityObject({ foo: "bar" }, (o) => {
-                expect(o).not.toEqual({ foo: "bar" });
+            createActivityObject({ foo: "bar" }, () => {
+                callbackInvoked = true;
             });
         }).toThrow("ActivityStreams validation failed: the \"object\" property requires an 'id' property. Example: { id: \"user@example.com\", type: \"person\" }");
+        expect(callbackInvoked).toBeFalse();
     });
     it("Calls activity.Object.create with incoming data", async () => {
         createActivityObject(

--- a/packages/server/src/middleware/expand-activity-stream.test.data.ts
+++ b/packages/server/src/middleware/expand-activity-stream.test.data.ts
@@ -154,7 +154,7 @@ export default [
         },
     },
     {
-        name: "expand unknown actor 2",
+        name: "expand unknown actor 3",
         type: "message",
         valid: "true",
         input: {
@@ -297,7 +297,7 @@ export default [
         },
     },
     {
-        name: "expand actor and target of unknowns",
+        name: "expand actor and target of unknowns with user@host",
         valid: true,
         type: "message",
         input: {

--- a/packages/server/src/sentry.ts
+++ b/packages/server/src/sentry.ts
@@ -10,8 +10,8 @@ const logger = createLogger("sentry");
 if (!config.get("sentry:dsn")) {
     throw new Error("Sentry attempted initialization with no DSN provided");
 }
-logger.info("initialized sentry");
 Sentry.init(config.get("sentry"));
+logger.info("initialized sentry");
 
 export function reportError(err: Error): void {
     logger.warn("reporting error");


### PR DESCRIPTION
## Findings addressed

Bug fixes:
1. `packages/server/src/index.ts:60-75` — `SIGINT`/`SIGTERM` handlers called `process.exit(0)` directly, skipping `Sockethub.shutdown()`. The `process.once('exit', async ...)` handler tried to do the shutdown work but the `exit` event does not wait for async work, so the await was effectively dead code.
2. `packages/server/src/bootstrap/init.ts:99-112` — the polling interval rejected with a bare string (`'failed to initialize'`) instead of an `Error`, and never cleared the interval after rejection. The timer kept firing and `initWaitCount` grew unbounded.
3. `packages/server/src/sentry.ts:13` — logged `'initialized sentry'` before `Sentry.init()` was called.
4. `packages/server/src/listener.ts:132` — cast `config.get('sockethub:host')` as `number` even though the value is a string in the config and every code path.

Test correctness:
5. `packages/server/src/config.test.ts:14,21` — `process.env = { HOST: hostname }` (and similar for `REDIS_URL`) wiped every other env var for the rest of the process. Tests that ran afterwards saw an empty environment.
6. `packages/server/src/middleware.test.ts:59,178` — `expect(funcs[i].calledWith('foobar981', funcs[i - 1]))` was called without a matcher. The expression is a boolean discarded by `expect()`, so the assertion was a no-op. The literal string also did not match what was actually passed (`'some data'`), and `funcs[i - 1]` is the raw spy, not the wrapper that the middleware actually passes.
7. `packages/server/src/middleware/create-activity-object.test.ts:5-11` — the inner callback contained `expect(o).not.toEqual({ foo: 'bar' })` but `createActivityObject` throws before invoking the callback, so the assertion was unreachable.
8. `packages/server/src/middleware/expand-activity-stream.test.data.ts:157,300` — two pairs of fixtures shared identical `name` values (`'expand unknown actor 2'` and `'expand actor and target of unknowns'`), making test failures ambiguous.
9. `packages/data-layer/integration/redis.integration.ts:53-58` — `expect(async () => { ... }).toThrow(...)`. Async functions return a Promise and never throw synchronously, so `toThrow` never observed the rejection.

## Fixes

- Replace SIGINT/SIGTERM/'exit' handlers with a single `gracefulShutdown()` that awaits `Sockethub.shutdown()` before exiting.
- Reject the init promise with `new Error(...)`, `clearInterval` and `return` out of the tick when the wait count is exceeded.
- Swap `Sentry.init(...)` and the `'initialized sentry'` log so the log reflects reality.
- Cast `sockethub:host` as `string`.
- Snapshot and restore `process.env` in `config.test.ts` via `beforeEach`/`afterEach`; mutate the snapshot rather than replacing it.
- Replace the bogus `calledWith` checks in `middleware.test.ts` with `calledWith('some data', sinon.match.func)` wrapped in `expect(...).toBeTrue()`.
- Replace the unreachable callback assertion in `create-activity-object.test.ts` with an explicit `callbackInvoked` flag.
- Rename duplicate fixture `name` values.
- Use `await expect(promise).rejects.toThrow(...)` in the redis integration test.

## Issues prevented

- Sockethub never running its shutdown path on Ctrl+C, leaving queues/connections in an inconsistent state.
- Bootstrap init that has timed out continuing to spin a timer for the rest of the process lifetime.
- Misleading log line that says Sentry is initialized before it actually is.
- Wrong type annotation propagating into IDEs/tooling.
- A whole config-test process whose environment is wiped, masking other tests' env-dependent behaviour.
- Three test assertions that silently passed regardless of behaviour.
- Ambiguous duplicate test names that hide which fixture actually failed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved graceful shutdown on termination signals with error reporting
  * Enhanced initialization retry logic with proper cleanup and clear error rejection
  * Fixed host configuration handling and listener startup typing
  * Adjusted Sentry initialization ordering for clearer logging

* **Tests**
  * Strengthened environment isolation and updated test assertions (credentials store, middleware, activity validation)
  * Minor test-data renames and assertion tightening across suites

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sockethub/sockethub/pull/1080?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->