### PR TITLE
feat(server): pass platform child env vars for local XMPP testing

### DIFF
--- a/packages/server/src/platform-instance.ts
+++ b/packages/server/src/platform-instance.ts
@@ -103,6 +103,9 @@ export default class PlatformInstance {
         if (process.env.LOG_LEVEL) {
             env.LOG_LEVEL = process.env.LOG_LEVEL;
         }
+        if (process.env.NODE_EXTRA_CA_CERTS) {
+            env.NODE_EXTRA_CA_CERTS = process.env.NODE_EXTRA_CA_CERTS;
+        }
         const heartbeatInterval = config.get("platformHeartbeat:intervalMs");
         if (typeof heartbeatInterval !== "undefined") {
             env.SOCKETHUB_PLATFORM_HEARTBEAT_INTERVAL_MS =
@@ -125,13 +128,17 @@ export default class PlatformInstance {
     }
 
     initProcess(parentId: string, name: string, id: string, env: EnvFormat) {
+        const forkOptions: Parameters<typeof fork>[2] = { env };
+        if (process.env.SOCKETHUB_PLATFORM_NODE) {
+            forkOptions.execPath = process.env.SOCKETHUB_PLATFORM_NODE;
+            // Bun passes --hot to child processes; Node does not understand it.
+            forkOptions.execArgv = [];
+        }
         // spin off a process
         this.process = fork(
             join(__dirname, "platform.js"),
             [parentId, name, id],
-            {
-                env: env,
-            },
+            forkOptions,
         );
     }
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Sockethub runs each platform (IRC, XMPP, feeds, …) as a **separate child process** forked from the main server. Today only a small set of variables (`REDIS_URL`, `LOG_LEVEL`, heartbeat settings) are copied into that child environment. Everything else the parent has set is invisible to platform code.

This PR forwards two **optional, developer-only** environment variables from the parent Sockethub process into platform workers. They exist to make **local integration testing** (especially XMPP against a local Prosody instance) practical without changing production defaults.

## Variables

### `NODE_EXTRA_CA_CERTS`

**What it is:** Standard Node.js variable. Path to a PEM file containing one or more trusted CA certificates.

**What it does here:** When set on the main Sockethub process, the same path is passed to every forked platform child. The XMPP platform uses `@xmpp/client`, which upgrades plain TCP connections to TLS via STARTTLS. Local Prosody installs almost always use a **self-signed certificate**. Without this variable, Node rejects the upgrade with `self signed certificate` even though the connection would otherwise work.

**Typical use:**

```bash
# After generating or copying Prosody's cert to a readable path
export NODE_EXTRA_CA_CERTS=/path/to/prosody-localhost.crt
bun run ./bin/sockethub --examples
```

**Production note:** In production you should use properly signed certificates; this variable is mainly for local/docker-compose Prosody setups that mirror `integration/prosody`.

---

### `SOCKETHUB_PLATFORM_NODE`

**What it is:** Absolute path to a Node.js binary (e.g. output of `which node`).

**What it does here:** When set, platform child processes are forked with `execPath` pointing at Node instead of inheriting Bun. The fork also clears `execArgv` because **Bun passes `--hot` to child processes**, which Node rejects (`bad option: --hot`) and the platform worker exits immediately.

**Why it exists:** Bun's bundled `@xmpp/client` path mishandles STARTTLS against local Prosody (TLS payload parsed as XML). Running platform workers under Node with `NODE_EXTRA_CA_CERTS` matches what integration tests expect and matches verified behavior from direct `@xmpp/client` usage under Node.

**Typical use:**

```bash
export SOCKETHUB_PLATFORM_NODE="$(which node)"
export NODE_EXTRA_CA_CERTS=/path/to/prosody-localhost.crt
bun run ./bin/sockethub --examples   # parent can stay on Bun; platforms run on Node
```

**Production note:** Not required when connecting to public XMPP services with valid TLS. Default behavior (platform children use the same runtime as the parent) is unchanged when this variable is unset.

## Example: local stack matching integration tests

```bash
# Redis + Prosody + Ergo (see integration/ configs)
export SOCKETHUB_PLATFORM_NODE="$(which node)"
export NODE_EXTRA_CA_CERTS="$PWD/integration/prosody/certs/localhost.crt"
bun run ./packages/sockethub/bin/sockethub --examples
```

Then in the examples IRC page, set server `localhost`, port `6667`, and in credentials JSON set `"secure": false`. For XMPP use `jimmy@localhost` with the integration test password and `server: "xmpp://localhost:5222"` in credentials.

## What does *not* change

- No new defaults in production.
- No change to platform protocols or credentials schemas.
- If neither variable is set, behavior is identical to today.

## Test plan

- [x] `packages/server/src/platform-instance.test.ts` (26 tests pass)
- [x] Manual: XMPP connect to local Prosody with both vars set; platform child starts without `--hot` error
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-0a81cfe3-260d-42a4-8d96-2e53e819471e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0a81cfe3-260d-42a4-8d96-2e53e819471e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

