### PR TITLE
fix(platform-metadata): accept TLD-less hosts so localhost fixtures are fetchable

### DIFF
--- a/integration/contract/platform-responses.integration.js
+++ b/integration/contract/platform-responses.integration.js
@@ -135,10 +135,12 @@ describe(`Platform response contracts at ${config.sockethub.url}`, () => {
 
     describe("metadata platform", () => {
         it("returns page object fields the examples metadata view expects", async () => {
-            const fixtureUrl = `${config.sockethub.url.replace(
-                "://localhost:",
-                "://127.0.0.1:",
-            )}/metadata-test.html`;
+            // Fetch the fixture via the same base URL the rest of the suite uses.
+            // An earlier revision rewrote localhost -> 127.0.0.1 to satisfy the
+            // scraper's URL validator, but that broke when Sockethub binds only to
+            // IPv6 localhost (::1) — the IPv4 fetch was refused. The metadata
+            // platform now accepts TLD-less hosts, so localhost works everywhere.
+            const fixtureUrl = `${config.sockethub.url}/metadata-test.html`;
             const msg = await emitWithAck(
                 sc.socket,
                 "message",

--- a/packages/examples/static/metadata-test.html
+++ b/packages/examples/static/metadata-test.html
@@ -7,7 +7,7 @@
     <meta property="og:title" content="Sockethub Metadata Test">
     <meta property="og:description" content="Local metadata fixture for integration tests">
     <meta property="og:type" content="website">
-    <meta property="og:url" content="http://127.0.0.1:10550/metadata-test.html">
+    <meta property="og:url" content="http://localhost:10550/metadata-test.html">
   </head>
   <body>
     <h1>Sockethub Metadata Test</h1>

--- a/packages/platform-metadata/src/index.ts
+++ b/packages/platform-metadata/src/index.ts
@@ -33,6 +33,26 @@ export default class Metadata implements PlatformInterface {
         this.log.debug(`fetching ${job.actor.id}`);
         ogs({
             url: job.actor.id,
+            // open-graph-scraper *replaces* (does not merge) the default URL
+            // validator settings, so we restate the defaults and only relax
+            // require_tld. This lets the scraper accept TLD-less hosts such as
+            // `localhost` and intranet names. Note: the default validator already
+            // accepts bare IPs, so this does not introduce a new SSRF class on its
+            // own — see the SSRF hardening tracked separately.
+            urlValidatorSettings: {
+                allow_fragments: true,
+                allow_protocol_relative_urls: false,
+                allow_query_components: true,
+                allow_trailing_dot: false,
+                allow_underscores: false,
+                protocols: ["http", "https"],
+                require_host: true,
+                require_port: false,
+                require_protocol: false,
+                require_tld: false,
+                require_valid_protocol: true,
+                validate_length: true,
+            },
         })
             .then((data) => {
                 const { result } = data;


### PR DESCRIPTION
## Summary

Fixes the `browser-contract` failure in the **Test NPM Package** workflow (run [27139752074](https://github.com/sockethub/sockethub/actions/runs/27139752074)) that surfaced after #1108 merged. CI was green but the packaged run failed:

```
❌ metadata platform > returns page object fields...
   Error: metadata fetch: connect ECONNREFUSED 127.0.0.1:10550
```

## Root cause

#1108 rewrote the metadata fixture URL `localhost` → `127.0.0.1` purely to satisfy `open-graph-scraper`'s URL validator (`require_tld: true` rejects bare `localhost`). But Sockethub listens on `config sockethub:host` (default `localhost`), which on the GitHub runner resolves to **IPv6 `::1`** — so the metadata platform's IPv4 `127.0.0.1` fetch was refused. In docker CI, Sockethub binds to all interfaces, so `127.0.0.1` happened to work — which is why the PR's own CI was green. The feeds contract test (same run) used `localhost` and passed, confirming `localhost` is the universally reachable address.

## Fix

- `platform-metadata`: relax the scraper's URL validator to allow TLD-less hosts (`require_tld: false`). Since ogs *replaces* rather than merges `urlValidatorSettings`, the other defaults are restated. This is the approach CodeRabbit originally recommended (option a) on #1108.
- Contract test: fetch the fixture via `config.sockethub.url` (`localhost`) — reachable in both docker and host environments — instead of the IPv4-only `127.0.0.1` rewrite.
- Fixture: `og:url` updated to the `localhost` form to match.

## SSRF note (#1109)

`require_tld: false` lets the metadata platform fetch bare hostnames (e.g. `localhost`, intranet names). The default validator **already** accepts bare IPs, so IP-based SSRF was always possible and this does not introduce a new class of exposure on its own. The proper mitigation remains #1109 (block private/loopback targets by **resolved IP**, which must now also cover hostname-resolved IPs).

## Validation
- `bun run lint`, `bun run build` (platform-metadata)
- Confirmed against the installed `open-graph-scraper@6.11.0` that `isUrlValid("http://localhost:10550/metadata-test.html", { ...defaults, require_tld: false })` returns `true` (and `false` with the defaults — the original failure mode).
- Full packaged verification runs in the Test NPM Package workflow.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes

* Fixed metadata URL validation and configuration handling to properly support localhost development environments, enabling consistent behavior across local development setups.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->