### PR TITLE
fix(data-layer): sanitize redis URL credentials before logging

### DIFF
--- a/packages/data-layer/src/index.ts
+++ b/packages/data-layer/src/index.ts
@@ -20,9 +20,22 @@ export * from "./types.js";
 
 import type { RedisConfig } from "./types.js";
 
+function sanitizeRedisUrl(url: string): string {
+    try {
+        const parsed = new URL(url);
+        if (parsed.username || parsed.password) {
+            parsed.username = parsed.username ? "***" : parsed.username;
+            parsed.password = parsed.password ? "***" : parsed.password;
+        }
+        return parsed.toString();
+    } catch {
+        return url;
+    }
+}
+
 async function redisCheck(config: RedisConfig): Promise<void> {
     const log = createLogger("data-layer:redis-check");
-    log.debug(`checking redis connection ${config.url}`);
+    log.debug(`checking redis connection ${sanitizeRedisUrl(config.url)}`);
     await verifySecureStore(config);
     await verifyJobQueue(config);
 }

--- a/packages/data-layer/src/index.ts
+++ b/packages/data-layer/src/index.ts
@@ -23,13 +23,16 @@ import type { RedisConfig } from "./types.js";
 function sanitizeRedisUrl(url: string): string {
     try {
         const parsed = new URL(url);
-        if (parsed.username || parsed.password) {
-            parsed.username = parsed.username ? "***" : parsed.username;
-            parsed.password = parsed.password ? "***" : parsed.password;
+        if (parsed.username) {
+            parsed.username = "***";
+        }
+        if (parsed.password) {
+            parsed.password = "***";
         }
         return parsed.toString();
     } catch {
-        return url;
+        // Parse failure: do not leak the original URL, which may contain credentials.
+        return "<redis-url:unparseable>";
     }
 }
 


### PR DESCRIPTION
## Finding addressed

`packages/data-layer/src/index.ts:25` logged the raw Redis connection URL at debug level: `log.debug(\`checking redis connection ${config.url}\`)`. A managed Redis deployment that uses a URL like `redis://user:password@host:6379` would put those credentials into the application log file and any downstream log aggregator that ingests it.

## Fix

Add a small `sanitizeRedisUrl` helper that parses the URL, masks the username and password components when present, and logs the sanitized form. If parsing fails the original string is returned so we never lose diagnostic context.

## Issue prevented

Plaintext Redis credentials being written to log files and any centralised logging pipeline.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Debug logs no longer expose Redis credentials; connection URLs are sanitized and redact username/password.
  * Unparseable Redis URLs are replaced with a safe placeholder in logs to avoid leaking raw input.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sockethub/sockethub/pull/1081?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->