### PR TITLE
test: replace external irc.libera.chat with local ergo server

### DIFF
--- a/integration/browser/basic.integration.js
+++ b/integration/browser/basic.integration.js
@@ -345,7 +345,7 @@ describe(`Sockethub Basic Integration Tests at ${config.sockethub.url}`, () => {
             });
 
             describe("IRC with invalid credentials", () => {
-                const invalidIrcActorId = "baduser@irc.libera.chat";
+                const invalidIrcActorId = `baduser@${config.irc.host}`;
 
                 it("should handle IPC channel closure gracefully with IRC wrong credentials", async () => {
                     // Set invalid IRC credentials
@@ -363,8 +363,9 @@ describe(`Sockethub Basic Integration Tests at ${config.sockethub.url}`, () => {
                                 type: "credentials",
                                 nick: "baduser",
                                 password: "wrong_password_456",
-                                server: "irc.libera.chat",
-                                port: 6667,
+                                server: config.irc.host,
+                                port: config.irc.port,
+                                secure: false,
                             },
                         },
                         { label: "irc invalid credentials" },


### PR DESCRIPTION
## Summary

- The \"IRC with invalid credentials\" browser integration test was hardcoded to `irc.libera.chat` — a real external IRC network
- The ack is only sent after the platform worker calls `done()`, which requires the TCP connection to complete; if the external server is unreachable or slow, the 2000ms ack timeout fires
- This caused both #1077 and #1080 to fail when their master-sync commits triggered fresh CI runs at a moment when `irc.libera.chat` was slow from GitHub Actions

## Changes

- Replace `server: "irc.libera.chat"` / `port: 6667` with `config.irc.host` / `config.irc.port` (the local ergo container already running in every Integration job)
- Add `secure: false` — ergo listens plaintext on 6667; the platform defaults `secure` to `true` which would try TLS on the wrong port (documented in `setIRCCredentials`)
- Update `invalidIrcActorId` to reflect the local host

## Test plan

- [ ] Integration / browser job passes: the SASL auth failure against local ergo completes in milliseconds, well within the 2000ms ack timeout
- [ ] No other integration tests regress: the fix is confined to one test block
- [ ] `incomingMessages` queue test still passes: failed connections do not trigger push events (platform listeners are only registered on successful connect)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Tests**
  * Updated integration tests to use configurable IRC server settings instead of hardcoded values, improving test flexibility and maintainability.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sockethub/sockethub/pull/1084?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->