### PR TITLE
fix(platform-xmpp): use unique IDs for attendance queries

### DIFF
--- a/packages/platform-xmpp/src/incoming-handlers.test.ts
+++ b/packages/platform-xmpp/src/incoming-handlers.test.ts
@@ -2,10 +2,12 @@ import { beforeEach, describe, expect, test } from "bun:test";
 import sinon from "sinon";
 
 import * as schemas from "@sockethub/schemas";
+import type { XmppClientInstance, XmppElement } from "@xmpp/client";
 import parse from "@xmpp/xml/lib/parse.js";
 
 import { IncomingHandlers } from "./incoming-handlers.js";
 import { stanzas } from "./incoming-handlers.test.data.js";
+import XMPP from "./index.js";
 import { PlatformSchema } from "./schema.js";
 import type { XmppHandlerSession } from "./types.js";
 
@@ -39,7 +41,14 @@ describe("Incoming handlers", () => {
 
         stanzas.forEach(([name, stanza, asobject]) => {
             test(name, () => {
-                const xmlObj = parse(stanza);
+                const xmlObj = parse(
+                    name === "attendance"
+                        ? stanza.replace(
+                            'id="muc_id"',
+                            'id="attendance_00000000-0000-4000-8000-000000000000"',
+                        )
+                        : stanza,
+                );
                 ih.stanza(xmlObj);
                 sinon.assert.calledWith(sendToClient, asobject);
             });
@@ -85,9 +94,9 @@ describe("Incoming handlers", () => {
             expect(arg.actor.id).toEqual("noroom@conference.example.org");
         });
 
-        test("routes IQ result with non-room_info ID prefix to attendance", () => {
+        test("routes IQ result with attendance ID prefix to attendance", () => {
             const stanza = parse(
-                `<iq from='room@conference.example.org' to='user@example.org' type='result' id='muc_id'>
+                `<iq from='room@conference.example.org' to='user@example.org' type='result' id='attendance_999'>
                   <query xmlns='http://jabber.org/protocol/disco#info'>
                     <identity category='conference' type='text' name='Test'/>
                     <feature var='http://jabber.org/protocol/muc'/>
@@ -99,6 +108,31 @@ describe("Incoming handlers", () => {
             const arg = sendToClient.getCall(0).args[0];
             expect(arg.type).toEqual("query");
             expect(arg.object.type).toEqual("attendance");
+        });
+
+        test("does not route old or unrelated IQ IDs to attendance", () => {
+            const oldIdStanza = parse(
+                `<iq from='room@conference.example.org' to='user@example.org' type='result' id='muc_id'>
+                  <query xmlns='http://jabber.org/protocol/disco#items'>
+                    <item jid='room@conference.example.org/nick' name='nick'/>
+                  </query>
+                </iq>`,
+            );
+            const unrelatedIdStanza = parse(
+                `<iq from='room@conference.example.org' to='user@example.org' type='result' id='room_members_1'>
+                  <query xmlns='http://jabber.org/protocol/disco#items'>
+                    <item jid='room@conference.example.org/nick' name='nick'/>
+                  </query>
+                </iq>`,
+            );
+
+            ih.stanza(oldIdStanza);
+            ih.stanza(unrelatedIdStanza);
+
+            sinon.assert.calledTwice(sendToClient);
+            for (const call of sendToClient.getCalls()) {
+                expect(call.args[0].object?.type).not.toEqual("attendance");
+            }
         });
 
         test("sends error response for disco#info result with wrong xmlns", () => {
@@ -147,6 +181,100 @@ describe("Incoming handlers", () => {
                 label: "Flat Key",
                 value: "flat_val",
             });
+        });
+    });
+
+    describe("Attendance query IDs", () => {
+        test("uses distinct attendance IDs and routes matching responses", async () => {
+            const send = sinon.fake.resolves();
+            const xmlFake = sinon.fake(
+                (
+                    name: string,
+                    attrs?: Record<string, string | undefined>,
+                    ...children: XmppElement[]
+                ) => ({ name, attrs, children }) as unknown as XmppElement,
+            );
+
+            class TestXMPP extends XMPP {
+                protected createXml(): void {
+                    this.__xml = xmlFake as unknown as typeof this.__xml;
+                }
+            }
+
+            const xp = new TestXMPP({
+                id: "user@example.org",
+                log: { debug: sinon.fake(), error: sinon.fake(), warn: sinon.fake(), info: sinon.fake() },
+                sendToClient: sinon.fake(),
+                updateActor: sinon.fake.resolves(),
+            });
+            xp.__client = {
+                send,
+            } as unknown as XmppClientInstance;
+
+            const job = {
+                actor: {
+                    id: "user@example.org",
+                    type: "person",
+                },
+                target: {
+                    id: "room@conference.example.org",
+                    type: "room",
+                },
+                object: {
+                    type: "attendance",
+                },
+            };
+
+            await new Promise<void>((resolve, reject) => {
+                xp.query(job as never, (err) => {
+                    if (err) {
+                        reject(err);
+                        return;
+                    }
+                    resolve();
+                });
+            });
+            await new Promise<void>((resolve, reject) => {
+                xp.query(job as never, (err) => {
+                    if (err) {
+                        reject(err);
+                        return;
+                    }
+                    resolve();
+                });
+            });
+
+            const firstId = send.getCall(0).args[0].attrs.id;
+            const secondId = send.getCall(1).args[0].attrs.id;
+
+            expect(firstId).toMatch(/^attendance_/);
+            expect(secondId).toMatch(/^attendance_/);
+            expect(firstId).not.toEqual(secondId);
+
+            const sendToClient = sinon.fake();
+            const ih = new IncomingHandlers(makeSession({ sendToClient }));
+            ih.stanza(
+                parse(
+                    `<iq from='room@conference.example.org' to='user@example.org' type='result' id='${firstId}'>
+                      <query xmlns='http://jabber.org/protocol/disco#items'>
+                        <item jid='room@conference.example.org/one' name='one'/>
+                      </query>
+                    </iq>`,
+                ),
+            );
+            ih.stanza(
+                parse(
+                    `<iq from='room@conference.example.org' to='user@example.org' type='result' id='${secondId}'>
+                      <query xmlns='http://jabber.org/protocol/disco#items'>
+                        <item jid='room@conference.example.org/two' name='two'/>
+                      </query>
+                    </iq>`,
+                ),
+            );
+
+            sinon.assert.calledTwice(sendToClient);
+            expect(sendToClient.getCall(0).args[0].object.members).toEqual(["one"]);
+            expect(sendToClient.getCall(1).args[0].object.members).toEqual(["two"]);
         });
     });
 

--- a/packages/platform-xmpp/src/incoming-handlers.ts
+++ b/packages/platform-xmpp/src/incoming-handlers.ts
@@ -424,8 +424,8 @@ export class IncomingHandlers {
             this.presence(stanza);
         } else if (stanza.is("iq")) {
             if (
-                stanza.attrs.id === "muc_id" &&
-                stanza.attrs.type === "result"
+                stanza.attrs.type === "result" &&
+                stanza.attrs.id?.startsWith("attendance_")
             ) {
                 this.session?.log.debug("got room attendance list");
                 this.notifyRoomAttendance(stanza);

--- a/packages/platform-xmpp/src/index.test.ts
+++ b/packages/platform-xmpp/src/index.test.ts
@@ -599,16 +599,12 @@ describe("XMPP", () => {
                         "query",
                         { xmlns: "http://jabber.org/protocol/disco#items" },
                     ]);
-                    expect(xmlFake.getCall(1).args).toEqual([
-                        "iq",
-                        {
-                            id: "muc_id",
-                            type: "get",
-                            from: "testingham@jabber.net",
-                            to: "partyroom@jabber.net",
-                        },
-                        undefined,
-                    ]);
+                    expect(xmlFake.getCall(1).args[0]).toEqual("iq");
+                    expect(xmlFake.getCall(1).args[1].type).toEqual("get");
+                    expect(xmlFake.getCall(1).args[1].from).toEqual("testingham@jabber.net");
+                    expect(xmlFake.getCall(1).args[1].to).toEqual("partyroom@jabber.net");
+                    expect(xmlFake.getCall(1).args[1].id).toMatch(/^attendance_/);
+                    expect(xmlFake.getCall(1).args[2]).toBeUndefined();
                     done();
                 });
             });

--- a/packages/platform-xmpp/src/index.ts
+++ b/packages/platform-xmpp/src/index.ts
@@ -596,12 +596,14 @@ export default class XMPP implements PersistentPlatformInterface {
                 .then(() => done())
                 .catch(done);
         } else {
+            const queryId = `attendance_${randomUUID()}`;
+
             this.__client
                 .send(
                     this.__xml(
                         "iq",
                         {
-                            id: "muc_id",
+                            id: queryId,
                             type: "get",
                             from: job.actor.id,
                             to: job.target?.id,


### PR DESCRIPTION
## Summary

XMPP attendance IQ stanzas now use unique per-query IDs instead of a single fixed `muc_id`, so concurrent attendance/room queries no longer collide on their response correlation.

## Why this matters

The XMPP platform sent attendance/room-info IQ queries with a hardcoded `id` (#1090). Multiple in-flight queries shared one ID, so responses could be correlated to the wrong request. This generates a unique `attendance_`-prefixed ID per query and matches incoming responses against it, mirroring the pattern the room-info path already uses.

## Testing

- `bun test packages/platform-xmpp/` passes (99 tests); the stale fixed-ID assertions were updated to assert the dynamic `attendance_` shape.

Closes #1090


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved attendance query request/response matching by using unique identifiers instead of static IDs, ensuring more reliable routing of attendance-related responses.
  * Updated test coverage to validate new attendance query ID generation and response handling logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->