### PR TITLE
test: start Ergo IRC server for the browser suite in npm-package test

### DIFF
--- a/scripts/test-installed-version/services.js
+++ b/scripts/test-installed-version/services.js
@@ -20,7 +20,10 @@ export class ServiceManager {
 
         const needsRedis = ["all", "browser"].includes(suite);
         const needsXmpp = ["all", "browser"].includes(suite);
-        const needsIrc = suite === "all";
+        // The "browser" suite includes the IRC browser tests (see runner.js),
+        // so it needs the Ergo IRC server too. Without this, `suite=browser`
+        // runs the IRC tests with no server and they fail to connect.
+        const needsIrc = ["all", "browser"].includes(suite);
 
         if (needsRedis) {
             await this.startRedis();


### PR DESCRIPTION
## Problem

In the Test NPM Package harness, `scripts/test-installed-version/services.js` only started the Ergo IRC container when `suite === "all"`:

```js
const needsIrc = suite === "all";
```

But the `browser` suite (`runner.js` `runBrowserTests()`) includes the four IRC browser tests (`browser-irc-basic`, `-multiclient`, `-reconnection`, `-nickclash`). So running with `suite=browser` executes those IRC tests with no IRC server, and they fail-fast with `error connecting to server`.

## Fix

Start Ergo for the `browser` suite too, matching `needsXmpp`/`needsRedis`:

```js
const needsIrc = ["all", "browser"].includes(suite);
```

## Notes
- Does not affect `suite=all` runs (the default), which already started Ergo.
- Surfaced while verifying #1111; a `suite=browser` dispatch spuriously failed all four IRC tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved test infrastructure: Browser test suite now properly initializes the IRC server when required for test execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->