### PR TITLE
chore: use LOG_LEVEL (winston) everywhere, drop legacy DEBUG

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,0 +1,4 @@
+reviews:
+  path_filters:
+    - "!build/**"
+    - "!packages/examples/**"

--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,4 +1,4 @@
 reviews:
   path_filters:
     - "!build/**"
-    - "!packages/examples/**"
+    - "!dist/**"

--- a/README.md
+++ b/README.md
@@ -154,7 +154,7 @@ For debugging and configuration options, see the [Server package documentation](
 **Debug logging:**
 
 ```bash
-DEBUG=sockethub* bun run dev
+LOG_LEVEL=debug bun run dev
 ```
 
 ## Packages

--- a/packages/server/README.md
+++ b/packages/server/README.md
@@ -52,7 +52,7 @@ and [Sockethub wiki](https://github.com/sockethub/sockethub/wiki).
 
 ## Running
 
-`$ DEBUG=sockethub* bunx @sockethub/server`
+`$ LOG_LEVEL=debug bunx @sockethub/server`
 
 ### Environment Variables
 
@@ -64,11 +64,11 @@ Default: `10550`
 
 Default: `localhost`
 
-- DEBUG
+- LOG_LEVEL
 
-Specify the namespace to console log, e.g. `sockethub*` will print all sockethub
-related debug statements, whereas `*` will also print any other modules debug
-statements that use the `debug` module.
+Console log level: `error`, `warn`, `info` (default), or `debug`. Set to
+`debug` to print all Sockethub debug statements. See also `LOG_FILE_LEVEL` and
+`LOG_FILE`.
 
 - REDIS_PORT
 
@@ -126,14 +126,14 @@ debugging in production environments.
 
 Run with debug output and examples enabled:
 
-`$ DEBUG=sockethub* bin/sockethub --examples`
+`$ LOG_LEVEL=debug bin/sockethub --examples`
 
 You should then be able to browse to `http://localhost:10550/examples` and try
 out the examples.
 
 For production, with examples disabled.
 
-`$ DEBUG=sockethub* bin/sockethub`
+`$ LOG_LEVEL=debug bin/sockethub`
 
 ## License
 

--- a/packages/sockethub/bin/sockethub-logged
+++ b/packages/sockethub/bin/sockethub-logged
@@ -1,16 +1,17 @@
 #!/usr/bin/env bun
 /**
  * Sockethub launcher with split logging:
- * - Console: filtered via DEBUG pattern
+ * - Console: filtered via namespace patterns
  * - File: full debug output to sockethub.log
  */
 import { spawn } from "node:child_process";
 import { createWriteStream } from "node:fs";
 import { dirname, join } from "node:path";
-import debug from "debug";
 
-// Console filter using DEBUG syntax
-const CONSOLE_DEBUG = [
+// Console namespace filter. Include patterns show a namespace; a leading "-"
+// excludes it; "*" matches any run of characters. (Self-contained matcher so we
+// don't depend on the legacy `debug` package — Sockethub logs via winston.)
+const CONSOLE_FILTER = [
     "sockethub:init",
     "sockethub:server:bootstrap:*",
     "sockethub:server:core",
@@ -18,14 +19,29 @@ const CONSOLE_DEBUG = [
     "sockethub:server:listener",
     "sockethub:server:janitor",
     "sockethub:server:rate-limiter",
-].join(",");
+];
 
-// Create a filter function using debug's enable/disable logic
-debug.enable(CONSOLE_DEBUG);
-const shouldShow = (namespace: string) => debug.enabled(namespace);
+function patternToRegExp(pattern: string): RegExp {
+    const escaped = pattern.replace(/[.+?^${}()|[\]\\]/g, "\\$&");
+    return new RegExp(`^${escaped.replace(/\*/g, ".*?")}$`);
+}
 
-// Extract namespace from debug output line
-// Format: "  sockethub:namespace message +0ms" (with optional ANSI colors)
+const includes = CONSOLE_FILTER.filter((p) => !p.startsWith("-")).map(
+    patternToRegExp,
+);
+const excludes = CONSOLE_FILTER.filter((p) => p.startsWith("-")).map((p) =>
+    patternToRegExp(p.slice(1)),
+);
+
+const shouldShow = (namespace: string): boolean => {
+    if (excludes.some((re) => re.test(namespace))) {
+        return false;
+    }
+    return includes.some((re) => re.test(namespace));
+};
+
+// Extract the sockethub namespace from a winston log line
+// (e.g. "2026-… debug: sockethub:server:core message", with optional ANSI colors)
 const namespaceRegex = /sockethub:[^\s\x1b]+/;
 function getNamespace(line: string): string | null {
     const match = line.match(namespaceRegex);
@@ -38,7 +54,7 @@ const timestamp = () => new Date().toISOString();
 logFile.write(`\n--- Sockethub started at ${timestamp()} ---\n`);
 
 const child = spawn("bun", ["run", join(dirname(import.meta.path), "sockethub")], {
-    env: { ...process.env, DEBUG: "sockethub:*", DEBUG_COLORS: "true" },
+    env: { ...process.env, LOG_LEVEL: "debug" },
     stdio: ["inherit", "pipe", "pipe"],
 });
 
@@ -46,7 +62,7 @@ function processLine(line: string, stream: "stdout" | "stderr") {
     // Always write to file
     logFile.write(`${line}\n`);
 
-    // Check if namespace passes DEBUG filter
+    // Check if namespace passes the console filter
     // Non-debug lines (console.log from init, errors) are always shown
     const namespace = getNamespace(line);
     const show = namespace

--- a/scripts/test-installed-version/services.js
+++ b/scripts/test-installed-version/services.js
@@ -172,7 +172,8 @@ export class ServiceManager {
                     ...process.env,
                     REDIS_URL: "redis://127.0.0.1:6379",
                     PORT: "10550",
-                    DEBUG: "sockethub*",
+                    // @sockethub/logger (winston) keys off LOG_LEVEL, not DEBUG.
+                    LOG_LEVEL: "debug",
                 },
             },
             "sockethub.log",

--- a/scripts/test-installed-version/services.js
+++ b/scripts/test-installed-version/services.js
@@ -175,7 +175,6 @@ export class ServiceManager {
                     ...process.env,
                     REDIS_URL: "redis://127.0.0.1:6379",
                     PORT: "10550",
-                    // @sockethub/logger (winston) keys off LOG_LEVEL, not DEBUG.
                     LOG_LEVEL: "debug",
                 },
             },


### PR DESCRIPTION
## Why

Sockethub logs via `@sockethub/logger` (winston), which takes its level from **`LOG_LEVEL`** (default `info`). Several places still used the legacy `debug` package's **`DEBUG`** env var, which is a **silent no-op** for winston — so "debug" output was never actually enabled, and logs stayed at `info`.

This bit us concretely: the Test NPM Package harness set `DEBUG=sockethub*` and captured **zero debug lines**, which is why the server-side `server:core` connection/credentials logs were missing when diagnosing the credential-ACK flake.

## Changes

- **`scripts/test-installed-version/services.js`** — spawn sockethub with `LOG_LEVEL=debug` instead of `DEBUG=sockethub*`, so the npm-package test actually captures server debug logs.
- **`packages/sockethub/bin/sockethub-logged`** — remove the `import debug from "debug"` (the `debug` package isn't even a declared dependency) and the child's `DEBUG`/`DEBUG_COLORS` env. Replace `debug.enable`/`debug.enabled` with a small self-contained namespace matcher (same include/exclude/`*` semantics) and run the child with `LOG_LEVEL=debug` so the file gets full debug output.
- **`README.md`, `packages/server/README.md`** — replace `DEBUG=sockethub*` examples and the `DEBUG` env-var doc entry with `LOG_LEVEL`.

## Notes
- No legacy `DEBUG`/`debug`-package usage remains anywhere in-tree.
- Matcher verified against the previous patterns (e.g. `sockethub:server:core` shows, `sockethub:server:core:<session>` excluded).
- `bin/sockethub-logged` is the `start` script in the root and sockethub package; it now produces real debug output to `sockethub.log` (previously it never did, since DEBUG was a no-op).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated debug logging instructions to use `LOG_LEVEL=debug bun run dev`
  * Updated environment variable documentation to reference `LOG_LEVEL` instead of previous approach

* **Chores**
  * Updated logging configuration across codebase to use `LOG_LEVEL` environment variable
  * Added code review path exclusions for build and examples directories

<!-- end of auto-generated comment: release notes by coderabbit.ai -->