### PR TITLE
fix(platform-feeds): compare pubDate and date by value, not reference

### DIFF
--- a/packages/platform-feeds/src/index.test.ts
+++ b/packages/platform-feeds/src/index.test.ts
@@ -1,6 +1,6 @@
 import { beforeEach, describe, expect, it } from "bun:test";
 import { RSSFeed} from "./index.test.data";
-import Feeds, { datesEqual } from "./index";
+import Feeds, { buildFeedItem, datesEqual } from "./index";
 import { ASCollection, PlatformSession } from "@sockethub/schemas";
 
 describe("datesEqual", () => {
@@ -30,6 +30,59 @@ describe("datesEqual", () => {
     it("falls back to string equality when both are unparseable", () => {
         expect(datesEqual("not-a-date", "not-a-date")).toBe(true);
         expect(datesEqual("not-a-date", "other-junk")).toBe(false);
+    });
+});
+
+describe("buildFeedItem", () => {
+    const baseItem: Parameters<typeof buildFeedItem>[0] = {
+        title: "Item",
+        description: "Body",
+        summary: "Body",
+        meta: {
+            title: "Feed",
+            description: "",
+            language: "en",
+            author: { name: "Author" },
+            summary: "",
+            type: "rss",
+            owner: { name: "Owner", email: "owner@example.com" },
+            image: { url: "", link: "", title: "" },
+            explicit: false,
+            lastBuildDate: "2024-01-01T00:00:00.000Z",
+            pubDate: "2024-01-01T00:00:00.000Z",
+            link: "http://example.com/feed",
+            links: [],
+        },
+        pubDate: "2024-01-01T00:00:00.000Z",
+        date: "2024-01-01T00:00:00.000Z",
+        categories: [],
+        media: [],
+        source: "feed-source",
+        author: "Author",
+        episodeType: undefined,
+        guid: "guid-1",
+        duration: 0,
+        enclosure: undefined,
+        link: "http://example.com/item",
+    } as Parameters<typeof buildFeedItem>[0];
+
+    it("omits updated when pubDate and date represent the same instant", () => {
+        const result = buildFeedItem({
+            ...baseItem,
+            date: new Date("2024-01-01T00:00:00.000Z") as unknown as string,
+        });
+
+        expect(result.published).toEqual("2024-01-01T00:00:00.000Z");
+        expect(result.updated).toBeUndefined();
+    });
+
+    it("preserves updated when pubDate and date differ", () => {
+        const result = buildFeedItem({
+            ...baseItem,
+            date: "2024-01-01T00:00:01.000Z",
+        });
+
+        expect(result.updated).toEqual("2024-01-01T00:00:01.000Z");
     });
 });
 

--- a/packages/platform-feeds/src/index.test.ts
+++ b/packages/platform-feeds/src/index.test.ts
@@ -1,7 +1,37 @@
 import { beforeEach, describe, expect, it } from "bun:test";
 import { RSSFeed} from "./index.test.data";
-import Feeds from "./index";
+import Feeds, { datesEqual } from "./index";
 import { ASCollection, PlatformSession } from "@sockethub/schemas";
+
+describe("datesEqual", () => {
+    it("treats two null/undefined as equal", () => {
+        expect(datesEqual(null, undefined)).toBe(true);
+        expect(datesEqual(undefined, null)).toBe(true);
+    });
+
+    it("treats one nullish and one defined as unequal", () => {
+        expect(datesEqual(null, new Date())).toBe(false);
+        expect(datesEqual("2024-01-01T00:00:00Z", undefined)).toBe(false);
+    });
+
+    it("compares Date instances by getTime (preserves ms)", () => {
+        const a = new Date("2024-01-01T00:00:00.123Z");
+        const b = new Date("2024-01-01T00:00:00.123Z");
+        const c = new Date("2024-01-01T00:00:00.456Z");
+        expect(datesEqual(a, b)).toBe(true);
+        expect(datesEqual(a, c)).toBe(false);
+    });
+
+    it("compares string and Date pointing to same instant as equal", () => {
+        const iso = "2024-01-01T00:00:00.000Z";
+        expect(datesEqual(iso, new Date(iso))).toBe(true);
+    });
+
+    it("falls back to string equality when both are unparseable", () => {
+        expect(datesEqual("not-a-date", "not-a-date")).toBe(true);
+        expect(datesEqual("not-a-date", "other-junk")).toBe(false);
+    });
+});
 
 describe("platform-feeds", () => {
     let platform;

--- a/packages/platform-feeds/src/index.ts
+++ b/packages/platform-feeds/src/index.ts
@@ -191,7 +191,7 @@ export function datesEqual(a: unknown, b: unknown): boolean {
     return at === bt;
 }
 
-function buildFeedItem(item: FeedItem): PlatformFeedsActivityObject {
+export function buildFeedItem(item: FeedItem): PlatformFeedsActivityObject {
     const dateNum = Date.parse(item.pubDate.toString()) || 0;
     return {
         type:

--- a/packages/platform-feeds/src/index.ts
+++ b/packages/platform-feeds/src/index.ts
@@ -175,6 +175,21 @@ interface FeedItem extends Episode {
     source: string;
 }
 
+function datesEqual(a: unknown, b: unknown): boolean {
+    if (a == null && b == null) {
+        return true;
+    }
+    if (a == null || b == null) {
+        return false;
+    }
+    const at = Date.parse(String(a));
+    const bt = Date.parse(String(b));
+    if (Number.isNaN(at) || Number.isNaN(bt)) {
+        return String(a) === String(b);
+    }
+    return at === bt;
+}
+
 function buildFeedItem(item: FeedItem): PlatformFeedsActivityObject {
     const dateNum = Date.parse(item.pubDate.toString()) || 0;
     return {
@@ -189,7 +204,7 @@ function buildFeedItem(item: FeedItem): PlatformFeedsActivityObject {
         contentType: isHtml(item.description || "") ? "html" : "text",
         url: item.link || item.meta.link,
         published: item.pubDate,
-        updated: item.pubDate === item.date ? undefined : item.date,
+        updated: datesEqual(item.pubDate, item.date) ? undefined : item.date,
         datenum: dateNum,
         tags: item.categories,
         media: item.media,

--- a/packages/platform-feeds/src/index.ts
+++ b/packages/platform-feeds/src/index.ts
@@ -175,15 +175,16 @@ interface FeedItem extends Episode {
     source: string;
 }
 
-function datesEqual(a: unknown, b: unknown): boolean {
+export function datesEqual(a: unknown, b: unknown): boolean {
     if (a == null && b == null) {
         return true;
     }
     if (a == null || b == null) {
         return false;
     }
-    const at = Date.parse(String(a));
-    const bt = Date.parse(String(b));
+    // Prefer Date.getTime() for Date instances; String(date)+Date.parse loses ms.
+    const at = a instanceof Date ? a.getTime() : Date.parse(String(a));
+    const bt = b instanceof Date ? b.getTime() : Date.parse(String(b));
     if (Number.isNaN(at) || Number.isNaN(bt)) {
         return String(a) === String(b);
     }


### PR DESCRIPTION
## Finding addressed

`packages/platform-feeds/src/index.ts:192` decided whether to include an `updated` field via `item.pubDate === item.date ? undefined : item.date`. The two values come from feedparser as either Date objects or strings. Even when they represent the same moment they are different references / differently formatted strings, so strict equality is essentially never true. Every feed item ends up exposing both `published` and `updated` fields even when the source feed only provided a single timestamp.

## Fix

Add a small `datesEqual` helper that normalises both inputs through `Date.parse` and compares the resulting millisecond values, with sensible fallbacks for unparseable strings and nullish inputs.

## Issue prevented

Redundant `updated` timestamps on every published feed item, and downstream consumers re-rendering or re-fetching content because pubDate and updated look different on every poll.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved date-comparison logic used when determining whether feed items are considered "updated", correctly handling null/undefined, Date objects, and diverse date string formats so feed update status is more accurate across sources.
* **Tests**
  * Added test coverage for date comparison scenarios (nullish values, Date instances, parseable and unparseable strings) to prevent regressions.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sockethub/sockethub/pull/1082?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->