### PR TITLE
ci: pin local @sockethub packages during test install

### DIFF
--- a/scripts/test-installed-version.js
+++ b/scripts/test-installed-version.js
@@ -101,6 +101,7 @@ async function runTestsForRuntime(
     isFirstRun,
     actualVersion,
     installSource,
+    localPackages = null,
 ) {
     console.log(`\n${"=".repeat(60)}`);
     console.log(`Testing with runtime: ${runtime.toUpperCase()}`);
@@ -120,7 +121,12 @@ async function runTestsForRuntime(
 
             if (values.local) {
                 // Install from local tarballs directory
-                await installer.install(installSource, runtime, true);
+                await installer.install(
+                    installSource,
+                    runtime,
+                    true,
+                    localPackages,
+                );
                 const installedVersion =
                     await installer.verifyVersion(actualVersion);
                 logger.version = installedVersion;
@@ -199,17 +205,23 @@ async function main() {
     // Build and pack locally if --local flag is set
     let installSource;
     let actualVersion = version;
+    /** @type {Record<string, string> | null} */
+    let localPackages = null;
 
     if (values.local) {
         console.log("Mode: Local (build and pack from source)");
         const tempLogger = new Logger(values["output-dir"], "local", "build");
         await tempLogger.init();
 
-        const { version: builtVersion, tarballPath } =
-            await buildAndPackLocally(tempLogger);
+        const {
+            version: builtVersion,
+            tarballPath,
+            packages,
+        } = await buildAndPackLocally(tempLogger);
 
         actualVersion = builtVersion;
         installSource = tarballPath;
+        localPackages = packages;
 
         console.log(`Built version: ${actualVersion}`);
         console.log(`Install from: ${tarballPath}`);
@@ -239,6 +251,7 @@ async function main() {
             isFirstRun,
             actualVersion,
             installSource,
+            localPackages,
         );
         allResults.push(result);
     }

--- a/scripts/test-installed-version/install.js
+++ b/scripts/test-installed-version/install.js
@@ -16,8 +16,9 @@ export class InstallManager {
      * @param {string} source - Version to install (e.g., "5.0.0-alpha.6", "latest") or path to local tarball
      * @param {string} runtime - Runtime to use for installation ("bun" or "node")
      * @param {boolean} isLocal - Whether this is a local tarball installation
+     * @param {Record<string, string>} [localPackages] - Map of package name to local tarball path
      */
-    async install(source, runtime, isLocal = false) {
+    async install(source, runtime, isLocal = false, localPackages = null) {
         const description = isLocal
             ? `local tarball (${source})`
             : `npm (sockethub@${source})`;
@@ -30,13 +31,33 @@ export class InstallManager {
         await mkdir(this.installDir, { recursive: true });
 
         if (isLocal) {
-            // Create package.json that references local tarball
+            /** @type {Record<string, string>} */
+            const dependencies = {
+                sockethub: `file:${source}`,
+            };
+            /** @type {Record<string, string>} */
+            const overrides = {};
+
+            if (localPackages) {
+                for (const [name, tarballPath] of Object.entries(
+                    localPackages,
+                )) {
+                    const fileRef = `file:${tarballPath}`;
+                    if (name === "sockethub") {
+                        dependencies.sockethub = fileRef;
+                        continue;
+                    }
+                    if (name.startsWith("@sockethub/")) {
+                        overrides[name] = fileRef;
+                    }
+                }
+            }
+
             const packageJson = {
                 name: "sockethub-test-install",
                 private: true,
-                dependencies: {
-                    sockethub: `file:${source}`,
-                },
+                dependencies,
+                ...(Object.keys(overrides).length > 0 && { overrides }),
             };
 
             const pkgPath = join(this.installDir, "package.json");

--- a/scripts/test-installed-version/local-build.js
+++ b/scripts/test-installed-version/local-build.js
@@ -140,5 +140,6 @@ export async function buildAndPackLocally(logger) {
     return {
         version,
         tarballPath: sockethubTarballPath,
+        packages: Object.fromEntries(tarballs),
     };
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes bun runtime failure in **Test NPM Package** when `source=local`.

## Root cause

Local installs only pinned the top-level `sockethub` tarball. Transitive `@sockethub/*` dependencies (e.g. `@sockethub/data-layer`) were still resolved from the npm registry.

- **Node** uses the `"import": "./dist/index.js"` export condition → worked
- **Bun** uses the `"bun": "./src/index.ts"` export condition → loaded stale registry source missing `CredentialsNotShareableError` → sockethub crashed on startup

From run https://github.com/sockethub/sockethub/actions/runs/27102125560:
```
SyntaxError: Export named 'CredentialsNotShareableError' not found in module '.../data-layer/src/index.ts'
```

## Fix

Return the full tarball map from `buildAndPackLocally()` and add npm/bun `overrides` for all `@sockethub/*` packages during local test installs.

## Test plan

- [x] Reproduced bun failure before fix (`sockethub --info` exit 1)
- [x] Verified fix locally (`bun node_modules/.bin/sockethub --info` succeeds)
- [x] `bun run lint`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6ebd6cef-3592-495d-9311-7bac705526b0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6ebd6cef-3592-495d-9311-7bac705526b0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved test infrastructure to better handle local package artifacts during testing, enabling comprehensive testing scenarios with multiple local packages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->