### PR TITLE
fix(server): skip delivery to disconnected sockets instead of error-spamming

### DIFF
--- a/packages/server/src/janitor.test.ts
+++ b/packages/server/src/janitor.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 import * as sinon from "sinon";
 
 import { Janitor } from "./janitor.js";
@@ -69,7 +69,7 @@ describe("Janitor", () => {
         }, janitor.cycleInterval * 2);
     });
 
-    it("runs cycle at every cycleInterval", (done) => {
+    test("runs cycle at every cycleInterval", (done) => {
         const currCycleCount = janitor.cycleCount;
         expect(currCycleCount).not.toEqual(0);
         setTimeout(() => {
@@ -83,7 +83,7 @@ describe("Janitor", () => {
     });
 
     describe("socketExists", () => {
-        it("reflects membership in the live connected-socket map", () => {
+        test("reflects membership in the live connected-socket map", () => {
             janitor.connectedSocketIds = sandbox
                 .stub()
                 .returns(new Map([["live session", {}]]));
@@ -93,7 +93,7 @@ describe("Janitor", () => {
     });
 
     describe("removeSessionCallbacks", () => {
-        it("removes session listeners and callbacks for a given platform", () => {
+        test("removes session listeners and callbacks for a given platform", () => {
             const pi = getPlatformInstanceFake();
             const barMessage = pi.sessionCallbacks.message.get("session bar");
             const barClose = pi.sessionCallbacks.close.get("session bar");
@@ -116,7 +116,7 @@ describe("Janitor", () => {
     });
 
     describe("removeStaleSocketSessions", () => {
-        it("doesnt do anything if the socket is active and stop is not flagged", async () => {
+        test("doesnt do anything if the socket is active and stop is not flagged", async () => {
             const pi = getPlatformInstanceFake();
             janitor.removeSessionCallbacks = sinon.stub();
             janitor.socketExists = sinon.stub().returns(true);
@@ -125,7 +125,7 @@ describe("Janitor", () => {
             sinon.assert.notCalled(janitor.removeSessionCallbacks);
         });
 
-        it("removes session if the socket is active and stop is flagged", async () => {
+        test("removes session if the socket is active and stop is flagged", async () => {
             const pi = getPlatformInstanceFake();
             janitor.removeSessionCallbacks = sinon.stub();
             janitor.socketExists = sinon.stub().returns(true);
@@ -145,7 +145,7 @@ describe("Janitor", () => {
             );
         });
 
-        it("removes session if the socket is inactive", async () => {
+        test("removes session if the socket is inactive", async () => {
             const pi = getPlatformInstanceFake();
             janitor.removeSessionCallbacks = sinon.stub();
             janitor.socketExists = sinon
@@ -166,7 +166,7 @@ describe("Janitor", () => {
     });
 
     describe("performStaleCheck", () => {
-        it("removes flagged and uninitialized platform instances", async () => {
+        test("removes flagged and uninitialized platform instances", async () => {
             const pi = getPlatformInstanceFake();
             pi.flaggedForTermination = true;
             pi.isInitialized.returns(false);
@@ -178,7 +178,7 @@ describe("Janitor", () => {
             expect(pi.flaggedForTermination).toBeTrue();
         });
 
-        it("flags for termination when there are not sockets", async () => {
+        test("flags for termination when there are not sockets", async () => {
             const pi = getPlatformInstanceFake();
             pi.sessions = new Set();
             pi.flaggedForTermination = false;
@@ -192,7 +192,7 @@ describe("Janitor", () => {
     });
 
     describe("removeStalePlatformInstance", () => {
-        it("flags stale platform", async () => {
+        test("flags stale platform", async () => {
             const pi = getPlatformInstanceFake();
             expect(pi.flaggedForTermination).toBeFalse();
             await janitor.removeStalePlatformInstance(pi);
@@ -200,7 +200,7 @@ describe("Janitor", () => {
             expect(pi.flaggedForTermination).toBeTrue();
         });
 
-        it("removes flagged stale platform", async () => {
+        test("removes flagged stale platform", async () => {
             const pi = getPlatformInstanceFake();
             pi.flaggedForTermination = true;
             await janitor.removeStalePlatformInstance(pi);
@@ -208,7 +208,7 @@ describe("Janitor", () => {
         });
     });
 
-    it("closes all connections when stop() is called", (done) => {
+    test("closes all connections when stop() is called", (done) => {
         const prevCycle = janitor.cycleCount;
         janitor.stop();
         setTimeout(() => {

--- a/packages/server/src/janitor.test.ts
+++ b/packages/server/src/janitor.test.ts
@@ -3,11 +3,6 @@ import * as sinon from "sinon";
 
 import { Janitor } from "./janitor.js";
 
-const sockets = [
-    { id: "socket foo", emit: () => {} },
-    { id: "socket bar", emit: () => {} },
-];
-
 function getPlatformInstanceFake() {
     return {
         flaggedForTermination: false,
@@ -44,20 +39,24 @@ function getPlatformInstanceFake() {
 const cycleInterval = 10;
 
 describe("Janitor", () => {
-    let sandbox, fetchSocketsFake, janitor;
+    let sandbox, janitor;
 
     beforeEach((done) => {
         sandbox = sinon.createSandbox();
-        fetchSocketsFake = sandbox.stub().returns(sockets);
 
         janitor = new Janitor();
-        janitor.getSockets = fetchSocketsFake;
+        // The live cycle reads socket.io's connected-socket map; stub it so the
+        // janitor can be tested without standing up a socket.io server.
+        janitor.connectedSocketIds = sandbox.stub().returns(new Map());
         expect(janitor.cycleInterval).not.toEqual(cycleInterval);
         janitor.cycleInterval = cycleInterval;
         expect(janitor.cycleInterval).toEqual(cycleInterval);
         janitor.start();
         setTimeout(() => {
-            expect(janitor.cycleCount).toEqual(1);
+            // The janitor has started and is cycling. Assert progress rather
+            // than an exact count — cycle timing against real timers is not
+            // deterministic to a single tick.
+            expect(janitor.cycleCount).toBeGreaterThanOrEqual(1);
             done();
         }, cycleInterval);
     });
@@ -74,12 +73,23 @@ describe("Janitor", () => {
         const currCycleCount = janitor.cycleCount;
         expect(currCycleCount).not.toEqual(0);
         setTimeout(() => {
-            expect(janitor.cycleCount).toEqual(currCycleCount + 1);
+            const afterOne = janitor.cycleCount;
+            expect(afterOne).toBeGreaterThan(currCycleCount);
             setTimeout(() => {
-                expect(janitor.cycleCount).toEqual(currCycleCount + 2);
+                expect(janitor.cycleCount).toBeGreaterThan(afterOne);
                 done();
             }, cycleInterval);
         }, cycleInterval);
+    });
+
+    describe("socketExists", () => {
+        it("reflects membership in the live connected-socket map", () => {
+            janitor.connectedSocketIds = sandbox
+                .stub()
+                .returns(new Map([["live session", {}]]));
+            expect(janitor.socketExists("live session")).toBeTrue();
+            expect(janitor.socketExists("gone session")).toBeFalse();
+        });
     });
 
     describe("removeSessionCallbacks", () => {

--- a/packages/server/src/janitor.ts
+++ b/packages/server/src/janitor.ts
@@ -101,11 +101,7 @@ export class Janitor {
         return await new Promise((resolve) => setTimeout(resolve, ms));
     }
 
-    /**
-     * Live map of currently-connected socket ids, owned by socket.io. This is
-     * the authoritative, O(1) source for whether a session still has a socket
-     * (no per-cycle materialization of the full socket list).
-     */
+    /** Live, O(1) map of connected socket ids (socket.io's namespace map). */
     private connectedSocketIds(): ReadonlyMap<string, unknown> {
         return listener.io.sockets.sockets;
     }

--- a/packages/server/src/janitor.ts
+++ b/packages/server/src/janitor.ts
@@ -1,6 +1,6 @@
 import { getRedisConnectionCount } from "@sockethub/data-layer";
 import { createLogger } from "@sockethub/logger";
-import listener, { type SocketInstance } from "./listener.js";
+import listener from "./listener.js";
 import type PlatformInstance from "./platform-instance.js";
 import { platformInstances } from "./platform-instance.js";
 
@@ -12,7 +12,6 @@ export class Janitor {
     cycleCount = 0; // a counter for each cycleInterval
     reportCount = 0; // number of times a report is printed
     protected stopTriggered = false;
-    protected sockets: Array<SocketInstance>;
     private cycleRunning = false;
 
     /**
@@ -94,21 +93,21 @@ export class Janitor {
         }
     }
 
-    private socketExists(sessionId: string) {
-        for (const socket of this.sockets) {
-            if (socket.id === sessionId) {
-                return true;
-            }
-        }
-        return false;
+    private socketExists(sessionId: string): boolean {
+        return this.connectedSocketIds().has(sessionId);
     }
 
     private async delay(ms: number): Promise<void> {
         return await new Promise((resolve) => setTimeout(resolve, ms));
     }
 
-    private async getSockets(): Promise<Array<SocketInstance>> {
-        return listener.io.fetchSockets();
+    /**
+     * Live map of currently-connected socket ids, owned by socket.io. This is
+     * the authoritative, O(1) source for whether a session still has a socket
+     * (no per-cycle materialization of the full socket list).
+     */
+    private connectedSocketIds(): ReadonlyMap<string, unknown> {
+        return listener.io.sockets.sockets;
     }
 
     private async performStaleCheck(platformInstance: PlatformInstance) {
@@ -139,13 +138,12 @@ export class Janitor {
         }
         this.cycleRunning = true;
         this.cycleCount++;
-        this.sockets = await this.getSockets();
 
         if (!(this.cycleCount % REPORT_CYCLE_MOD)) {
             this.reportCount++;
             const redisConnections = await getRedisConnectionCount();
             rmLog.info(
-                `socket sessions: ${this.sockets.length} platform instances: ${platformInstances.size} redis connections: ${redisConnections}`,
+                `socket sessions: ${this.connectedSocketIds().size} platform instances: ${platformInstances.size} redis connections: ${redisConnections}`,
             );
         }
 

--- a/packages/server/src/listener.ts
+++ b/packages/server/src/listener.ts
@@ -6,7 +6,7 @@ import { createLogger } from "@sockethub/logger";
 import bodyParser from "body-parser";
 import express, { type Express, type Request, type Response } from "express";
 import rateLimit from "express-rate-limit";
-import { Server } from "socket.io";
+import { Server, type Socket } from "socket.io";
 import config from "./config.js";
 import routes from "./routes.js";
 
@@ -153,23 +153,21 @@ class Listener {
 
 const listener = new Listener();
 
-type EmitFunction = (type: string, data: unknown) => void;
-
-export interface SocketInstance {
-    id: string;
-    emit: EmitFunction;
-}
-
-export async function getSocket(sessionId: string): Promise<SocketInstance> {
-    const sockets: Array<SocketInstance> = await listener.io.fetchSockets();
-    return new Promise((resolve, reject) => {
-        for (const socket of sockets) {
-            if (sessionId === socket.id) {
-                return resolve(socket);
-            }
-        }
-        return reject(`unable to find socket for sessionId ${sessionId}`);
-    });
+/**
+ * Look up a currently-connected socket by its session id (== socket.id).
+ *
+ * Returns `undefined` when no socket with that id is connected — e.g. the
+ * client has disconnected and its session is in the janitor grace window
+ * awaiting a possible reconnect. Callers treat that as "nothing to deliver to
+ * right now", not an error.
+ *
+ * This is an O(1) lookup against socket.io's local namespace map. Sockethub
+ * runs a single socket.io server (no redis adapter), and a platform instance
+ * only ever delivers to sockets connected to its own server, so the local map
+ * is the authoritative source.
+ */
+export function getSocket(sessionId: string): Socket | undefined {
+    return listener.io.sockets.sockets.get(sessionId);
 }
 
 export default listener;

--- a/packages/server/src/listener.ts
+++ b/packages/server/src/listener.ts
@@ -154,17 +154,10 @@ class Listener {
 const listener = new Listener();
 
 /**
- * Look up a currently-connected socket by its session id (== socket.id).
- *
- * Returns `undefined` when no socket with that id is connected — e.g. the
- * client has disconnected and its session is in the janitor grace window
- * awaiting a possible reconnect. Callers treat that as "nothing to deliver to
- * right now", not an error.
- *
- * This is an O(1) lookup against socket.io's local namespace map. Sockethub
- * runs a single socket.io server (no redis adapter), and a platform instance
- * only ever delivers to sockets connected to its own server, so the local map
- * is the authoritative source.
+ * O(1) lookup of a connected socket by session id (== socket.id). Returns
+ * `undefined` when no such socket is connected (e.g. disconnected, awaiting
+ * reconnect). Single socket.io server, no adapter, so the local map is
+ * authoritative.
  */
 export function getSocket(sessionId: string): Socket | undefined {
     return listener.io.sockets.sockets.get(sessionId);

--- a/packages/server/src/platform-instance.test.ts
+++ b/packages/server/src/platform-instance.test.ts
@@ -17,7 +17,9 @@ describe("PlatformInstance", () => {
         socketMock = {
             emit: sandbox.spy(),
         };
-        getSocketFake = sinon.fake.resolves(socketMock);
+        // getSocket is a synchronous lookup that returns the socket or
+        // undefined when no socket is connected for the session.
+        getSocketFake = sinon.fake.returns(socketMock);
         forkFake = sandbox.fake();
     });
 
@@ -215,6 +217,38 @@ describe("PlatformInstance", () => {
             await pi.broadcastToSharedPeers("myself", { foo: "bar" });
             expect(getSocketFake.callCount).toEqual(2);
             sandbox.assert.calledWith(getSocketFake, "other peer");
+        });
+
+        it("skips delivery (no emit, no error) when the socket is not connected", () => {
+            // Simulate a disconnected session in the janitor grace window.
+            getSocketFake = sinon.fake.returns(undefined);
+            pi.getSocket = getSocketFake;
+            const errorSpy = sandbox.spy(pi.log, "error");
+
+            pi.sendToClient("disconnected session", {
+                foo: "this should not be delivered",
+            });
+
+            sandbox.assert.calledOnce(getSocketFake);
+            sandbox.assert.notCalled(socketMock.emit);
+            sandbox.assert.notCalled(errorSpy);
+        });
+
+        it("broadcastToSharedPeers delivers only to connected peers", async () => {
+            // "live peer" is connected; "stale peer" is not (returns undefined).
+            const liveSocket = { emit: sandbox.spy() };
+            getSocketFake = sinon.fake((id) =>
+                id === "live peer" ? liveSocket : undefined,
+            );
+            pi.getSocket = getSocketFake;
+            const errorSpy = sandbox.spy(pi.log, "error");
+
+            pi.sessions.add("live peer");
+            pi.sessions.add("stale peer");
+            await pi.broadcastToSharedPeers("myself", { foo: "bar" });
+
+            sandbox.assert.calledOnce(liveSocket.emit);
+            sandbox.assert.notCalled(errorSpy);
         });
 
         describe("handleJobResult", () => {

--- a/packages/server/src/platform-instance.test.ts
+++ b/packages/server/src/platform-instance.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 import * as sinon from "sinon";
 import {
     buildCanonicalContext,
@@ -50,7 +50,7 @@ describe("PlatformInstance", () => {
     });
 
     describe("private instance per-actor", () => {
-        it("is set as non-global when an actor is provided", async () => {
+        test("is set as non-global when an actor is provided", async () => {
             const TestPlatformInstance = getTestPlatformInstanceClass();
             const pi = new TestPlatformInstance({
                 identifier: "id",
@@ -91,16 +91,16 @@ describe("PlatformInstance", () => {
             await pi.shutdown();
         });
 
-        it("has expected properties", () => {
+        test("has expected properties", () => {
             const TestPlatformInstance = getTestPlatformInstanceClass();
             expect(typeof TestPlatformInstance).toEqual("function");
         });
 
-        it("should have a platformInstances Map", () => {
+        test("should have a platformInstances Map", () => {
             expect(platformInstances instanceof Map).toEqual(true);
         });
 
-        it("has certain accessible properties", () => {
+        test("has certain accessible properties", () => {
             expect(pi.id).toEqual("platform identifier");
             expect(pi.name).toEqual("a platform name");
             expect(pi.parentId).toEqual("the parentId");
@@ -120,7 +120,7 @@ describe("PlatformInstance", () => {
                 pi.callbackFunction = sandbox.fake();
             });
 
-            it("adds a close and message handler when a session is registered", () => {
+            test("adds a close and message handler when a session is registered", () => {
                 pi.registerSession("my session id");
                 expect(pi.callbackFunction.callCount).toEqual(2);
                 sandbox.assert.calledWith(
@@ -136,7 +136,7 @@ describe("PlatformInstance", () => {
                 expect(pi.sessions.has("my session id")).toEqual(true);
             });
 
-            it("is able to generate failure reports", async () => {
+            test("is able to generate failure reports", async () => {
                 pi.registerSession("my session id");
                 expect(pi.sessions.has("my session id")).toEqual(true);
                 pi.sendToClient = sandbox.stub();
@@ -146,13 +146,13 @@ describe("PlatformInstance", () => {
             });
         });
 
-        it("initializes the job queue", () => {
+        test("initializes the job queue", () => {
             expect(pi.queue).toBeUndefined();
             pi.initQueue("a secret");
             expect(pi.queue).toBeDefined();
         });
 
-        it("cleans up its references when shutdown", async () => {
+        test("cleans up its references when shutdown", async () => {
             pi.initQueue("a secret");
             expect(pi.queue).toBeDefined();
             expect(platformInstances.has("platform identifier")).toBeTrue();
@@ -161,14 +161,14 @@ describe("PlatformInstance", () => {
             expect(platformInstances.has("platform identifier")).toBeFalse();
         });
 
-        it("updates its identifier when changed", () => {
+        test("updates its identifier when changed", () => {
             pi.updateIdentifier("foo bar");
             expect(pi.id).toEqual("foo bar");
             expect(platformInstances.has("platform identifier")).toBeFalse();
             expect(platformInstances.has("foo bar")).toBeTrue();
         });
 
-        it("sends messages to client using socket session id", async () => {
+        test("sends messages to client using socket session id", async () => {
             await pi.sendToClient("my session id", {
                 foo: "this is a message object",
                 sessionSecret: "private data",
@@ -185,7 +185,7 @@ describe("PlatformInstance", () => {
             });
         });
 
-        it("injects platform-specific @context when contextUrl is set", async () => {
+        test("injects platform-specific @context when contextUrl is set", async () => {
             const testContextUrl =
                 "https://sockethub.org/ns/context/platform/dummy/v1.jsonld";
             pi.contextUrl = testContextUrl;
@@ -200,7 +200,7 @@ describe("PlatformInstance", () => {
             );
         });
 
-        it("strips legacy context field from outbound payloads", async () => {
+        test("strips legacy context field from outbound payloads", async () => {
             await pi.sendToClient("my session id", {
                 type: "echo",
                 context: "dummy",
@@ -211,7 +211,7 @@ describe("PlatformInstance", () => {
             expect(emittedMsg["@context"]).toBeDefined();
         });
 
-        it("broadcasts to peers", async () => {
+        test("broadcasts to peers", async () => {
             pi.sessions.add("other peer");
             pi.sessions.add("another peer");
             await pi.broadcastToSharedPeers("myself", { foo: "bar" });
@@ -219,22 +219,20 @@ describe("PlatformInstance", () => {
             sandbox.assert.calledWith(getSocketFake, "other peer");
         });
 
-        it("skips delivery (no emit, no error) when the socket is not connected", () => {
+        test("skips delivery (no emit, no error) when the socket is not connected", () => {
             // Simulate a disconnected session in the janitor grace window.
             getSocketFake = sinon.fake.returns(undefined);
             pi.getSocket = getSocketFake;
             const errorSpy = sandbox.spy(pi.log, "error");
 
-            pi.sendToClient("disconnected session", {
-                foo: "this should not be delivered",
-            });
+            pi.sendToClient("disconnected session", { foo: "bar" });
 
             sandbox.assert.calledOnce(getSocketFake);
             sandbox.assert.notCalled(socketMock.emit);
             sandbox.assert.notCalled(errorSpy);
         });
 
-        it("broadcastToSharedPeers delivers only to connected peers", async () => {
+        test("broadcastToSharedPeers delivers only to connected peers", async () => {
             // "live peer" is connected; "stale peer" is not (returns undefined).
             const liveSocket = { emit: sandbox.spy() };
             getSocketFake = sinon.fake((id) =>
@@ -245,7 +243,10 @@ describe("PlatformInstance", () => {
 
             pi.sessions.add("live peer");
             pi.sessions.add("stale peer");
-            await pi.broadcastToSharedPeers("myself", { foo: "bar" });
+            await pi.broadcastToSharedPeers("myself", {
+                type: "message",
+                actor: { id: "actor@dummy", type: "person" },
+            });
 
             sandbox.assert.calledOnce(liveSocket.emit);
             sandbox.assert.notCalled(errorSpy);
@@ -258,7 +259,7 @@ describe("PlatformInstance", () => {
                 pi.config = { persist: false };
             });
 
-            it("broadcasts to peers when handling a completed job", async () => {
+            test("broadcasts to peers when handling a completed job", async () => {
                 pi.sessions.add("other peer");
                 await pi.handleJobResult(
                     "completed",
@@ -269,7 +270,7 @@ describe("PlatformInstance", () => {
                 expect(pi.broadcastToSharedPeers.callCount).toEqual(1);
             });
 
-            it("appends completed result message when present", async () => {
+            test("appends completed result message when present", async () => {
                 await pi.handleJobResult(
                     "completed",
                     { sessionId: "a session id", msg: { foo: "bar" } },
@@ -284,7 +285,7 @@ describe("PlatformInstance", () => {
                 });
             });
 
-            it("appends failed result message when present", async () => {
+            test("appends failed result message when present", async () => {
                 await pi.handleJobResult(
                     "failed",
                     { sessionId: "a session id", msg: { foo: "bar" } },
@@ -308,7 +309,7 @@ describe("PlatformInstance", () => {
                 pi.updateIdentifier = sandbox.fake();
             });
 
-            it("close events from platform thread are reported", async () => {
+            test("close events from platform thread are reported", async () => {
                 // Mock process as connected and not flagged for termination
                 pi.process.connected = true;
                 pi.flaggedForTermination = false;
@@ -322,7 +323,7 @@ describe("PlatformInstance", () => {
                 );
             });
 
-            it("close events skip error reporting when process disconnected", async () => {
+            test("close events skip error reporting when process disconnected", async () => {
                 // Mock process as disconnected
                 pi.process.connected = false;
                 pi.flaggedForTermination = false;
@@ -337,7 +338,7 @@ describe("PlatformInstance", () => {
                 sandbox.assert.called(pi.shutdown);
             });
 
-            it("close events skip error reporting when flagged for termination", async () => {
+            test("close events skip error reporting when flagged for termination", async () => {
                 // Mock process as flagged for termination
                 pi.process.connected = true;
                 pi.flaggedForTermination = true;
@@ -352,7 +353,7 @@ describe("PlatformInstance", () => {
                 sandbox.assert.called(pi.shutdown);
             });
 
-            it("message events from platform thread are route based on command: error", () => {
+            test("message events from platform thread are route based on command: error", () => {
                 const message = pi.callbackFunction("message", "my session id");
                 message(["error", "error message"]);
                 sandbox.assert.calledWith(
@@ -362,13 +363,13 @@ describe("PlatformInstance", () => {
                 );
             });
 
-            it("message events from platform thread are route based on command: updateActor", () => {
+            test("message events from platform thread are route based on command: updateActor", () => {
                 const message = pi.callbackFunction("message", "my session id");
                 message(["updateActor", undefined, { foo: "bar" }]);
                 sandbox.assert.calledWith(pi.updateIdentifier, { foo: "bar" });
             });
 
-            it("message events from platform thread are route based on command: else", () => {
+            test("message events from platform thread are route based on command: else", () => {
                 const message = pi.callbackFunction("message", "my session id");
                 message(["blah", { foo: "bar" }]);
                 sandbox.assert.calledWith(pi.sendToClient, "my session id", {
@@ -400,7 +401,7 @@ describe("PlatformInstance", () => {
         });
 
         describe("POSITIVE: Platform initialized - credential failure should NOT terminate", () => {
-            it("should keep platform alive when credential job fails on initialized platform", async () => {
+            test("should keep platform alive when credential job fails on initialized platform", async () => {
                 const TestPlatformInstance = getTestPlatformInstanceClass();
                 pi = new TestPlatformInstance({
                     identifier: "test-platform-id",
@@ -452,7 +453,7 @@ describe("PlatformInstance", () => {
                 sinon.assert.called(pi.sendToClient);
             });
 
-            it("should allow subsequent jobs after non-fatal credential error", async () => {
+            test("should allow subsequent jobs after non-fatal credential error", async () => {
                 const TestPlatformInstance = getTestPlatformInstanceClass();
                 pi = new TestPlatformInstance({
                     identifier: "test-platform-id",
@@ -509,7 +510,7 @@ describe("PlatformInstance", () => {
         });
 
         describe("NEGATIVE: Platform NOT initialized - credential failure SHOULD terminate", () => {
-            it("should terminate platform when credential job fails on uninitialized platform", async () => {
+            test("should terminate platform when credential job fails on uninitialized platform", async () => {
                 const TestPlatformInstance = getTestPlatformInstanceClass();
                 pi = new TestPlatformInstance({
                     identifier: "test-platform-id",
@@ -559,7 +560,7 @@ describe("PlatformInstance", () => {
                 sinon.assert.called(pi.sendToClient);
             });
 
-            it("should pause queue when credential initialization fails", async () => {
+            test("should pause queue when credential initialization fails", async () => {
                 const TestPlatformInstance = getTestPlatformInstanceClass();
                 pi = new TestPlatformInstance({
                     identifier: "test-platform-id",

--- a/packages/server/src/platform-instance.ts
+++ b/packages/server/src/platform-instance.ts
@@ -14,7 +14,6 @@ import {
     buildCanonicalContext,
     INTERNAL_PLATFORM_CONTEXT_URL,
 } from "@sockethub/schemas";
-import type { Socket } from "socket.io";
 import config from "./config.js";
 import { getSocket } from "./listener.js";
 import { __dirname } from "./util.js";
@@ -241,22 +240,30 @@ export default class PlatformInstance {
      * @param sessionId ID of the socket connection to send the message to
      * @param msg ActivityStream object to send to client
      */
-    public async sendToClient(sessionId: string, msg: InternalActivityStream) {
-        return this.getSocket(sessionId).then(
-            (socket: Socket) => {
-                this.toExternalPayload(msg);
-                if (
-                    msg.type === "error" &&
-                    typeof msg.actor === "undefined" &&
-                    this.actor
-                ) {
-                    // ensure an actor is present if not otherwise defined
-                    msg.actor = { id: this.actor, type: "unknown" };
-                }
-                socket.emit("message", msg as ActivityStream);
-            },
-            (err) => this.log.error(`sendToClient ${String(err)}`),
-        );
+    public sendToClient(sessionId: string, msg: InternalActivityStream) {
+        const socket = this.getSocket(sessionId);
+        if (!socket) {
+            // No socket is currently connected for this session — e.g. the
+            // client is mid page-refresh and its session is in the janitor
+            // grace window awaiting reconnect. There is simply nothing to
+            // deliver to right now, so skip quietly. The session reference is
+            // retained for reconnect (the janitor owns its lifecycle); on
+            // reconnect the client re-registers and delivery resumes.
+            this.log.debug(
+                `skipping delivery to ${sessionId}: socket not connected`,
+            );
+            return;
+        }
+        this.toExternalPayload(msg);
+        if (
+            msg.type === "error" &&
+            typeof msg.actor === "undefined" &&
+            this.actor
+        ) {
+            // ensure an actor is present if not otherwise defined
+            msg.actor = { id: this.actor, type: "unknown" };
+        }
+        socket.emit("message", msg as ActivityStream);
     }
 
     // send message to every connected socket associated with this platform instance.
@@ -318,7 +325,7 @@ export default class PlatformInstance {
             callback(payload);
             this.completedJobHandlers.delete(job.title);
         } else {
-            await this.sendToClient(job.sessionId, payload);
+            this.sendToClient(job.sessionId, payload);
         }
 
         if (payload) {
@@ -375,7 +382,7 @@ export default class PlatformInstance {
         // Only attempt to send to client if we have a valid session
         try {
             if (sessionId && this.sessions.has(sessionId)) {
-                await this.sendToClient(sessionId, errorObject);
+                this.sendToClient(sessionId, errorObject);
             }
         } catch (err) {
             this.log.error(
@@ -456,7 +463,7 @@ export default class PlatformInstance {
                     return;
                 } else {
                     // treat like a message to clients
-                    await this.sendToClient(sessionId, second);
+                    this.sendToClient(sessionId, second);
                 }
             },
         };

--- a/packages/server/src/platform-instance.ts
+++ b/packages/server/src/platform-instance.ts
@@ -243,12 +243,9 @@ export default class PlatformInstance {
     public sendToClient(sessionId: string, msg: InternalActivityStream) {
         const socket = this.getSocket(sessionId);
         if (!socket) {
-            // No socket is currently connected for this session — e.g. the
-            // client is mid page-refresh and its session is in the janitor
-            // grace window awaiting reconnect. There is simply nothing to
-            // deliver to right now, so skip quietly. The session reference is
-            // retained for reconnect (the janitor owns its lifecycle); on
-            // reconnect the client re-registers and delivery resumes.
+            // Socket not connected (e.g. mid page-refresh, within the janitor
+            // grace window). Nothing to deliver to right now; skip quietly. The
+            // session/reconnect lifecycle is the janitor's job.
             this.log.debug(
                 `skipping delivery to ${sessionId}: socket not connected`,
             );


### PR DESCRIPTION
Closes #1116.

## Problem

When a socket disconnects but its persistent platform session is kept alive for the janitor's reconnect grace window, the server kept attempting to deliver inbound protocol traffic (e.g. XMPP MUC presence) to the now-gone socket. Each attempt failed with `sendToClient unable to find socket for sessionId …` logged at **error** — **119–186 errors per Test NPM Package run** under MUC churn.

Two issues: it was **noisy** (an expected state logged as an error) and **inefficient** (`getSocket` did `await io.fetchSockets()` — an O(N), adapter-aware scan of *all* sockets — on every delivery).

## Key insight

We don't need to infer or track whether to send. "Should we deliver to this session right now?" is answered exactly by ground truth: **is that socket currently connected?**
- connected → deliver (unchanged)
- not connected → physically undeliverable; skipping is the only correct action

No false-negative risk ("deciding not to send when we should"): if the socket is connected the lookup finds it; if not, there's no socket under any logic. On reconnect the client returns as a **new** socket id and re-registers, so delivery resumes. Session retention/termination stays the janitor's job, so **grace semantics are unchanged**.

## Changes

- **`getSocket()`** → O(1) synchronous `io.sockets.sockets.get(id)` returning `Socket | undefined`. Single socket.io server, no redis adapter, and a platform instance only delivers to its own server's sockets, so the local namespace map is authoritative.
- **`sendToClient()`** → skip quietly (debug log) when no socket is connected; no error. Now synchronous (dropped the pointless `await`s).
- **janitor** → replaced the per-cycle `fetchSockets()` materialization + linear `socketExists` scan with O(1) map membership/size via `connectedSocketIds()`.
- Removed the now-unused **`SocketInstance`** interface and all `fetchSockets()` usage.

Net: **less code**, O(1) instead of O(N)-async per delivery and per janitor cycle, and the error-spam gone. This also relieves the long-polling payload pressure noted in #1117/#1118.

## Tests

- New: `sendToClient` skips with **no emit and no error** when the socket isn't connected; `broadcastToSharedPeers` delivers **only to connected peers**; janitor `socketExists` reflects the live socket map.
- Removed tests tied to the deleted `getSockets()`/socket-list machinery.
- Made the janitor's real-timer cycle assertions robust (assert *progress*, not an exact per-tick count) — they were knife-edge timing-dependent.

## Validation
- `bun run lint`, `@sockethub/server` build, and full server test suite (**118 pass, 0 fail**) green locally.

## Note on horizontal scaling
`fetchSockets()` is the adapter-aware API (sees sockets across instances when a socket.io redis adapter is configured). Sockethub has no such adapter today, and platform instances are per-server and only deliver to their own server's sockets — so the local map is correct even under future scaling. Flagging it as a conscious assumption.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved socket connection management for more reliable session handling and reporting; socket lookups are now direct and more efficient.
  * Made message delivery synchronous and resilient to disconnected clients (skips silently when a client is absent).

* **Bug Fixes**
  * Prevented erroneous errors or emits when peers are disconnected or stale.

* **Tests**
  * Strengthened timing- and connectivity-related tests and added coverage for disconnected-peer behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->