### PR TITLE
ci: de-flake browser integration suite (metadata fixture, multiclient delivery barrier, contract job split)

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -107,9 +107,6 @@ jobs:
       - name: Basic Browser Integration Tests
         run: XMPP_HOST=prosody bun run integration:browser:basic
 
-      - name: Platform Response Contract Tests
-        run: XMPP_HOST=prosody bun run integration:browser:contract
-
       - name: Sockethub Logs - Basic
         if: always()
         continue-on-error: true
@@ -204,3 +201,45 @@ jobs:
         if: always()
         continue-on-error: true
         run: docker logs --since "${{ env.START_TIME }}" sockethub-ergo-1
+
+  contract:
+    runs-on: ubuntu-latest
+
+    steps:
+      - run: sudo chown -R $USER:$USER ${{ github.workspace }}
+      - name: Checkout repository
+        uses: actions/checkout@v3
+      - name: Use Bun latest
+        uses: oven-sh/setup-bun@v2.0.1
+        with:
+          bun-version: latest
+      - run: bun install
+      - run: bun run build
+
+      - run: docker compose build --build-arg bun_version=latest --build-arg LOG_LEVEL=debug
+
+      # Contract tests only exercise the feeds, dummy, and metadata platforms,
+      # which need Sockethub + Redis (sockethub depends_on redis) — no XMPP/IRC.
+      # Running in a dedicated job keeps a flaky XMPP/IRC delivery race in the
+      # browser job from blocking unrelated contract changes, and vice versa.
+      - run: docker compose up sockethub -d
+      - run: sleep 5
+
+      - name: Verify Sockethub is listening externally
+        run: nc -zv localhost 10550
+
+      - name: Verify Redis is listening
+        run: nc -zv localhost 6379
+
+      - name: Verify Sockethub serves client files
+        run: |
+          curl -f http://localhost:10550/socket.io.js > /dev/null
+          curl -f http://localhost:10550/sockethub-client.js > /dev/null
+
+      - name: Platform Response Contract Tests
+        run: bun run integration:browser:contract
+
+      - name: Sockethub Logs - Contract
+        if: always()
+        continue-on-error: true
+        run: docker logs sockethub-sockethub-1

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -11,6 +11,8 @@ jobs:
       - run: sudo chown -R $USER:$USER ${{ github.workspace }}
       - name: Checkout repository
         uses: actions/checkout@v3
+        with:
+          persist-credentials: false
       - name: Use Bun latest
         uses: oven-sh/setup-bun@v2.0.1
         with:
@@ -34,6 +36,8 @@ jobs:
       - run: sudo chown -R $USER:$USER ${{ github.workspace }}
       - name: Checkout repository
         uses: actions/checkout@v3
+        with:
+          persist-credentials: false
       - name: Use Bun latest
         uses: oven-sh/setup-bun@v2.0.1
         with:
@@ -72,6 +76,8 @@ jobs:
       - run: sudo chown -R $USER:$USER ${{ github.workspace }}
       - name: Checkout repository
         uses: actions/checkout@v3
+        with:
+          persist-credentials: false
       - name: Use Bun latest
         uses: oven-sh/setup-bun@v2.0.1
         with:
@@ -209,6 +215,8 @@ jobs:
       - run: sudo chown -R $USER:$USER ${{ github.workspace }}
       - name: Checkout repository
         uses: actions/checkout@v3
+        with:
+          persist-credentials: false
       - name: Use Bun latest
         uses: oven-sh/setup-bun@v2.0.1
         with:

--- a/integration/browser/multiclient.integration.js
+++ b/integration/browser/multiclient.integration.js
@@ -430,6 +430,7 @@ describe(`Multi-Client XMPP Integration Tests at ${config.sockethub.url}`, () =>
                 () => newSockethubClient.socket.connected,
                 config.timeouts.connect,
             );
+            await newSockethubClient.ready();
 
             // Set WRONG credentials (same actor JID, different resource)
             await setXMPPCredentials(

--- a/integration/browser/multiclient.integration.js
+++ b/integration/browser/multiclient.integration.js
@@ -207,19 +207,24 @@ describe(`Multi-Client XMPP Integration Tests at ${config.sockethub.url}`, () =>
             );
 
             // Wait for messages to propagate to other clients
-            // Use longer timeout for multi-client tests due to XMPP routing delays
+            // Use longer timeout for multi-client tests due to XMPP routing delays.
+            // The gate must exclude the sender's own echoed message; otherwise it
+            // can be satisfied by [sender echo + N-2 peers] and resolve one
+            // delivery early, only for the sender-excluding assertion below to
+            // then fail with one fewer message than required.
+            const peerDeliveries = () =>
+                messageLog.filter(
+                    (log) =>
+                        log.message?.object?.content === testMessage &&
+                        log.message?.type === "send" &&
+                        log.clientId !== sendingClientRecord.jid,
+                ).length;
             await waitFor(
-                () =>
-                    messageLog.filter(
-                        (log) =>
-                            log.message?.object?.content === testMessage &&
-                            log.message?.type === "send",
-                    ).length >=
-                    CLIENT_COUNT - 1,
+                () => peerDeliveries() >= CLIENT_COUNT - 1,
                 config.timeouts.multiClientMessage,
                 50,
                 () =>
-                    `Received ${messageLog.filter((log) => log.message?.object?.content === testMessage).length}/${CLIENT_COUNT - 1} messages`,
+                    `Received ${peerDeliveries()}/${CLIENT_COUNT - 1} messages`,
             );
 
             // Verify message was received by other clients

--- a/integration/browser/multiclient.integration.js
+++ b/integration/browser/multiclient.integration.js
@@ -4,7 +4,6 @@ import {
     connectXMPP,
     getConfig,
     joinXMPPRoom,
-    queryRoomAttendance,
     sendXMPPMessage,
     setXMPPCredentials,
     validateGlobals,
@@ -36,8 +35,11 @@ async function ensureSocketsConnected(records) {
     );
 }
 
-async function waitForStableRoomDelivery(records, messageLog) {
-    const sender = records[records.length - 1];
+async function waitForStableRoomDelivery(
+    records,
+    messageLog,
+    sender = records[records.length - 1],
+) {
     const maxAttempts = 3;
 
     for (let attempt = 1; attempt <= maxAttempts; attempt++) {
@@ -82,31 +84,6 @@ async function waitForStableRoomDelivery(records, messageLog) {
             await new Promise((resolve) => setTimeout(resolve, 500 * attempt));
         }
     }
-}
-
-// Poll the room's attendance list until the server reports every client as an
-// occupant. This is the precondition for MUC fan-out: a message is only routed
-// to clients already present when it is broadcast (the room does not replay it
-// to late joiners). Asserting membership before sending closes the join race at
-// its source instead of inferring it by bouncing messages.
-async function waitForRoomOccupancy(sender, expectedCount, timeout) {
-    const startTime = Date.now();
-    let members = [];
-    while (Date.now() - startTime < timeout) {
-        members = await queryRoomAttendance(
-            sender.sockethubClient,
-            sender.jid,
-            config.prosody.room,
-        );
-        if (members.length >= expectedCount) {
-            return members;
-        }
-        await new Promise((resolve) => setTimeout(resolve, 200));
-    }
-    throw new Error(
-        `Room never reached ${expectedCount} occupants within ${timeout}ms; ` +
-            `last saw ${members.length}: [${members.join(", ")}]`,
-    );
 }
 
 describe(`Multi-Client XMPP Integration Tests at ${config.sockethub.url}`, () => {
@@ -218,59 +195,15 @@ describe(`Multi-Client XMPP Integration Tests at ${config.sockethub.url}`, () =>
 
     describe("Cross-Client Message Verification", () => {
         it("message from client 1 is received by all other clients", async () => {
-            const testMessage = `Test message from client 1 at ${Date.now()}`;
-            const sendingClientRecord = records[0];
-
-            // Confirm every client is registered as a room occupant before
-            // broadcasting, so the message cannot be lost to a client whose MUC
-            // join has not fully propagated yet.
-            await waitForRoomOccupancy(
-                sendingClientRecord,
-                CLIENT_COUNT,
-                config.timeouts.multiClientMessage,
-            );
-
-            // Clear message log (drops the attendance query responses above)
             messageLog.length = 0;
 
-            // Send message from client 1
-            await sendXMPPMessage(
-                sendingClientRecord.sockethubClient,
-                sendingClientRecord.jid,
-                config.prosody.room,
-                testMessage,
-            );
-
-            // Wait for messages to propagate to other clients
-            // Use longer timeout for multi-client tests due to XMPP routing delays.
-            // The gate must exclude the sender's own echoed message; otherwise it
-            // can be satisfied by [sender echo + N-2 peers] and resolve one
-            // delivery early, only for the sender-excluding assertion below to
-            // then fail with one fewer message than required.
-            const peerDeliveries = () =>
-                messageLog.filter(
-                    (log) =>
-                        log.message?.object?.content === testMessage &&
-                        log.message?.type === "send" &&
-                        log.clientId !== sendingClientRecord.jid,
-                ).length;
-            await waitFor(
-                () => peerDeliveries() >= CLIENT_COUNT - 1,
-                config.timeouts.multiClientMessage,
-                50,
-                () =>
-                    `Received ${peerDeliveries()}/${CLIENT_COUNT - 1} messages`,
-            );
-
-            // Verify message was received by other clients
-            const receivedMessages = messageLog.filter(
-                (log) =>
-                    log.message?.object?.content === testMessage &&
-                    log.message?.type === "send" &&
-                    log.clientId !== sendingClientRecord.jid,
-            );
-
-            expect(receivedMessages).to.have.length.at.least(CLIENT_COUNT - 1);
+            // A MUC only delivers a message to occupants already present when it
+            // is broadcast; it is not replayed to a peer whose join has not yet
+            // propagated. A single send is therefore racy. waitForStableRoomDelivery
+            // re-sends a freshly tagged message (with backoff) until every peer
+            // receives one, converging on confirmed room-wide delivery and failing
+            // only if it never reaches all peers within the attempts.
+            await waitForStableRoomDelivery(records, messageLog, records[0]);
         });
 
         it("rapid messages from multiple clients are all delivered", async () => {

--- a/integration/browser/multiclient.integration.js
+++ b/integration/browser/multiclient.integration.js
@@ -4,6 +4,7 @@ import {
     connectXMPP,
     getConfig,
     joinXMPPRoom,
+    queryRoomAttendance,
     sendXMPPMessage,
     setXMPPCredentials,
     validateGlobals,
@@ -81,6 +82,31 @@ async function waitForStableRoomDelivery(records, messageLog) {
             await new Promise((resolve) => setTimeout(resolve, 500 * attempt));
         }
     }
+}
+
+// Poll the room's attendance list until the server reports every client as an
+// occupant. This is the precondition for MUC fan-out: a message is only routed
+// to clients already present when it is broadcast (the room does not replay it
+// to late joiners). Asserting membership before sending closes the join race at
+// its source instead of inferring it by bouncing messages.
+async function waitForRoomOccupancy(sender, expectedCount, timeout) {
+    const startTime = Date.now();
+    let members = [];
+    while (Date.now() - startTime < timeout) {
+        members = await queryRoomAttendance(
+            sender.sockethubClient,
+            sender.jid,
+            config.prosody.room,
+        );
+        if (members.length >= expectedCount) {
+            return members;
+        }
+        await new Promise((resolve) => setTimeout(resolve, 200));
+    }
+    throw new Error(
+        `Room never reached ${expectedCount} occupants within ${timeout}ms; ` +
+            `last saw ${members.length}: [${members.join(", ")}]`,
+    );
 }
 
 describe(`Multi-Client XMPP Integration Tests at ${config.sockethub.url}`, () => {
@@ -195,7 +221,16 @@ describe(`Multi-Client XMPP Integration Tests at ${config.sockethub.url}`, () =>
             const testMessage = `Test message from client 1 at ${Date.now()}`;
             const sendingClientRecord = records[0];
 
-            // Clear message log
+            // Confirm every client is registered as a room occupant before
+            // broadcasting, so the message cannot be lost to a client whose MUC
+            // join has not fully propagated yet.
+            await waitForRoomOccupancy(
+                sendingClientRecord,
+                CLIENT_COUNT,
+                config.timeouts.multiClientMessage,
+            );
+
+            // Clear message log (drops the attendance query responses above)
             messageLog.length = 0;
 
             // Send message from client 1

--- a/integration/browser/shared-setup.js
+++ b/integration/browser/shared-setup.js
@@ -254,67 +254,6 @@ export function sendXMPPMessage(sh, jid, room, content) {
     });
 }
 
-// Query MUC occupancy (disco#items) and resolve with the room's member list.
-//
-// The emit ack only confirms the attendance IQ was *sent*; the member list
-// arrives later as a separate inbound `type: "query"` message, so we listen for
-// that and race it against a safety timeout.
-export function queryRoomAttendance(sh, jid, room = config.prosody.room) {
-    return new Promise((resolve, reject) => {
-        const onMessage = (msg) => {
-            if (
-                msg?.type === "query" &&
-                msg?.object?.type === "attendance" &&
-                msg?.target?.id === jid
-            ) {
-                cleanup();
-                resolve(
-                    Array.isArray(msg.object.members) ? msg.object.members : [],
-                );
-            }
-        };
-        const timer = setTimeout(() => {
-            cleanup();
-            reject(
-                new Error(`Attendance query timed out for ${jid} in ${room}`),
-            );
-        }, config.timeouts.message);
-        function cleanup() {
-            clearTimeout(timer);
-            sh.socket.off("message", onMessage);
-        }
-
-        sh.socket.on("message", onMessage);
-        emitWithAck(
-            sh.socket,
-            "message",
-            {
-                type: "query",
-                actor: asPersonActor(jid),
-                "@context": ctx("xmpp"),
-                target: { type: "room", id: room },
-                object: { type: "attendance" },
-            },
-            { label: "xmpp attendance query" },
-        ).then(
-            (msg) => {
-                if (msg?.error) {
-                    cleanup();
-                    reject(
-                        new Error(
-                            `Attendance query failed for ${jid}: ${msg.error}`,
-                        ),
-                    );
-                }
-            },
-            (err) => {
-                cleanup();
-                reject(err);
-            },
-        );
-    });
-}
-
 // --- IRC helpers ---
 //
 // platform-irc has a few non-obvious constraints these helpers encode:

--- a/integration/browser/shared-setup.js
+++ b/integration/browser/shared-setup.js
@@ -254,6 +254,67 @@ export function sendXMPPMessage(sh, jid, room, content) {
     });
 }
 
+// Query MUC occupancy (disco#items) and resolve with the room's member list.
+//
+// The emit ack only confirms the attendance IQ was *sent*; the member list
+// arrives later as a separate inbound `type: "query"` message, so we listen for
+// that and race it against a safety timeout.
+export function queryRoomAttendance(sh, jid, room = config.prosody.room) {
+    return new Promise((resolve, reject) => {
+        const onMessage = (msg) => {
+            if (
+                msg?.type === "query" &&
+                msg?.object?.type === "attendance" &&
+                msg?.target?.id === jid
+            ) {
+                cleanup();
+                resolve(
+                    Array.isArray(msg.object.members) ? msg.object.members : [],
+                );
+            }
+        };
+        const timer = setTimeout(() => {
+            cleanup();
+            reject(
+                new Error(`Attendance query timed out for ${jid} in ${room}`),
+            );
+        }, config.timeouts.message);
+        function cleanup() {
+            clearTimeout(timer);
+            sh.socket.off("message", onMessage);
+        }
+
+        sh.socket.on("message", onMessage);
+        emitWithAck(
+            sh.socket,
+            "message",
+            {
+                type: "query",
+                actor: asPersonActor(jid),
+                "@context": ctx("xmpp"),
+                target: { type: "room", id: room },
+                object: { type: "attendance" },
+            },
+            { label: "xmpp attendance query" },
+        ).then(
+            (msg) => {
+                if (msg?.error) {
+                    cleanup();
+                    reject(
+                        new Error(
+                            `Attendance query failed for ${jid}: ${msg.error}`,
+                        ),
+                    );
+                }
+            },
+            (err) => {
+                cleanup();
+                reject(err);
+            },
+        );
+    });
+}
+
 // --- IRC helpers ---
 //
 // platform-irc has a few non-obvious constraints these helpers encode:

--- a/integration/browser/test-runner.js
+++ b/integration/browser/test-runner.js
@@ -17,6 +17,11 @@ const configContent = `export default {
     nodeResolve: true,
     open: ${process.argv.includes("--open")},
     manual: ${process.argv.includes("--manual")},
+    // The browser job launches headless Chrome alongside a full docker stack
+    // (sockethub, prosody, ergo, redis), so a cold start can exceed the 30s
+    // default and fail with "unable to create and start a test page".
+    browserStartTimeout: 120000,
+    testsStartTimeout: 60000,
     testRunnerHtml: (testFramework) => \`
         <!DOCTYPE html>
         <html>

--- a/integration/contract/platform-responses.integration.js
+++ b/integration/contract/platform-responses.integration.js
@@ -135,7 +135,10 @@ describe(`Platform response contracts at ${config.sockethub.url}`, () => {
 
     describe("metadata platform", () => {
         it("returns page object fields the examples metadata view expects", async () => {
-            const fixtureUrl = `${config.sockethub.url}/metadata-test.html`;
+            const fixtureUrl = `${config.sockethub.url.replace(
+                "://localhost:",
+                "://127.0.0.1:",
+            )}/metadata-test.html`;
             const msg = await emitWithAck(
                 sc.socket,
                 "message",

--- a/integration/contract/platform-responses.integration.js
+++ b/integration/contract/platform-responses.integration.js
@@ -135,6 +135,7 @@ describe(`Platform response contracts at ${config.sockethub.url}`, () => {
 
     describe("metadata platform", () => {
         it("returns page object fields the examples metadata view expects", async () => {
+            const fixtureUrl = `${config.sockethub.url}/metadata-test.html`;
             const msg = await emitWithAck(
                 sc.socket,
                 "message",
@@ -143,7 +144,7 @@ describe(`Platform response contracts at ${config.sockethub.url}`, () => {
                     type: "fetch",
                     actor: {
                         type: "website",
-                        id: "https://sockethub.org",
+                        id: fixtureUrl,
                     },
                 },
                 { label: "metadata contract" },
@@ -155,9 +156,15 @@ describe(`Platform response contracts at ${config.sockethub.url}`, () => {
             expect(msg.actor).to.have.property("id").that.is.a("string");
             expect(msg.object).to.be.an("object");
             expect(msg.object).to.have.property("type", "page");
-            expect(msg.object).to.have.property("title");
-            expect(msg.object).to.have.property("url");
-            expect(msg.object).to.have.property("description");
+            expect(msg.object).to.have.property(
+                "title",
+                "Sockethub Metadata Test",
+            );
+            expect(msg.object).to.have.property("url", fixtureUrl);
+            expect(msg.object).to.have.property(
+                "description",
+                "Local metadata fixture for integration tests",
+            );
         });
     });
 });

--- a/packages/examples/static/metadata-test.html
+++ b/packages/examples/static/metadata-test.html
@@ -7,6 +7,7 @@
     <meta property="og:title" content="Sockethub Metadata Test">
     <meta property="og:description" content="Local metadata fixture for integration tests">
     <meta property="og:type" content="website">
+    <meta property="og:url" content="http://127.0.0.1:10550/metadata-test.html">
   </head>
   <body>
     <h1>Sockethub Metadata Test</h1>

--- a/packages/examples/static/metadata-test.html
+++ b/packages/examples/static/metadata-test.html
@@ -1,0 +1,15 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <title>Sockethub Metadata Test</title>
+    <meta name="description" content="Local metadata fixture for integration tests">
+    <meta property="og:title" content="Sockethub Metadata Test">
+    <meta property="og:description" content="Local metadata fixture for integration tests">
+    <meta property="og:type" content="website">
+  </head>
+  <body>
+    <h1>Sockethub Metadata Test</h1>
+    <p>Local metadata fixture for integration tests.</p>
+  </body>
+</html>


### PR DESCRIPTION
## Summary

De-flakes the integration **browser** CI job, which began failing intermittently once #1098 added the contract tests to it. Several independent flaky failure modes were in play; this PR addresses each and isolates them so one can't block the others.

### 1. Metadata contract test — remove the external network dependency
- Add a local `metadata-test.html` fixture served by the examples app.
- Point the metadata contract test at the local fixture instead of `https://sockethub.org`, and assert deterministic title/url/description values.
- Use a `127.0.0.1` fixture URL when `config.sockethub.url` is localhost (IP literals satisfy `open-graph-scraper`'s URL validator without touching production scraper options).

### 2. Multiclient XMPP test — fix the cross-client delivery race
- A MUC only delivers a message to occupants already present when it is broadcast (no replay to late joiners). The test sent a single message immediately after join, so a slightly-late occupant could permanently miss it.
- Gate the broadcast on a **resend-until-delivered barrier**: generalize the existing `waitForStableRoomDelivery` helper to take a sender, and have the cross-client test delegate to it. It re-sends a freshly tagged message (with backoff) until every peer (excluding the sender) receives one, converging on confirmed room-wide delivery and failing only if delivery never completes.
- (An attendance-query barrier via the platform's `disco#items` feature was attempted first, but prosody returns an empty occupant list for the room in this setup, so it can't confirm membership — see notes.)

### 3. Isolate contract tests in their own CI job
- Move the platform contract tests (feeds/dummy/metadata) out of the `browser` job into a dedicated `contract` job that starts only Sockethub + Redis (no XMPP/IRC).
- A flaky XMPP/IRC delivery race in the `browser` job no longer blocks unrelated contract changes, and vice versa.

### 4. Browser job startup flake
- Headless Chrome intermittently failed to start within web-test-runner's 30s default ("unable to create and start a test page") while sharing the runner with the full docker stack. Raised `browserStartTimeout`/`testsStartTimeout`.

### Other
- Multiclient mismatched-credentials test now waits for `SockethubClient.ready()` before emitting credentials, without increasing the credential ACK timeout.
- `persist-credentials: false` on all `integration.yml` checkout steps (none of these jobs need the token).

## Notes
- **SSRF (deferred to #1109):** `platform-metadata` passes the client-controlled `actor.id` to `open-graph-scraper` with no private/loopback filtering. This is a pre-existing gap and a proper fix conflicts with the local-fixture approach here, so it's split into a focused security PR (#1109).
- **Attendance feature gap:** the room-attendance (`disco#items`) query returns an empty occupant list against the integration prosody, so it currently has no usable integration coverage; worth a separate look.

## Validation
- `bun run lint`
- `bun run build`
- Browser/contract behavior verified via CI (local Docker is unavailable in this environment).
