### PR TITLE
ci(examples): add smoke tests, contract checks, and nightly matrix

### DIFF
--- a/.github/workflows/compliance.yml
+++ b/.github/workflows/compliance.yml
@@ -61,3 +61,26 @@ jobs:
             - run: bun install --frozen-lockfile
             - run: bun run build
             - run: bun test
+
+    examples:
+        runs-on: ubuntu-latest
+        needs: [build]
+
+        steps:
+            - run: sudo chown -R $USER:$USER ${{ github.workspace }}
+            - name: Checkout repository
+              uses: actions/checkout@v4
+            - name: Use Bun latest
+              uses: oven-sh/setup-bun@v2
+              with:
+                  bun-version: latest
+            - run: bun install --frozen-lockfile
+            - run: bun run build
+            - run: bun run docker:start:redis
+            - run: sleep 5
+            - name: Verify Redis is listening
+              run: nc -zv localhost 6379
+            - name: Examples svelte-check
+              run: cd packages/examples && bun run check
+            - name: Examples smoke tests (sockethub --examples)
+              run: cd packages/examples && bun run test:smoke

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -104,6 +104,9 @@ jobs:
       - name: Basic Browser Integration Tests
         run: XMPP_HOST=prosody bun run integration:browser:basic
 
+      - name: Platform Response Contract Tests
+        run: XMPP_HOST=prosody bun run integration:browser:contract
+
       - name: Sockethub Logs - Basic
         if: always()
         run: docker logs sockethub-sockethub-1

--- a/.github/workflows/test-npm-package.yml
+++ b/.github/workflows/test-npm-package.yml
@@ -46,17 +46,49 @@ on:
     - cron: '0 2 * * *'  # Nightly at 2am UTC
 
 jobs:
+  setup:
+    runs-on: ubuntu-latest
+    outputs:
+      versions: ${{ steps.versions.outputs.versions }}
+      suite: ${{ steps.versions.outputs.suite }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2.0.1
+        with:
+          bun-version: latest
+
+      - name: Resolve test matrix
+        id: versions
+        run: |
+          if [ "${{ github.event_name }}" = "schedule" ]; then
+            echo "versions=$(bun run scripts/resolve-nightly-versions.mjs)" >> $GITHUB_OUTPUT
+            echo "suite=all" >> $GITHUB_OUTPUT
+          else
+            VERSION="${{ github.event.inputs.version || 'latest' }}"
+            echo "versions=[\"${VERSION}\"]" >> $GITHUB_OUTPUT
+            echo "suite=${{ github.event.inputs.suite || 'all' }}" >> $GITHUB_OUTPUT
+          fi
+
   test-npm-version:
     runs-on: ubuntu-latest
+    needs: [setup]
 
     strategy:
       matrix:
+        version: ${{ fromJson(needs.setup.outputs.versions) }}
         runtime: [bun, node]
-      fail-fast: false  # Continue testing other runtimes even if one fails
+      fail-fast: false
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2.0.1
@@ -64,7 +96,7 @@ jobs:
           bun-version: latest
 
       - name: Setup Node.js
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: '20'
 
@@ -74,24 +106,6 @@ jobs:
       - name: Build packages (if local mode)
         if: github.event.inputs.local == 'true'
         run: bun run build
-
-      - name: Determine version
-        id: version
-        run: |
-          if [ "${{ github.event_name }}" = "schedule" ]; then
-            echo "version=latest" >> $GITHUB_OUTPUT
-          else
-            echo "version=${{ github.event.inputs.version }}" >> $GITHUB_OUTPUT
-          fi
-
-      - name: Determine suite
-        id: suite
-        run: |
-          if [ "${{ github.event_name }}" = "schedule" ]; then
-            echo "suite=all" >> $GITHUB_OUTPUT
-          else
-            echo "suite=${{ github.event.inputs.suite || 'all' }}" >> $GITHUB_OUTPUT
-          fi
 
       - name: Determine runtime
         id: runtime
@@ -113,19 +127,19 @@ jobs:
             bun run scripts/test-installed-version.js \
               --local \
               --runtime ${{ matrix.runtime }} \
-              --suite ${{ steps.suite.outputs.suite }}
+              --suite ${{ needs.setup.outputs.suite }}
           else
             bun run scripts/test-installed-version.js \
-              ${{ steps.version.outputs.version }} \
+              ${{ matrix.version }} \
               --runtime ${{ matrix.runtime }} \
-              --suite ${{ steps.suite.outputs.suite }}
+              --suite ${{ needs.setup.outputs.suite }}
           fi
 
       - name: Upload test results
         if: always() && steps.runtime.outputs.run_test == 'true'
         uses: actions/upload-artifact@v4
         with:
-          name: test-results-${{ steps.version.outputs.version }}-${{ matrix.runtime }}
+          name: test-results-${{ matrix.version }}-${{ matrix.runtime }}
           path: test-results/
           retention-days: 30
 

--- a/bun.lock
+++ b/bun.lock
@@ -34,7 +34,7 @@
       "name": "@sockethub/activity-streams",
       "version": "4.4.0-alpha.12",
       "dependencies": {
-        "@sockethub/schemas": "^3.0.0-alpha.11",
+        "@sockethub/schemas": "^3.0.0-alpha.12",
         "eventemitter3": "^5.0.4",
       },
       "devDependencies": {
@@ -47,8 +47,8 @@
       "name": "@sockethub/client",
       "version": "5.0.0-alpha.12",
       "dependencies": {
-        "@sockethub/activity-streams": "^4.4.0-alpha.11",
-        "@sockethub/schemas": "^3.0.0-alpha.11",
+        "@sockethub/activity-streams": "^4.4.0-alpha.12",
+        "@sockethub/schemas": "^3.0.0-alpha.12",
         "eventemitter3": "^5.0.4",
       },
       "devDependencies": {
@@ -101,7 +101,8 @@
       "version": "1.0.0-alpha.12",
       "devDependencies": {
         "@playwright/test": "^1.57.0",
-        "@sockethub/client": "^5.0.0-alpha.11",
+        "@sockethub/activity-streams": "workspace:4.4.0-alpha.12",
+        "@sockethub/client": "^5.0.0-alpha.12",
         "@sveltejs/adapter-static": "^3.0.10",
         "@sveltejs/kit": "^2.50.0",
         "@sveltejs/vite-plugin-svelte": "^5.1.1",
@@ -3740,11 +3741,11 @@
 
     "@sinonjs/samsam/type-detect": ["type-detect@4.1.0", "", {}, "sha512-Acylog8/luQ8L7il+geoSxhEkazvkslg7PSNKOX59mbB9cOveP5aq9h74Y7YU8yDpJwetzQQrfIwtf4Wp4LKcw=="],
 
-    "@sockethub/activity-streams/@types/bun": ["@types/bun@1.3.11", "", { "dependencies": { "bun-types": "1.3.11" } }, "sha512-5vPne5QvtpjGpsGYXiFyycfpDF2ECyPcTSsFBMa0fraoxiQyMJ3SmuQIGhzPg2WJuWxVBoxWJ2kClYTcw/4fAg=="],
+    "@sockethub/activity-streams/@types/bun": ["@types/bun@1.3.14", "", { "dependencies": { "bun-types": "1.3.14" } }, "sha512-h1hFqFVcvAvD9j9K7ZW7vd82aSA+rTdznZa+5bwvCwqSB1jmmfLcbIWhOLx1/+boy/xmjgCs/OMUL8hRJSmnPw=="],
 
     "@sockethub/activity-streams/@web/test-runner": ["@web/test-runner@0.19.0", "", { "dependencies": { "@web/browser-logs": "^0.4.0", "@web/config-loader": "^0.3.0", "@web/dev-server": "^0.4.0", "@web/test-runner-chrome": "^0.17.0", "@web/test-runner-commands": "^0.9.0", "@web/test-runner-core": "^0.13.0", "@web/test-runner-mocha": "^0.9.0", "camelcase": "^6.2.0", "command-line-args": "^5.1.1", "command-line-usage": "^7.0.1", "convert-source-map": "^2.0.0", "diff": "^5.0.0", "globby": "^11.0.1", "nanocolors": "^0.2.1", "portfinder": "^1.0.32", "source-map": "^0.7.3" }, "bin": { "wtr": "dist/bin.js", "web-test-runner": "dist/bin.js" } }, "sha512-qLUupi88OK1Kl52cWPD/2JewUCRUxYsZ1V1DyLd05P7u09zCdrUYrtkB/cViWyxlBe/TOvqkSNpcTv6zLJ9GoA=="],
 
-    "@sockethub/client/@types/bun": ["@types/bun@1.3.11", "", { "dependencies": { "bun-types": "1.3.11" } }, "sha512-5vPne5QvtpjGpsGYXiFyycfpDF2ECyPcTSsFBMa0fraoxiQyMJ3SmuQIGhzPg2WJuWxVBoxWJ2kClYTcw/4fAg=="],
+    "@sockethub/client/@types/bun": ["@types/bun@1.3.14", "", { "dependencies": { "bun-types": "1.3.14" } }, "sha512-h1hFqFVcvAvD9j9K7ZW7vd82aSA+rTdznZa+5bwvCwqSB1jmmfLcbIWhOLx1/+boy/xmjgCs/OMUL8hRJSmnPw=="],
 
     "@sockethub/client/@web/test-runner": ["@web/test-runner@0.19.0", "", { "dependencies": { "@web/browser-logs": "^0.4.0", "@web/config-loader": "^0.3.0", "@web/dev-server": "^0.4.0", "@web/test-runner-chrome": "^0.17.0", "@web/test-runner-commands": "^0.9.0", "@web/test-runner-core": "^0.13.0", "@web/test-runner-mocha": "^0.9.0", "camelcase": "^6.2.0", "command-line-args": "^5.1.1", "command-line-usage": "^7.0.1", "convert-source-map": "^2.0.0", "diff": "^5.0.0", "globby": "^11.0.1", "nanocolors": "^0.2.1", "portfinder": "^1.0.32", "source-map": "^0.7.3" }, "bin": { "wtr": "dist/bin.js", "web-test-runner": "dist/bin.js" } }, "sha512-qLUupi88OK1Kl52cWPD/2JewUCRUxYsZ1V1DyLd05P7u09zCdrUYrtkB/cViWyxlBe/TOvqkSNpcTv6zLJ9GoA=="],
 
@@ -4526,11 +4527,11 @@
 
     "@puppeteer/browsers/yargs/string-width": ["string-width@4.2.3", "", { "dependencies": { "emoji-regex": "^8.0.0", "is-fullwidth-code-point": "^3.0.0", "strip-ansi": "^6.0.1" } }, "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g=="],
 
-    "@sockethub/activity-streams/@types/bun/bun-types": ["bun-types@1.3.11", "", { "dependencies": { "@types/node": "*" } }, "sha512-1KGPpoxQWl9f6wcZh57LvrPIInQMn2TQ7jsgxqpRzg+l0QPOFvJVH7HmvHo/AiPgwXy+/Thf6Ov3EdVn1vOabg=="],
+    "@sockethub/activity-streams/@types/bun/bun-types": ["bun-types@1.3.14", "", { "dependencies": { "@types/node": "*" } }, "sha512-4N0ig0fEomHt5R0KCFWjovxow98rIoRwKolrYdCcknNwMekCXRnWEUvgu5soYV8QXtVsrUD8B95MBOZGPvr6KQ=="],
 
     "@sockethub/activity-streams/@web/test-runner/@web/test-runner-chrome": ["@web/test-runner-chrome@0.17.0", "", { "dependencies": { "@web/test-runner-core": "^0.13.0", "@web/test-runner-coverage-v8": "^0.8.0", "async-mutex": "0.4.0", "chrome-launcher": "^0.15.0", "puppeteer-core": "^23.2.0" } }, "sha512-Il5N9z41NKWCrQM1TVgRaDWWYoJtG5Ha4fG+cN1MWL2OlzBS4WoOb4lFV3EylZ7+W3twZOFr1zy2Rx61yDYd/A=="],
 
-    "@sockethub/client/@types/bun/bun-types": ["bun-types@1.3.11", "", { "dependencies": { "@types/node": "*" } }, "sha512-1KGPpoxQWl9f6wcZh57LvrPIInQMn2TQ7jsgxqpRzg+l0QPOFvJVH7HmvHo/AiPgwXy+/Thf6Ov3EdVn1vOabg=="],
+    "@sockethub/client/@types/bun/bun-types": ["bun-types@1.3.14", "", { "dependencies": { "@types/node": "*" } }, "sha512-4N0ig0fEomHt5R0KCFWjovxow98rIoRwKolrYdCcknNwMekCXRnWEUvgu5soYV8QXtVsrUD8B95MBOZGPvr6KQ=="],
 
     "@sockethub/client/@web/test-runner/@web/test-runner-chrome": ["@web/test-runner-chrome@0.17.0", "", { "dependencies": { "@web/test-runner-core": "^0.13.0", "@web/test-runner-coverage-v8": "^0.8.0", "async-mutex": "0.4.0", "chrome-launcher": "^0.15.0", "puppeteer-core": "^23.2.0" } }, "sha512-Il5N9z41NKWCrQM1TVgRaDWWYoJtG5Ha4fG+cN1MWL2OlzBS4WoOb4lFV3EylZ7+W3twZOFr1zy2Rx61yDYd/A=="],
 

--- a/integration/contract/platform-responses.integration.js
+++ b/integration/contract/platform-responses.integration.js
@@ -1,0 +1,158 @@
+import { expect } from "@esm-bundle/chai";
+import {
+    ctx,
+    emitWithAck,
+    getConfig,
+    validateGlobals,
+} from "../browser/shared-setup.js";
+
+const config = getConfig();
+
+/**
+ * Contract tests assert platform response shapes match what the Sockethub client
+ * and examples app expect. Failures here indicate a platform/client UI mismatch.
+ */
+describe(`Platform response contracts at ${config.sockethub.url}`, () => {
+    validateGlobals();
+
+    let sc;
+
+    before(async () => {
+        sc = new SockethubClient(
+            io(config.sockethub.url, { path: "/sockethub" }),
+        );
+        await sc.ready();
+    });
+
+    after(() => {
+        if (sc?.socket) {
+            sc.socket.disconnect();
+        }
+    });
+
+    function assertNoError(msg, label) {
+        if (msg?.error) {
+            throw new Error(`${label}: ${msg.error}`);
+        }
+    }
+
+    function assertCollectionContract(msg) {
+        expect(msg.type).to.equal("collection");
+        expect(msg).to.have.property("totalItems");
+        expect(msg.totalItems).to.be.a("number");
+        expect(msg).to.have.property("items");
+        expect(msg.items).to.be.an("array");
+        expect(msg.items.length).to.equal(msg.totalItems);
+        expect(msg).to.have.property("summary").that.is.a("string");
+        expect(msg).to.have.property("@context").that.is.an("array");
+    }
+
+    function assertFeedItemContract(item) {
+        expect(item.type).to.equal("post");
+        expect(item.actor).to.have.property("type", "feed");
+        expect(item.actor).to.have.property("id").that.is.a("string");
+        expect(item.object).to.be.an("object");
+        expect(item.object)
+            .to.have.property("type")
+            .that.is.oneOf(["article", "note"]);
+        expect(item.object).to.have.property("title").that.is.a("string");
+        expect(item.object).to.have.property("id").that.is.a("string");
+        expect(item.object).to.have.property("url").that.is.a("string");
+        expect(item.object).to.have.property("content").that.is.a("string");
+        expect(item.object)
+            .to.have.property("contentType")
+            .that.is.oneOf(["html", "text"]);
+        expect(item.object).to.have.property("published");
+        expect(item.object).to.have.property("datenum").that.is.a("number");
+    }
+
+    describe("feeds platform", () => {
+        it("returns a collection contract the examples app can render", async () => {
+            const msg = await emitWithAck(
+                sc.socket,
+                "message",
+                {
+                    "@context": ctx("feeds"),
+                    type: "fetch",
+                    actor: {
+                        type: "feed",
+                        id: `${config.sockethub.url}/feed.xml`,
+                    },
+                },
+                { label: "feeds contract" },
+            );
+
+            assertNoError(msg, "feeds fetch");
+            assertCollectionContract(msg);
+
+            for (const item of msg.items) {
+                assertFeedItemContract(item);
+            }
+        });
+    });
+
+    describe("dummy platform", () => {
+        const actor = {
+            id: "contract-test@dummy",
+            type: "person",
+            name: "Contract Tester",
+        };
+
+        before(() => {
+            sc.ActivityStreams.Object.create(actor);
+        });
+
+        it("returns an echo response the client stores on the actor", async () => {
+            const msg = await emitWithAck(
+                sc.socket,
+                "message",
+                {
+                    "@context": ctx("dummy"),
+                    type: "echo",
+                    actor: actor.id,
+                    object: {
+                        type: "message",
+                        content: "contract echo",
+                    },
+                },
+                { label: "dummy echo contract" },
+            );
+
+            assertNoError(msg, "dummy echo");
+            expect(msg.type).to.equal("echo");
+            expect(msg.actor).to.have.property("type", "platform");
+            expect(msg.target).to.eql(sc.ActivityStreams.Object.get(actor.id));
+            expect(msg.object).to.deep.include({
+                type: "message",
+                content: "contract echo",
+            });
+        });
+    });
+
+    describe("metadata platform", () => {
+        it("returns page object fields the examples metadata view expects", async () => {
+            const msg = await emitWithAck(
+                sc.socket,
+                "message",
+                {
+                    "@context": ctx("metadata"),
+                    type: "fetch",
+                    actor: {
+                        type: "website",
+                        id: "https://sockethub.org",
+                    },
+                },
+                { label: "metadata contract" },
+            );
+
+            assertNoError(msg, "metadata fetch");
+            expect(msg.type).to.equal("fetch");
+            expect(msg.actor).to.have.property("id").that.is.a("string");
+            expect(msg.object).to.be.an("object");
+            expect(msg.object).to.have.property("type", "page");
+            expect(msg.object).to.have.property("title");
+            expect(msg.object).to.have.property("url");
+            expect(msg.object).to.have.property("description");
+        });
+    });
+});

--- a/package.json
+++ b/package.json
@@ -63,6 +63,7 @@
     "integration:browser:irc-reconnection": "bun integration/browser/test-runner.js ./integration/browser/irc-reconnection.integration.js",
     "integration:browser:irc-nickclash": "bun integration/browser/test-runner.js ./integration/browser/irc-nickclash.integration.js",
     "integration:browser:irc-sasl-auth": "bun integration/browser/test-runner.js ./integration/browser/irc-sasl-auth.integration.js",
+    "integration:browser:contract": "bun integration/browser/test-runner.js ./integration/contract/platform-responses.integration.js",
     "integration:packages": "bun --workspaces --if-present run test:integration",
     "integration:process": "bun test ./integration/process.integration.ts",
     "integration:rate-limiter": "bun test ./integration/rate-limiter.integration.ts",

--- a/packages/examples/package.json
+++ b/packages/examples/package.json
@@ -33,6 +33,7 @@
     "build": "bunx --bun vite build",
     "test": "bun run test:unit",
     "test:integration": "sh -c 'if [ -z \"$RUN_PLAYWRIGHT\" ]; then echo \"Skipping Playwright integration tests (set RUN_PLAYWRIGHT=1 to run).\"; else bunx --bun playwright test; fi'",
+    "test:smoke": "bunx playwright test --config playwright.smoke.config.ts",
     "test:unit": "bunx --bun vitest run",
     "preview": "bunx --bun vite preview",
     "clean": "rm -rf build",
@@ -42,6 +43,7 @@
   },
   "devDependencies": {
     "@playwright/test": "^1.57.0",
+    "@sockethub/activity-streams": "workspace:4.4.0-alpha.12",
     "@sockethub/client": "^5.0.0-alpha.12",
     "@sveltejs/adapter-static": "^3.0.10",
     "@sveltejs/kit": "^2.50.0",

--- a/packages/examples/playwright.smoke.config.ts
+++ b/packages/examples/playwright.smoke.config.ts
@@ -1,0 +1,18 @@
+import type { PlaywrightTestConfig } from "@playwright/test";
+
+const config: PlaywrightTestConfig = {
+    webServer: {
+        command: "bun run scripts/smoke-server.mjs",
+        url: "http://localhost:10550",
+        reuseExistingServer: !process.env.CI,
+        timeout: 180_000,
+    },
+    use: {
+        baseURL: "http://localhost:10550",
+    },
+    testDir: "tests",
+    testMatch: /smoke\.spec\.ts/,
+    timeout: 60_000,
+};
+
+export default config;

--- a/packages/examples/scripts/smoke-server.mjs
+++ b/packages/examples/scripts/smoke-server.mjs
@@ -1,0 +1,105 @@
+#!/usr/bin/env bun
+import { execSync, spawn } from "node:child_process";
+/**
+ * Starts Redis and Sockethub with --examples for Playwright smoke tests.
+ * Assumes the monorepo has already been built.
+ */
+import { readFileSync } from "node:fs";
+import { createServer } from "node:http";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const root = path.resolve(
+    fileURLToPath(new URL(".", import.meta.url)),
+    "../../..",
+);
+const healthUrl = "http://localhost:10550/";
+const feedFixtureUrl = "http://localhost:10551/feed.xml";
+const feedFixturePath = path.join(root, "packages/examples/static/feed.xml");
+
+async function waitForHttp(url, maxAttempts = 90) {
+    for (let attempt = 1; attempt <= maxAttempts; attempt++) {
+        try {
+            const response = await fetch(url);
+            if (response.ok) {
+                return;
+            }
+        } catch {
+            // Server not ready yet.
+        }
+
+        if (attempt === maxAttempts) {
+            throw new Error(
+                `Timed out waiting for ${url} after ${maxAttempts}s`,
+            );
+        }
+
+        await new Promise((resolve) => setTimeout(resolve, 1000));
+    }
+}
+
+function shutdown(child) {
+    if (child && !child.killed) {
+        child.kill("SIGTERM");
+    }
+}
+
+try {
+    execSync("nc -z 127.0.0.1 6379", { stdio: "ignore" });
+    console.log("Redis already listening on 6379");
+} catch {
+    console.log("Starting Redis for examples smoke tests...");
+    execSync("docker compose up redis -d", { cwd: root, stdio: "inherit" });
+    execSync(
+        "bash -c 'for i in $(seq 1 30); do nc -z 127.0.0.1 6379 && exit 0; sleep 1; done; exit 1'",
+        {
+            stdio: "inherit",
+        },
+    );
+}
+
+const feedFixture = createServer((req, res) => {
+    if (req.url === "/feed.xml") {
+        res.writeHead(200, { "Content-Type": "application/rss+xml" });
+        res.end(readFileSync(feedFixturePath));
+        return;
+    }
+
+    res.writeHead(404);
+    res.end();
+});
+feedFixture.listen(10551, "localhost");
+console.log(`Feed fixture served at ${feedFixtureUrl}`);
+
+console.log("Starting Sockethub with examples...");
+const sockethub = spawn(
+    "bun",
+    ["packages/sockethub/bin/sockethub", "--examples"],
+    {
+        cwd: root,
+        stdio: "inherit",
+        env: {
+            ...process.env,
+            REDIS_URL: "redis://127.0.0.1:6379",
+            PORT: "10550",
+        },
+    },
+);
+
+for (const signal of ["SIGINT", "SIGTERM", "SIGHUP"]) {
+    process.on(signal, () => {
+        feedFixture.close();
+        shutdown(sockethub);
+        process.exit(0);
+    });
+}
+
+sockethub.on("exit", (code, sig) => {
+    if (sig) {
+        process.exit(0);
+    }
+    process.exit(code ?? 1);
+});
+
+await waitForHttp(healthUrl);
+console.log(`Sockethub examples smoke server ready on ${healthUrl}`);

--- a/packages/examples/tests/smoke.spec.ts
+++ b/packages/examples/tests/smoke.spec.ts
@@ -1,0 +1,55 @@
+import { expect, test } from "@playwright/test";
+
+test.describe("examples smoke against sockethub --examples", () => {
+    test("home page loads", async ({ page }) => {
+        await page.goto("/");
+        await expect(page.getByRole("heading", { level: 1 })).toHaveText(
+            "Sockethub Examples",
+        );
+    });
+
+    test("feeds page fetches local feed.xml without runtime errors", async ({
+        page,
+    }) => {
+        const consoleErrors: string[] = [];
+        page.on("pageerror", (error) => {
+            consoleErrors.push(error.message);
+        });
+        page.on("console", (message) => {
+            if (message.type() === "error") {
+                consoleErrors.push(message.text());
+            }
+        });
+
+        await page.goto("/feeds");
+        // Use a separate local fixture server to avoid Sockethub deadlocking when
+        // the feeds platform fetches from the same HTTP port as the examples app.
+        await page
+            .getByLabel("Feed URL")
+            .fill("http://localhost:10551/feed.xml");
+
+        const fetchButton = page.getByRole("button", { name: "Fetch Feed" });
+        await expect(fetchButton).toBeEnabled({ timeout: 30_000 });
+
+        await page
+            .getByRole("button", { name: "Activity Object Create" })
+            .click();
+        await fetchButton.click();
+
+        // The examples logger renders individual feed items (not the collection
+        // summary line) when Sockethub returns a feeds collection.
+        await expect(
+            page.getByRole("link", { name: "Sockethub 4.1.0" }),
+        ).toBeVisible({ timeout: 30_000 });
+        await expect(
+            page.getByText("Sent → Response OK").first(),
+        ).toBeVisible();
+
+        const relevantErrors = consoleErrors.filter(
+            (message) =>
+                !message.includes("favicon") &&
+                !message.includes("Failed to load resource"),
+        );
+        expect(relevantErrors).toEqual([]);
+    });
+});

--- a/scripts/resolve-nightly-versions.mjs
+++ b/scripts/resolve-nightly-versions.mjs
@@ -1,0 +1,44 @@
+#!/usr/bin/env bun
+/**
+ * Resolve npm/git versions for nightly package verification.
+ *
+ * Outputs a JSON array with:
+ * - latest (npm dist-tag)
+ * - latest stable git tag (semver without prerelease)
+ * - latest tagged git release (most recent v* tag)
+ */
+import { execSync } from "node:child_process";
+
+function latestStableTag() {
+    const tags = execSync("git tag -l 'v*'", { encoding: "utf8" })
+        .trim()
+        .split("\n")
+        .filter(Boolean);
+    const stable = tags
+        .filter((tag) => /^v\d+\.\d+\.\d+$/.test(tag))
+        .sort((a, b) => a.localeCompare(b, undefined, { numeric: true }));
+    const latest = stable.at(-1);
+    return latest ? latest.replace(/^v/, "") : null;
+}
+
+function latestTaggedRelease() {
+    const tag = execSync("git tag -l 'v*' --sort=-v:refname", {
+        encoding: "utf8",
+    })
+        .trim()
+        .split("\n")[0];
+    return tag ? tag.replace(/^v/, "") : null;
+}
+
+const versions = ["latest"];
+const stable = latestStableTag();
+const tagged = latestTaggedRelease();
+
+if (stable) {
+    versions.push(stable);
+}
+if (tagged && !versions.includes(tagged)) {
+    versions.push(tagged);
+}
+
+console.log(JSON.stringify(versions));

--- a/scripts/test-installed-version/config.js
+++ b/scripts/test-installed-version/config.js
@@ -17,6 +17,7 @@ export const CONFIG = {
     SERVICES: {
         REDIS: { host: "localhost", port: 6379 },
         PROSODY: { host: "localhost", port: 5222 },
+        IRC: { host: "localhost", port: 6667 },
         SOCKETHUB: { host: "localhost", port: 10550 },
     },
 

--- a/scripts/test-installed-version/runner.js
+++ b/scripts/test-installed-version/runner.js
@@ -62,6 +62,10 @@ export class TestRunner {
                 file: "./integration/browser/basic.integration.js",
             },
             {
+                name: "browser-contract",
+                file: "./integration/contract/platform-responses.integration.js",
+            },
+            {
                 name: "browser-multiclient",
                 file: "./integration/browser/multiclient.integration.js",
             },
@@ -73,10 +77,30 @@ export class TestRunner {
                 name: "browser-resourceclash",
                 file: "./integration/browser/resourceclash.integration.js",
             },
+            {
+                name: "browser-irc-basic",
+                file: "./integration/browser/irc-basic.integration.js",
+                env: { IRC_HOST: "localhost" },
+            },
+            {
+                name: "browser-irc-multiclient",
+                file: "./integration/browser/irc-multiclient.integration.js",
+                env: { IRC_HOST: "localhost" },
+            },
+            {
+                name: "browser-irc-reconnection",
+                file: "./integration/browser/irc-reconnection.integration.js",
+                env: { IRC_HOST: "localhost" },
+            },
+            {
+                name: "browser-irc-nickclash",
+                file: "./integration/browser/irc-nickclash.integration.js",
+                env: { IRC_HOST: "localhost" },
+            },
         ];
 
         for (const test of browserTests) {
-            await this.runBrowserTest(test.name, test.file);
+            await this.runBrowserTest(test.name, test.file, test.env);
         }
     }
 
@@ -85,7 +109,7 @@ export class TestRunner {
      * @param {string} name - Test name
      * @param {string} file - Test file path
      */
-    async runBrowserTest(name, file) {
+    async runBrowserTest(name, file, extraEnv = {}) {
         await this.logger.info(`Running ${name} tests...`);
 
         const startTime = Date.now();
@@ -96,6 +120,7 @@ export class TestRunner {
                 env: {
                     ...process.env,
                     XMPP_HOST: "localhost",
+                    ...extraEnv,
                 },
             },
             `integration-${name}.log`,

--- a/scripts/test-installed-version/services.js
+++ b/scripts/test-installed-version/services.js
@@ -20,6 +20,7 @@ export class ServiceManager {
 
         const needsRedis = ["all", "browser"].includes(suite);
         const needsXmpp = ["all", "browser"].includes(suite);
+        const needsIrc = suite === "all";
 
         if (needsRedis) {
             await this.startRedis();
@@ -27,6 +28,10 @@ export class ServiceManager {
 
         if (needsXmpp) {
             await this.startXmpp();
+        }
+
+        if (needsIrc) {
+            await this.startIrc();
         }
     }
 
@@ -91,6 +96,34 @@ export class ServiceManager {
         await new Promise((resolve) => setTimeout(resolve, 5000));
 
         await this.logger.success("Prosody is ready");
+    }
+
+    /**
+     * Start Ergo IRC Docker container
+     */
+    async startIrc() {
+        await this.logger.info("Starting Ergo IRC container...");
+
+        const result = await this.logger.exec(
+            "docker",
+            ["compose", "up", "ergo", "-d"],
+            {},
+            "ergo.log",
+        );
+
+        if (result.exitCode !== 0) {
+            throw new Error(`Failed to start Ergo: ${result.stderr}`);
+        }
+
+        this.startedServices.push("ergo");
+
+        await this.waitForService(
+            CONFIG.SERVICES.IRC?.host || "localhost",
+            CONFIG.SERVICES.IRC?.port || 6667,
+            "Ergo IRC",
+        );
+
+        await this.logger.success("Ergo IRC is ready");
     }
 
     /**


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
> **Superseded by #1098** — branch renamed to `ci/examples-smoke-contract-nightly` to satisfy repository branch naming rules (`ci/` prefix required).

## Summary

Implements testing improvements **3, 9, 10, and 12** from the feeds testing gap analysis:

### Examples smoke tests (3, 12)
- New `test:smoke` Playwright suite runs against `sockethub --examples` (not Vite preview)
- `smoke-server.mjs` starts Redis, a separate feed fixture server (avoids same-port deadlock), and Sockethub
- Compliance workflow gains an `examples` job running `bun run check` and `bun run test:smoke`
- Adds missing `@sockethub/activity-streams` workspace dependency so examples build succeeds

### Platform↔client contract tests (9)
- New `integration/contract/platform-responses.integration.js` validates feeds collection, dummy echo, and metadata fetch response shapes
- Wired into integration browser CI and npm package verification runner

### Nightly full integration matrix (10)
- Nightly workflow now tests **three versions**: `latest` (npm), latest **stable** git tag (`4.1.0`), and latest **tagged release** (`5.0.0-alpha.12`)
- `scripts/resolve-nightly-versions.mjs` resolves the version matrix from git tags
- Nightly `all` suite now includes IRC browser tests and contract tests; services start Ergo when needed

## Test plan

- [x] `bunx playwright test --config playwright.smoke.config.ts` (2 tests)
- [x] `bun run scripts/resolve-nightly-versions.mjs` → `["latest","4.1.0","5.0.0-alpha.12"]`
- [ ] CI compliance `examples` job
- [ ] CI integration contract tests
- [ ] Nightly workflow (scheduled)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-0a81cfe3-260d-42a4-8d96-2e53e819471e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0a81cfe3-260d-42a4-8d96-2e53e819471e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

