### PR TITLE
fix(ci): repair test-npm-package local pack and test setup

### DIFF
--- a/.github/workflows/test-npm-package.yml
+++ b/.github/workflows/test-npm-package.yml
@@ -4,9 +4,9 @@ on:
   workflow_dispatch:
     inputs:
       version:
-        description: 'Sockethub version to test (e.g., 5.0.0-alpha.6, latest)'
+        description: 'Sockethub version to test (e.g., 5.0.0-alpha.12, alpha, latest)'
         required: true
-        default: 'latest'
+        default: 'alpha'
       runtime:
         description: 'Runtime to test (bun, node, both)'
         required: false
@@ -23,10 +23,10 @@ on:
   workflow_call:
     inputs:
       version:
-        description: 'Sockethub version to test (e.g., 5.0.0-alpha.6, latest)'
+        description: 'Sockethub version to test (e.g., 5.0.0-alpha.12, alpha, latest)'
         required: false
         type: string
-        default: 'latest'
+        default: 'alpha'
       runtime:
         description: 'Runtime to test (bun, node, both)'
         required: false
@@ -120,8 +120,7 @@ jobs:
       - name: Install dependencies (for test runner)
         run: bun install
 
-      - name: Build packages (if local mode)
-        if: github.event.inputs.local == 'true'
+      - name: Build packages (integration test dependencies)
         run: bun run build
 
       - name: Determine runtime

--- a/scripts/resolve-nightly-versions.mjs
+++ b/scripts/resolve-nightly-versions.mjs
@@ -3,7 +3,7 @@
  * Resolve npm/git versions for nightly package verification.
  *
  * Outputs a JSON array with:
- * - latest (npm dist-tag)
+ * - alpha (npm dist-tag for the current pre-release line)
  * - latest stable git tag (semver without prerelease)
  * - latest tagged git release (most recent v* tag)
  */
@@ -32,7 +32,9 @@ function latestTaggedRelease() {
     return tag ? tag.replace(/^v/, "") : null;
 }
 
-const versions = ["latest"];
+// Use the npm alpha dist-tag while master tracks v5 pre-releases. The npm
+// `latest` tag still points at v4 and is covered by the stable git tag slot.
+const versions = ["alpha"];
 const stable = latestStableTag();
 const tagged = latestTaggedRelease();
 
@@ -45,7 +47,7 @@ if (tagged && !versions.includes(tagged)) {
 
 if (versions.length === 1) {
     console.error(
-        "Warning: no git release tags found; nightly matrix will only test npm latest",
+        "Warning: no git release tags found; nightly matrix will only test npm alpha",
     );
 }
 

--- a/scripts/test-installed-version/local-build.js
+++ b/scripts/test-installed-version/local-build.js
@@ -7,6 +7,23 @@ import { cp, mkdir, readdir, readFile, rm, writeFile } from "node:fs/promises";
 import { join } from "node:path";
 
 /**
+ * Extract tarball filename from `bun pm pack` / `npm pack` stdout.
+ * Bun prints metadata lines after the filename (e.g. "Packed size: ...").
+ * @param {string} output
+ * @returns {string}
+ */
+export function tarballNameFromPackOutput(output) {
+    const match = output.match(/(\S+\.tgz)/);
+    if (!match) {
+        throw new Error(
+            `Could not find tarball filename in pack output:\n${output}`,
+        );
+    }
+
+    return match[1];
+}
+
+/**
  * Build and pack packages locally for testing
  * @param {Logger} logger - Logger instance
  * @returns {Promise<{version: string, tarballsDir: string}>} Version and directory containing tarballs
@@ -55,7 +72,7 @@ export async function buildAndPackLocally(logger) {
                 encoding: "utf-8",
             });
 
-            const tarballName = output.trim().split("\n").pop();
+            const tarballName = tarballNameFromPackOutput(output);
             const tarballPath = join(pkgDir, tarballName);
 
             // Move to tarballs directory
@@ -109,7 +126,7 @@ export async function buildAndPackLocally(logger) {
         encoding: "utf-8",
     });
 
-    const sockethubTarball = packOutput.trim().split("\n").pop();
+    const sockethubTarball = tarballNameFromPackOutput(packOutput);
     const sockethubTarballPath = join(tarballsDir, sockethubTarball);
 
     await logger.success(`Created sockethub tarball: ${sockethubTarball}`);


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes real bugs in the **Test NPM Package** workflow that caused both manual runs to fail after #1098 merged. Manual dispatch and the nightly schedule use the same workflow — these failures were infrastructure problems, not "expected" behavior.

## Root causes

### Run #142 (`local: true`)
`scripts/test-installed-version/local-build.js` parsed `bun pm pack` output by taking the **last line**, which is now metadata (`Packed size: …`) or an inline prefix (`packed 0KB sockethub-….tgz`). That produced invalid tarball paths and failed before any tests ran.

### Run #143 (`version: latest`)
Two bugs:
1. The workflow did not run `bun run build` before browser integration tests, so Web Test Runner 404'd on `packages/schemas/dist/context.js`.
2. npm `latest` is still **4.1.0** while master integration tests target **v5** APIs. The default dist-tag for manual/nightly runs now uses `alpha` (currently `5.0.0-alpha.12`); v4 coverage remains via the stable git tag (`4.1.0`) in the nightly matrix.

## Changes

- Add `tarballNameFromPackOutput()` to extract `.tgz` filenames reliably from pack stdout
- Always `bun run build` in the test job (integration tests need built workspace packages)
- Default workflow dispatch / nightly npm slot to `alpha` instead of `latest` during v5 pre-release

## Test plan

- [x] Verified `tarballNameFromPackOutput()` against current `bun pm pack` output formats
- [x] Verified `--local` path reaches successful install (docker unavailable in agent env for full suite)
- [x] `bun run lint`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6ebd6cef-3592-495d-9311-7bac705526b0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6ebd6cef-3592-495d-9311-7bac705526b0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

