### PR TITLE
docs(agents): add Cursor Cloud development environment instructions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -139,3 +139,40 @@ patterns including schema definitions, credential handling, client lifecycle, an
 
 See `docs/CONTRIBUTING.md` for the complete contributor guide including version bump rules,
 release process, and workflow details.
+
+## Cursor Cloud specific instructions
+
+### Runtime and Redis
+
+- **Bun** is required (`>=1.2.4`). Cloud VMs may not have it pre-installed; install with
+  `curl -fsSL https://bun.sh/install | bash` (adds `~/.bun/bin` to `~/.bashrc`).
+- **Redis** is required before starting Sockethub. Docker is not available in this environment;
+  use the system package instead: `sudo apt-get install -y redis-server`, then start it with
+  `redis-server --daemonize yes --port 6379` and verify with `redis-cli ping`.
+- Default Redis URL is `redis://127.0.0.1:6379` (see `packages/server/src/defaults.json`).
+
+### Dev server
+
+From the repo root after `bun install` and `bun run build`:
+
+```bash
+cd packages/sockethub && bun run dev
+```
+
+This serves the SvelteKit examples at `http://localhost:10550` (`--examples`). Root `bun run dev`
+rebuilds all packages first, then starts the same server.
+
+### Tests
+
+- `bun test` at the repo root runs Bun's test runner across all `*.test.ts` files. It also
+  discovers `packages/examples/tests/smoke.spec.ts` (a Playwright spec), which causes one error;
+  462+ unit tests still pass. Run Playwright smoke tests separately with
+  `cd packages/examples && bun run test:smoke` (requires a running Sockethub on port 10550).
+- Examples unit tests use Vitest: `cd packages/examples && bun run test:unit`.
+- Full IRC/XMPP integration tests need Docker Compose (`bun run docker:start:deps`); skip unless
+  Docker is available.
+
+### Quick verification
+
+Programmatic echo (no browser): connect with `@sockethub/client` and send a dummy-platform `echo`
+message to `http://localhost:10550` (see `integration/browser/basic.integration.js`).


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Documents Cloud Agent VM setup for the Sockethub monorepo: Bun installation, Redis without Docker, dev server startup, test caveats, and quick verification steps.

## Context

Cloud Agent environment setup verified:

- Bun 1.3.14 installed
- Redis 7 started via `redis-server --daemonize yes`
- `bun install`, `bun run lint`, `bun run build` all pass
- `bun test`: 462 unit tests pass (1 Playwright spec incorrectly picked up by Bun's runner)
- Sockethub dev server running at `http://localhost:10550`
- Dummy platform echo verified programmatically and in the browser examples UI

## VM update script

```
export PATH="$HOME/.bun/bin:$PATH"
bun install
```

Redis must be started manually per AGENTS.md (not in update script).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-84c50daa-6bb9-4f59-b322-c067d4281d82"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-84c50daa-6bb9-4f59-b322-c067d4281d82"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

