### PR TITLE
test: await client connect+ready before sending credentials

### DIFF
--- a/integration/browser/multiclient.integration.js
+++ b/integration/browser/multiclient.integration.js
@@ -93,7 +93,7 @@ describe(`Multi-Client XMPP Integration Tests at ${config.sockethub.url}`, () =>
     const messageLog = [];
     const connectionLog = [];
 
-    before(() => {
+    before(async () => {
         for (let i = 1; i <= CLIENT_COUNT; i++) {
             const socket = io(config.sockethub.url, { path: "/sockethub" });
             const sockethubClient = new SockethubClient(socket);
@@ -115,6 +115,15 @@ describe(`Multi-Client XMPP Integration Tests at ${config.sockethub.url}`, () =>
 
             records.push(clientRecord);
         }
+
+        // Wait for every client to connect and finish initialization (schema
+        // registry loaded) before any test sends credentials. Otherwise the
+        // first test emits credentials while the clients are still connecting;
+        // SockethubClient queues them and the per-emit ack must then also cover
+        // connect + ready + flush, which races the credential ACK timeout.
+        await Promise.all(
+            records.map((clientRecord) => clientRecord.sockethubClient.ready()),
+        );
     });
 
     after(() => {


### PR DESCRIPTION
## Problem

The multiclient `before()` hook creates the `SockethubClient`s but **never waits for them to connect or finish initialization**. The first test, "all clients can set credentials simultaneously", then emits `credentials` immediately.

`SockethubClient` queues outbound events until it is `ready()` (schema registry loaded) and flushes them on connect. So the per-emit credential **ACK** has to cover **connect + ready + flush + server processing** within the 2s ACK timeout. Under the bun server runtime this intermittently lost the race:

```
[diag] handlePublicEmit event=credentials initState=idle isReady=false connected=false
Timeout waiting for ack after 2000ms for event=credentials
```

(Diagnosed via the Test NPM Package workflow — bun runtime. node was unaffected.)

## Fix

Make `before()` async and await `ready()` for every client before any test runs, so each test starts from a fully-connected, initialized client and the credential ACK only has to cover server processing.

## Notes
- Test-only change; no production or dependency changes (kept separate intentionally).
- This addresses the "client not ready at emit" failure mode. A separate, rarer mode (a fully-ready client's event apparently dropped by the bun socket.io server on an established connection) is tracked independently; the socket.io/engine.io dependency bump for that is a separate PR.