### PR TITLE
chore: correct package metadata and a README typo

### DIFF
--- a/packages/crypto/package.json
+++ b/packages/crypto/package.json
@@ -27,17 +27,16 @@
   "keywords": [
     "sockethub",
     "messaging",
-    "redis",
-    "data lyer",
-    "rpc",
-    "data store"
+    "crypto",
+    "encryption",
+    "cryptography"
   ],
   "repository": {
     "type": "git",
     "url": "git+https://github.com/sockethub/sockethub.git",
-    "directory": "packages/data-layer"
+    "directory": "packages/crypto"
   },
-  "homepage": "https://github.com/sockethub/sockethub/tree/master/packages/data-layer",
+  "homepage": "https://github.com/sockethub/sockethub/tree/master/packages/crypto",
   "scripts": {
     "build": "bun build src/index.ts --outdir dist --target node --format esm --sourcemap=external",
     "clean": "rm -rf dist",

--- a/packages/server/README.md
+++ b/packages/server/README.md
@@ -83,7 +83,7 @@ Default: `localhost`
 - REDIS_URL
 
 Overrides `REDIS_HOST` and `REDIS_PORT`, can specify a full redis connect URL
-(eq. `redis://username:password@host:port`)
+(e.g. `redis://username:password@host:port`)
 
 #### Sentry Configuration
 

--- a/packages/sockethub/package.json
+++ b/packages/sockethub/package.json
@@ -33,7 +33,7 @@
   "repository": {
     "type": "git",
     "url": "git+https://github.com/sockethub/sockethub.git",
-    "directory": "apps/sockethub"
+    "directory": "packages/sockethub"
   },
   "homepage": "https://sockethub.org",
   "dependencies": {


### PR DESCRIPTION
## Findings addressed

1. `packages/crypto/package.json` was carrying metadata copied verbatim from `packages/data-layer/package.json`: a `data lyer` (sic) keyword in the list, `repository.directory` set to `packages/data-layer`, and a `homepage` URL pointing at the data-layer subtree on GitHub. npm and GitHub therefore linked from the crypto package to the wrong source directory.
2. `packages/sockethub/package.json` listed `repository.directory` as `apps/sockethub`. The package lives under `packages/sockethub` since the monorepo restructure, so the npm 'Repository' link 404s.
3. `packages/server/README.md:86` documented the Redis URL format as `(eq. redis://...)` where it clearly meant `e.g.`.

## Fixes

- Replace the crypto keywords with crypto-appropriate values (`crypto`, `encryption`, `cryptography`) and point `repository.directory` and `homepage` at `packages/crypto`.
- Update `sockethub` package's `repository.directory` to `packages/sockethub`.
- Change `eq.` to `e.g.` in the server README.

## Issues prevented

- npm and GitHub showing the wrong source location for the crypto and sockethub packages.
- Broken `Repository` deep links in the npm UI.
- A small but visible English typo in the public-facing README.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated package metadata including keywords and repository directory references across crypto and sockethub packages.
  * Corrected repository directory paths in package configurations to align with actual locations.
  * Improved documentation formatting in environment variable sections.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sockethub/sockethub/pull/1083?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->