### PR TITLE
fix(activity-streams): allow XMPP message correction metadata

### DIFF
--- a/packages/activity-streams/src/activity-streams.test.ts
+++ b/packages/activity-streams/src/activity-streams.test.ts
@@ -204,6 +204,23 @@ describe("basic tests", () => {
                 });
             }).toThrow('ActivityStreams validation failed: property "foo" with value "bar" is not allowed on the "object" object of type "hola".');
         });
+
+        test("allows XMPP message correction metadata", () => {
+            expect(() => {
+                activity.Stream({
+                    type: "send",
+                    "@context": IRC_CONTEXT,
+                    actor: "thingy",
+                    object: {
+                        type: "message",
+                        id: "new-message-id",
+                        content: "corrected message",
+                        "xmpp:replace": { id: "old-message-id" },
+                    },
+                    target: "thingy2",
+                });
+            }).not.toThrow();
+        });
     });
 
     describe("emitters", () => {

--- a/packages/activity-streams/src/activity-streams.ts
+++ b/packages/activity-streams/src/activity-streams.ts
@@ -89,6 +89,7 @@ const baseProps = {
         "titleMap",
         "updated",
         "url",
+        "xmpp:replace",
         "xmpp:stanza-id",
     ],
 } as const;


### PR DESCRIPTION
## Summary
- allow XMPP message correction metadata in ActivityStreams message objects
- add regression coverage for object[xmpp:replace]

## Testing
- bun test packages/activity-streams/src/activity-streams.test.ts
- bunx biome check packages/activity-streams/src/activity-streams.ts packages/activity-streams/src/activity-streams.test.ts

## Notes
- This is the small immediate fix.
- PR #1088 replaces the static protocol-specific whitelist with platform-declared dynamic extensions.