### PR TITLE
feat(schemas): outbound response-schema validation infra (warn-only)

### DIFF
--- a/packages/schemas/src/index.test.ts
+++ b/packages/schemas/src/index.test.ts
@@ -13,6 +13,7 @@ import {
     getPlatformSchema,
     validateActivityObject,
     validateActivityStream,
+    validateActivityStreamResponse,
     validateCredentials,
     validatePlatformSchema,
 } from "./validator";
@@ -44,6 +45,17 @@ addPlatformContext(
     "test-platform",
     "https://sockethub.org/ns/context/platform/test-platform/v1.jsonld",
 );
+// A platform with an outbound `responses` schema (only allows type "collection").
+addPlatformSchema(
+    { required: ["type"], properties: { type: { enum: ["collection"] } } },
+    "respplat/responses",
+);
+addPlatformContext(
+    "respplat",
+    "https://sockethub.org/ns/context/platform/respplat/v1.jsonld",
+);
+const RESP_CTX = "https://sockethub.org/ns/context/platform/respplat/v1.jsonld";
+const NO_RESP_CTX = "https://sockethub.org/ns/context/platform/dood/v1.jsonld";
 
 describe("schemas/src/index.ts", () => {
     describe("Platform schema validation", () => {
@@ -132,5 +144,43 @@ describe("schemas/src/index.ts", () => {
                 });
             },
         );
+    });
+
+    describe("validateActivityStreamResponse", () => {
+        test("is a no-op (passes) when the platform has no responses schema", () => {
+            const msg = {
+                "@context": [NO_RESP_CTX],
+                type: "anything",
+                actor: { id: "a@b", type: "person" },
+            } as unknown as ActivityStream;
+            expect(validateActivityStreamResponse(msg)).toEqual("");
+        });
+
+        test("is a no-op when no registered platform context is present", () => {
+            const msg = {
+                "@context": ["https://example.com/unregistered"],
+                type: "collection",
+                actor: { id: "a@b", type: "person" },
+            } as unknown as ActivityStream;
+            expect(validateActivityStreamResponse(msg)).toEqual("");
+        });
+
+        test("passes a response matching the platform's responses schema", () => {
+            const msg = {
+                "@context": [RESP_CTX],
+                type: "collection",
+                actor: { id: "a@b", type: "feed" },
+            } as unknown as ActivityStream;
+            expect(validateActivityStreamResponse(msg)).toEqual("");
+        });
+
+        test("fails a response that violates the platform's responses schema", () => {
+            const msg = {
+                "@context": [RESP_CTX],
+                type: "page",
+                actor: { id: "a@b", type: "feed" },
+            } as unknown as ActivityStream;
+            expect(validateActivityStreamResponse(msg)).not.toEqual("");
+        });
     });
 });

--- a/packages/schemas/src/index.ts
+++ b/packages/schemas/src/index.ts
@@ -27,6 +27,7 @@ import {
     setValidationErrorOptions,
     validateActivityObject,
     validateActivityStream,
+    validateActivityStreamResponse,
     validateCredentials,
     validatePlatformSchema,
 } from "./validator.js";
@@ -58,6 +59,7 @@ export {
     validatePlatformSchema,
     validateCredentials,
     validateActivityStream,
+    validateActivityStreamResponse,
     validateActivityObject,
     setValidationErrorOptions,
     PlatformSchema,

--- a/packages/schemas/src/schemas/platform.ts
+++ b/packages/schemas/src/schemas/platform.ts
@@ -58,6 +58,11 @@ export const PlatformSchema = {
             type: "object",
         },
 
+        responses: {
+            title: "responses",
+            type: "object",
+        },
+
         name: {
             title: "name",
             type: "string",

--- a/packages/schemas/src/types.ts
+++ b/packages/schemas/src/types.ts
@@ -139,6 +139,8 @@ export interface PlatformSchemaStruct {
             };
         };
     };
+    // Outbound (platform → client) response schema. Validated on send.
+    responses?: object;
 }
 
 export interface PlatformConstructor {

--- a/packages/schemas/src/validator.ts
+++ b/packages/schemas/src/validator.ts
@@ -135,6 +135,27 @@ export function validateActivityStream(msg: ActivityStream): string {
     return handleValidation(schemaId, msg);
 }
 
+/**
+ * Validate an outbound platform response against that platform's `responses`
+ * schema. Returns "" when the platform has no responses schema registered (yet),
+ * so outbound validation can be adopted platform-by-platform.
+ */
+export function validateActivityStreamResponse(msg: ActivityStream): string {
+    const platformContextUrl = resolvePlatformContextUrl(msg);
+    if (!platformContextUrl) {
+        return "";
+    }
+    const platformId = getPlatformIdByContextUrl(platformContextUrl);
+    if (!platformId) {
+        return "";
+    }
+    const responsesSchemaId = `${schemaURL}/context/${platformId}/responses`;
+    if (!ajv.getSchema(responsesSchemaId)) {
+        return "";
+    }
+    return handleValidation(responsesSchemaId, msg);
+}
+
 export function validateCredentials(msg: ActivityStream): string {
     if (!Array.isArray(msg["@context"])) {
         return "credential activity streams must have an @context set";

--- a/packages/server/src/bootstrap/init.ts
+++ b/packages/server/src/bootstrap/init.ts
@@ -160,6 +160,9 @@ export async function registerPlatforms(initObj: IInitObject): Promise<void> {
         if (schemas.messages !== undefined) {
             addPlatformSchema(schemas.messages, `${platform.id}/messages`);
         }
+        if (schemas.responses !== undefined) {
+            addPlatformSchema(schemas.responses, `${platform.id}/responses`);
+        }
     }
 }
 

--- a/packages/server/src/bootstrap/load-platforms.ts
+++ b/packages/server/src/bootstrap/load-platforms.ts
@@ -43,6 +43,7 @@ export type PlatformSchemaRegistry = {
     schemaVersion: string;
     credentials?: Schema | boolean;
     messages?: Schema | boolean;
+    responses?: Schema | boolean;
 };
 
 const dummySession: PlatformSession = {
@@ -169,6 +170,8 @@ export default async function loadPlatforms(
                 schemaVersion: p.schema.schemaVersion,
                 credentials: p.schema.credentials || {},
                 messages: p.schema.messages || {},
+                // Server-side only (not sent to clients): outbound validation.
+                responses: p.schema.responses,
             },
             version: p.schema.version,
             contextUrl: p.schema.contextUrl,

--- a/packages/server/src/platform-instance.test.ts
+++ b/packages/server/src/platform-instance.test.ts
@@ -1,9 +1,21 @@
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 import * as sinon from "sinon";
 import {
+    addPlatformContext,
+    addPlatformSchema,
     buildCanonicalContext,
     INTERNAL_PLATFORM_CONTEXT_URL,
 } from "@sockethub/schemas";
+
+// A platform context with an outbound `responses` schema (only allows
+// type "collection"), used to exercise warn-only outbound validation.
+const RESPONSES_CTX =
+    "https://sockethub.org/ns/context/platform/respplat/v1.jsonld";
+addPlatformSchema(
+    { required: ["type"], properties: { type: { enum: ["collection"] } } },
+    "respplat/responses",
+);
+addPlatformContext("respplat", RESPONSES_CTX);
 import { __dirname } from "./util.js";
 const FORK_PATH = __dirname + "/platform.js";
 
@@ -250,6 +262,28 @@ describe("PlatformInstance", () => {
 
             sandbox.assert.calledOnce(liveSocket.emit);
             sandbox.assert.notCalled(errorSpy);
+        });
+
+        test("warns (but still delivers) when an outbound message violates the responses schema", () => {
+            pi.contextUrl = RESPONSES_CTX;
+            const warnSpy = sandbox.spy(pi.log, "warn");
+            pi.sendToClient("my session id", {
+                type: "page", // not allowed by respplat responses schema
+                actor: { id: "a@b", type: "feed" },
+            });
+            sandbox.assert.calledOnce(warnSpy);
+            sandbox.assert.calledOnce(socketMock.emit); // warn-only: still delivered
+        });
+
+        test("does not warn when an outbound message matches the responses schema", () => {
+            pi.contextUrl = RESPONSES_CTX;
+            const warnSpy = sandbox.spy(pi.log, "warn");
+            pi.sendToClient("my session id", {
+                type: "collection",
+                actor: { id: "a@b", type: "feed" },
+            });
+            sandbox.assert.notCalled(warnSpy);
+            sandbox.assert.calledOnce(socketMock.emit);
         });
 
         describe("handleJobResult", () => {

--- a/packages/server/src/platform-instance.ts
+++ b/packages/server/src/platform-instance.ts
@@ -13,6 +13,7 @@ import type {
 import {
     buildCanonicalContext,
     INTERNAL_PLATFORM_CONTEXT_URL,
+    validateActivityStreamResponse,
 } from "@sockethub/schemas";
 import config from "./config.js";
 import { getSocket } from "./listener.js";
@@ -259,6 +260,18 @@ export default class PlatformInstance {
         ) {
             // ensure an actor is present if not otherwise defined
             msg.actor = { id: this.actor, type: "unknown" };
+        }
+        // Warn-only outbound validation (see #1120): no-op until a platform
+        // registers a `responses` schema. Once it does, mismatches are logged
+        // (not dropped) so we can converge schemas against real traffic before
+        // enforcing.
+        const responseError = validateActivityStreamResponse(
+            msg as ActivityStream,
+        );
+        if (responseError) {
+            this.log.warn(
+                `outbound message does not match ${this.name} responses schema [${sessionId}]: ${responseError}`,
+            );
         }
         socket.emit("message", msg as ActivityStream);
     }


### PR DESCRIPTION
First step of #1120 (per-platform outbound schemas + validate on send), per the [agreed design](https://github.com/sockethub/sockethub/issues/1120#issuecomment-4669722717).

## What this does
Lands the **infra** for outbound (`responses`) validation and a **warn-only** hook — no enforcement, no behavior change yet.

- **`@sockethub/schemas`**
  - Allow a `responses` key in the platform meta-schema (`messages` = inbound, `responses` = outbound).
  - `validateActivityStreamResponse(msg)`: validates against the platform's registered `responses` schema; **no-op when none is registered**, so platforms adopt it one at a time. Mirrors `validateActivityStream` (which uses the inbound `messages` schema).
  - Add `responses` to `PlatformSchemaStruct`.
- **server bootstrap**: register a platform's `responses` schema if present — **server-side only**, *not* added to the client registry payload (keeps the payload lean, re #1117).
- **server `sendToClient`**: validate outbound messages and **log** mismatches (warn) **without dropping**. This is the measurement harness: once a platform ships a `responses` schema, real-traffic mismatches surface as warnings so we can converge the schema before enforcing.

## What this intentionally does NOT do
- No platform ships a `responses` schema yet → validation is a no-op → **zero behavior change**.
- The global object `oneOf` in the base envelope is untouched (inbound stays strict); it's removed in the final PR once object types live in platforms.
- No switch to drop-on-invalid (enforce) — that's the last PR.

## Rollout (tracked in #1120)
1. **This PR** — infra + warn-only.
2. Per-platform — move object types out of the global stop-gap into each platform's `objectTypes`, add its `responses` schema, drive to zero warnings (with fixtures).
3. Final — remove the global object `oneOf` (delegate to platform schemas) and flip warn→enforce.

## Validation
- `bun run lint`, full `bun run build`, schemas suite (62) and server suite (120) green locally. New tests: schemas (`validateActivityStreamResponse` no-op + pass/fail) and server (warn-but-still-deliver on mismatch; no warn when matching).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Platform responses are now validated against configured schemas. When responses don't meet requirements, the system logs a warning but continues delivery to the client, ensuring reliability.

* **Tests**
  * Added comprehensive test coverage for response validation across multiple scenarios, including both conforming and non-conforming responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->