### PR TITLE
feat: strict per-platform outbound responses schemas + enforce on send (#1120)

### DIFF
--- a/packages/platform-feeds/src/index.test.ts
+++ b/packages/platform-feeds/src/index.test.ts
@@ -2,9 +2,42 @@ import { readFileSync } from "node:fs";
 import path from "node:path";
 import { beforeEach, describe, expect, test } from "bun:test";
 import type { ASCollection, PlatformSession } from "@sockethub/schemas";
+import {
+    addPlatformContext,
+    addPlatformSchema,
+    validateActivityStreamResponse,
+} from "@sockethub/schemas";
 import getPodcastFromFeed from "podparse";
+import feedsSchema from "./schema";
 import { RSSFeed } from "./index.test.data";
 import Feeds, { buildFeedItem, datesEqual } from "./index";
+
+addPlatformSchema(feedsSchema.responses, "feeds/responses");
+addPlatformContext("feeds", feedsSchema.contextUrl);
+
+// Wrap feed-item objects exactly as the feeds platform emits them: a single
+// `collection` message whose `items` are `post` entries. Used to validate real
+// parsed output against the strict outbound `responses` schema.
+function buildCollection(objects: Array<ReturnType<typeof buildFeedItem>>) {
+    return {
+        "@context": [feedsSchema.contextUrl],
+        type: "collection",
+        summary: "Test Feed",
+        totalItems: objects.length,
+        items: objects.map((object) => ({
+            "@context": [feedsSchema.contextUrl],
+            type: "post",
+            actor: {
+                id: "https://example.com/feed",
+                type: "feed",
+                name: "Example",
+                link: "https://example.com",
+                categories: [],
+            },
+            object,
+        })),
+    };
+}
 
 const FIXTURES_DIR = path.join(import.meta.dirname, "../test/fixtures");
 
@@ -190,9 +223,31 @@ describe("feed fixture matrix", () => {
                     ),
                 );
                 fixture.assertItems(results);
+                // Real parsed output must satisfy the strict outbound schema.
+                expect(
+                    validateActivityStreamResponse(buildCollection(results)),
+                ).toEqual("");
             }
         });
     }
+
+    test("rejects a collection whose item object has an unknown type", () => {
+        const items = [
+            {
+                type: "article",
+                title: "t",
+                id: "id-1",
+                content: "c",
+                contentType: "text",
+                url: "https://example.com/a",
+                datenum: 0,
+                bogusField: "nope", // not in the strict feedItem schema
+            },
+        ] as unknown as Array<ReturnType<typeof buildFeedItem>>;
+        expect(
+            validateActivityStreamResponse(buildCollection(items)),
+        ).not.toEqual("");
+    });
 
     test("builds atom-like entries without per-entry link via buildFeedItem", () => {
         const result = buildFeedItem(

--- a/packages/platform-feeds/src/schema.ts
+++ b/packages/platform-feeds/src/schema.ts
@@ -34,4 +34,88 @@ export default {
             },
         },
     },
+    // Outbound (platform -> client): the feeds platform only emits a single
+    // `collection` message whose `items` are `post` entries. Strict: every
+    // field the platform constructs is enumerated.
+    responses: {
+        type: "object",
+        required: ["type", "totalItems", "items"],
+        additionalProperties: false,
+        properties: {
+            "@context": { type: "array", items: { type: "string" } },
+            id: { type: ["string", "null"] },
+            type: { enum: ["collection"] },
+            summary: { type: "string" },
+            totalItems: { type: "number" },
+            items: {
+                type: "array",
+                items: { $ref: "#/definitions/responses/post" },
+            },
+        },
+        definitions: {
+            responses: {
+                post: {
+                    type: "object",
+                    required: ["type", "actor", "object"],
+                    additionalProperties: false,
+                    properties: {
+                        "@context": {
+                            type: "array",
+                            items: { type: "string" },
+                        },
+                        type: { enum: ["post"] },
+                        actor: { $ref: "#/definitions/responses/feedChannel" },
+                        object: { $ref: "#/definitions/responses/feedItem" },
+                    },
+                },
+                feedChannel: {
+                    type: "object",
+                    required: ["id", "type", "name", "link"],
+                    additionalProperties: false,
+                    properties: {
+                        id: { type: "string" },
+                        type: { enum: ["feed"] },
+                        name: { type: "string" },
+                        link: { type: "string" },
+                        description: { type: "string" },
+                        image: { type: "string" },
+                        categories: {
+                            type: "array",
+                            items: { type: "string" },
+                        },
+                        language: { type: "string" },
+                        author: { type: "string" },
+                    },
+                },
+                feedItem: {
+                    type: "object",
+                    required: [
+                        "type",
+                        "title",
+                        "id",
+                        "content",
+                        "contentType",
+                        "url",
+                        "datenum",
+                    ],
+                    additionalProperties: false,
+                    properties: {
+                        type: { enum: ["article", "note"] },
+                        title: { type: "string" },
+                        id: { type: "string" },
+                        brief: { type: "string" },
+                        content: { type: "string" },
+                        contentType: { enum: ["html", "text"] },
+                        url: { type: "string" },
+                        published: { type: "string" },
+                        updated: { type: "string" },
+                        datenum: { type: "number" },
+                        tags: { type: "array", items: { type: "string" } },
+                        media: { type: "array" },
+                        source: { type: "string" },
+                    },
+                },
+            },
+        },
+    },
 };

--- a/packages/platform-irc/src/responses-schema.test.ts
+++ b/packages/platform-irc/src/responses-schema.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, test } from "bun:test";
+import {
+    addPlatformContext,
+    addPlatformSchema,
+    validateActivityStreamResponse,
+} from "@sockethub/schemas";
+// Canonical irc2as translation outputs — the messages the irc platform emits.
+import { TestData } from "../../irc2as/src/index.test.data.js";
+import { PlatformIrcSchema } from "./schema.js";
+
+addPlatformSchema(PlatformIrcSchema.responses, "irc/responses");
+addPlatformContext("irc", PlatformIrcSchema.contextUrl);
+
+const CTX = [PlatformIrcSchema.contextUrl];
+
+describe("irc responses schema", () => {
+    for (const [index, stream] of (
+        TestData as Array<Record<string, unknown>>
+    ).entries()) {
+        if (!stream || typeof stream.type !== "string") {
+            continue;
+        }
+        test(`accepts irc2as output #${index} (${stream.type})`, () => {
+            // biome-ignore lint/suspicious/noExplicitAny: fixture
+            expect(validateActivityStreamResponse(stream as any)).toEqual("");
+        });
+    }
+
+    test("rejects an unknown message type", () => {
+        expect(
+            validateActivityStreamResponse({
+                "@context": CTX,
+                type: "bogus",
+                actor: { id: "a@b", type: "person" },
+                // biome-ignore lint/suspicious/noExplicitAny: test
+            } as any),
+        ).not.toEqual("");
+    });
+
+    test("rejects an unknown field on a message object", () => {
+        expect(
+            validateActivityStreamResponse({
+                "@context": CTX,
+                type: "send",
+                actor: { id: "a@b", type: "person" },
+                target: { id: "localhost/#x", type: "room" },
+                object: { type: "message", content: "x", bogus: "y" },
+                // biome-ignore lint/suspicious/noExplicitAny: test
+            } as any),
+        ).not.toEqual("");
+    });
+});

--- a/packages/platform-irc/src/schema.ts
+++ b/packages/platform-irc/src/schema.ts
@@ -25,6 +25,152 @@ export const PlatformIrcSchema = {
             },
         },
     },
+    // Outbound (platform -> client) via the irc2as translator. Strict: every
+    // message type, object type, and field is enumerated. Validated against the
+    // canonical irc2as output fixtures.
+    responses: {
+        type: "object",
+        required: ["type", "actor"],
+        additionalProperties: false,
+        properties: {
+            "@context": { type: "array", items: { type: "string" } },
+            id: { type: "string" },
+            published: { type: "string" },
+            type: {
+                enum: ["update", "send", "join", "leave", "add", "remove"],
+            },
+            actor: {
+                oneOf: [
+                    { $ref: "#/definitions/responses/person" },
+                    { $ref: "#/definitions/responses/service" },
+                ],
+            },
+            target: {
+                oneOf: [
+                    { $ref: "#/definitions/responses/person" },
+                    { $ref: "#/definitions/responses/room" },
+                    { $ref: "#/definitions/responses/service" },
+                ],
+            },
+            error: { type: "string" },
+            object: {
+                oneOf: [
+                    { $ref: "#/definitions/responses/message" },
+                    { $ref: "#/definitions/responses/me" },
+                    { $ref: "#/definitions/responses/presence" },
+                    { $ref: "#/definitions/responses/topic" },
+                    { $ref: "#/definitions/responses/address" },
+                    { $ref: "#/definitions/responses/relationship" },
+                ],
+            },
+        },
+        definitions: {
+            responses: {
+                person: {
+                    type: "object",
+                    required: ["id", "type"],
+                    additionalProperties: false,
+                    properties: {
+                        id: { type: "string" },
+                        type: { enum: ["person"] },
+                        name: { type: "string" },
+                    },
+                },
+                service: {
+                    type: "object",
+                    required: ["id", "type"],
+                    additionalProperties: false,
+                    properties: {
+                        id: { type: "string" },
+                        type: { enum: ["service"] },
+                        name: { type: "string" },
+                    },
+                },
+                room: {
+                    type: "object",
+                    required: ["id", "type"],
+                    additionalProperties: false,
+                    properties: {
+                        id: { type: "string" },
+                        type: { enum: ["room"] },
+                        name: { type: "string" },
+                    },
+                },
+                message: {
+                    type: "object",
+                    required: ["type", "content"],
+                    additionalProperties: false,
+                    properties: {
+                        type: { enum: ["message"] },
+                        content: { type: "string" },
+                    },
+                },
+                me: {
+                    type: "object",
+                    required: ["type", "content"],
+                    additionalProperties: false,
+                    properties: {
+                        type: { enum: ["me"] },
+                        content: { type: "string" },
+                    },
+                },
+                presence: {
+                    type: "object",
+                    required: ["type"],
+                    additionalProperties: false,
+                    properties: {
+                        type: { enum: ["presence"] },
+                        role: {
+                            enum: ["owner", "member", "participant", "admin"],
+                        },
+                    },
+                },
+                topic: {
+                    type: "object",
+                    required: ["type", "content"],
+                    additionalProperties: false,
+                    properties: {
+                        type: { enum: ["topic"] },
+                        content: { type: "string" },
+                    },
+                },
+                address: {
+                    type: "object",
+                    required: ["type"],
+                    additionalProperties: false,
+                    properties: {
+                        type: { enum: ["address"] },
+                    },
+                },
+                relationship: {
+                    type: "object",
+                    required: ["type", "relationship"],
+                    additionalProperties: false,
+                    properties: {
+                        type: { enum: ["relationship"] },
+                        relationship: { enum: ["role"] },
+                        subject: {
+                            type: "object",
+                            required: ["type", "role"],
+                            additionalProperties: false,
+                            properties: {
+                                type: { enum: ["presence"] },
+                                role: {
+                                    enum: [
+                                        "owner",
+                                        "member",
+                                        "participant",
+                                        "admin",
+                                    ],
+                                },
+                            },
+                        },
+                        object: { $ref: "#/definitions/responses/room" },
+                    },
+                },
+            },
+        },
+    },
     credentials: {
         required: ["object"],
         properties: {

--- a/packages/platform-metadata/src/schema.test.ts
+++ b/packages/platform-metadata/src/schema.test.ts
@@ -1,0 +1,93 @@
+import { describe, expect, mock, test } from "bun:test";
+import {
+    addPlatformContext,
+    addPlatformSchema,
+    validateActivityStreamResponse,
+} from "@sockethub/schemas";
+import { PlatformMetadataSchema } from "./schema";
+
+addPlatformSchema(PlatformMetadataSchema.responses, "metadata/responses");
+addPlatformContext("metadata", PlatformMetadataSchema.contextUrl);
+
+const CTX = [PlatformMetadataSchema.contextUrl];
+
+// Mock open-graph-scraper so we exercise the platform's real fetch() output
+// path against the strict responses schema, without network access.
+let ogResult: Record<string, unknown> = {};
+mock.module("open-graph-scraper", () => ({
+    default: async () => ({ result: ogResult }),
+}));
+
+const { default: Metadata } = await import("./index");
+// biome-ignore lint/suspicious/noExplicitAny: minimal fake session
+const platform = new Metadata({ log: { debug() {} } } as any);
+
+// Run the real fetch() handler with a given open-graph-scraper result and
+// return the produced message as the server would see it (post-IPC: a JSON
+// round-trip drops `undefined`-valued keys).
+function runFetch(result: Record<string, unknown>): Promise<unknown> {
+    ogResult = result;
+    const job = {
+        "@context": CTX,
+        type: "fetch",
+        actor: { id: "https://example.com", type: "website" },
+    };
+    return new Promise((resolve) => {
+        // biome-ignore lint/suspicious/noExplicitAny: test job
+        platform.fetch(job as any, (_err, produced) => {
+            resolve(JSON.parse(JSON.stringify(produced ?? job)));
+        });
+    });
+}
+
+describe("metadata responses schema", () => {
+    test("real fetch() output (fully populated) passes validation", async () => {
+        const produced = await runFetch({
+            ogTitle: "Example",
+            ogDescription: "a description",
+            ogSiteName: "Example Site",
+            ogLocale: "en_US",
+            ogUrl: "https://example.com",
+            ogImage: [
+                {
+                    url: "https://example.com/i.png",
+                    type: "png",
+                    width: "100",
+                    height: "50",
+                },
+            ],
+            favicon: "https://example.com/favicon.ico",
+            charset: "utf-8",
+        });
+        // biome-ignore lint/suspicious/noExplicitAny: assertion
+        expect(validateActivityStreamResponse(produced as any)).toEqual("");
+    });
+
+    test("real fetch() output (sparse scrape) passes validation", async () => {
+        const produced = await runFetch({ ogTitle: "Only a title" });
+        // biome-ignore lint/suspicious/noExplicitAny: assertion
+        expect(validateActivityStreamResponse(produced as any)).toEqual("");
+    });
+
+    test("rejects an unknown field on the page object", () => {
+        const msg = {
+            "@context": CTX,
+            type: "fetch",
+            actor: { id: "https://example.com", type: "website" },
+            object: { type: "page", bogus: "x" },
+        };
+        // biome-ignore lint/suspicious/noExplicitAny: assertion
+        expect(validateActivityStreamResponse(msg as any)).not.toEqual("");
+    });
+
+    test("rejects an invalid actor type", () => {
+        const msg = {
+            "@context": CTX,
+            type: "fetch",
+            actor: { id: "https://example.com", type: "person" },
+            object: { type: "page" },
+        };
+        // biome-ignore lint/suspicious/noExplicitAny: assertion
+        expect(validateActivityStreamResponse(msg as any)).not.toEqual("");
+    });
+});

--- a/packages/platform-metadata/src/schema.ts
+++ b/packages/platform-metadata/src/schema.ts
@@ -31,4 +31,64 @@ export const PlatformMetadataSchema = {
             },
         },
     },
+    // Outbound (platform -> client): the metadata platform echoes the `fetch`
+    // request with a `page` object built from open-graph-scraper output. Strict:
+    // every field the platform constructs is enumerated.
+    responses: {
+        type: "object",
+        required: ["type", "actor", "object"],
+        additionalProperties: false,
+        properties: {
+            "@context": { type: "array", items: { type: "string" } },
+            id: { type: "string" },
+            type: { enum: ["fetch"] },
+            actor: {
+                type: "object",
+                required: ["id", "type"],
+                additionalProperties: false,
+                properties: {
+                    id: { type: "string" },
+                    type: { enum: ["website"] },
+                    name: { type: "string" },
+                },
+            },
+            object: { $ref: "#/definitions/responses/page" },
+        },
+        definitions: {
+            responses: {
+                page: {
+                    type: "object",
+                    required: ["type"],
+                    additionalProperties: false,
+                    properties: {
+                        type: { enum: ["page"] },
+                        language: { type: "string" },
+                        title: { type: "string" },
+                        name: { type: "string" },
+                        description: { type: "string" },
+                        image: { $ref: "#/definitions/responses/ogImage" },
+                        url: { type: "string" },
+                        favicon: { type: "string" },
+                        charset: { type: "string" },
+                    },
+                },
+                // open-graph-scraper returns ogImage as an array of image
+                // objects (url + optional dimensions/type).
+                ogImage: {
+                    type: "array",
+                    items: {
+                        type: "object",
+                        required: ["url"],
+                        additionalProperties: false,
+                        properties: {
+                            url: { type: "string" },
+                            type: { type: "string" },
+                            width: { type: ["string", "number"] },
+                            height: { type: ["string", "number"] },
+                        },
+                    },
+                },
+            },
+        },
+    },
 };

--- a/packages/platform-xmpp/src/responses-schema.test.ts
+++ b/packages/platform-xmpp/src/responses-schema.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, test } from "bun:test";
+import {
+    addPlatformContext,
+    addPlatformSchema,
+    validateActivityStreamResponse,
+} from "@sockethub/schemas";
+import { stanzas } from "./incoming-handlers.test.data.js";
+import { PlatformSchema } from "./schema.js";
+
+addPlatformSchema(PlatformSchema.responses, "xmpp/responses");
+addPlatformContext("xmpp", PlatformSchema.contextUrl);
+
+const CTX = [PlatformSchema.contextUrl];
+
+describe("xmpp responses schema", () => {
+    // Every message the incoming handlers emit (the expected `asobject` in the
+    // fixtures) must satisfy the strict outbound schema.
+    for (const [name, , asobject] of stanzas) {
+        if (!asobject || typeof asobject.type !== "string") {
+            continue;
+        }
+        test(`accepts emitted message: ${name}`, () => {
+            // biome-ignore lint/suspicious/noExplicitAny: fixture
+            expect(validateActivityStreamResponse(asobject as any)).toEqual("");
+        });
+    }
+
+    test("rejects an unknown message type", () => {
+        expect(
+            validateActivityStreamResponse({
+                "@context": CTX,
+                type: "bogus",
+                actor: { id: "a@b", type: "person" },
+                // biome-ignore lint/suspicious/noExplicitAny: test
+            } as any),
+        ).not.toEqual("");
+    });
+
+    test("rejects an unknown field on a message object", () => {
+        expect(
+            validateActivityStreamResponse({
+                "@context": CTX,
+                type: "send",
+                actor: { id: "a@b", type: "person" },
+                object: { type: "message", content: "x", bogus: "y" },
+                // biome-ignore lint/suspicious/noExplicitAny: test
+            } as any),
+        ).not.toEqual("");
+    });
+});

--- a/packages/platform-xmpp/src/schema.ts
+++ b/packages/platform-xmpp/src/schema.ts
@@ -26,6 +26,184 @@ export const PlatformSchema: PlatformSchemaStruct = {
             },
         },
     },
+    // Outbound (platform -> client). Strict: every message type, object type,
+    // and field the platform emits is enumerated. Validated against the
+    // incoming-handlers test fixtures.
+    responses: {
+        type: "object",
+        required: ["type", "actor"],
+        additionalProperties: false,
+        properties: {
+            "@context": { type: "array", items: { type: "string" } },
+            id: { type: "string" },
+            type: {
+                enum: [
+                    "connect",
+                    "close",
+                    "error",
+                    "update",
+                    "send",
+                    "query",
+                    "request-friend",
+                    "join",
+                    "leave",
+                ],
+            },
+            actor: { $ref: "#/definitions/responses/jid" },
+            target: { $ref: "#/definitions/responses/jid" },
+            error: { type: "string" },
+            published: { type: "string" },
+            object: {
+                oneOf: [
+                    { $ref: "#/definitions/responses/message" },
+                    { $ref: "#/definitions/responses/presence" },
+                    { $ref: "#/definitions/responses/attendance" },
+                    { $ref: "#/definitions/responses/roomInfo" },
+                    { $ref: "#/definitions/responses/connect" },
+                ],
+            },
+        },
+        definitions: {
+            responses: {
+                jid: {
+                    type: "object",
+                    required: ["id", "type"],
+                    additionalProperties: false,
+                    properties: {
+                        id: { type: "string" },
+                        type: { enum: ["person", "room"] },
+                        name: { type: "string" },
+                    },
+                },
+                message: {
+                    type: "object",
+                    required: ["type"],
+                    additionalProperties: false,
+                    properties: {
+                        type: { enum: ["message"] },
+                        id: { type: "string" },
+                        content: { type: "string" },
+                        "xmpp:stanza-id": { type: "string" },
+                        "xmpp:replace": {
+                            type: "object",
+                            required: ["id"],
+                            additionalProperties: false,
+                            properties: { id: { type: "string" } },
+                        },
+                    },
+                },
+                presence: {
+                    type: "object",
+                    required: ["type"],
+                    additionalProperties: false,
+                    properties: {
+                        type: { enum: ["presence"] },
+                        presence: {
+                            enum: [
+                                "away",
+                                "chat",
+                                "dnd",
+                                "xa",
+                                "offline",
+                                "online",
+                                "notauthorized",
+                            ],
+                        },
+                        content: { type: "string" },
+                    },
+                },
+                attendance: {
+                    type: "object",
+                    required: ["type"],
+                    additionalProperties: false,
+                    properties: {
+                        type: { enum: ["attendance"] },
+                        members: { type: "array", items: { type: "string" } },
+                    },
+                },
+                connect: {
+                    type: "object",
+                    required: ["type"],
+                    additionalProperties: false,
+                    properties: {
+                        type: { enum: ["connect"] },
+                        status: { type: "string" },
+                        condition: { type: "string" },
+                    },
+                },
+                roomInfoField: {
+                    type: "object",
+                    required: ["type", "value"],
+                    additionalProperties: false,
+                    properties: {
+                        type: { type: "string" },
+                        label: { type: "string" },
+                        value: {
+                            oneOf: [
+                                { type: "string" },
+                                { type: "number" },
+                                { type: "boolean" },
+                                { type: "null" },
+                                { type: "array", items: { type: "string" } },
+                            ],
+                        },
+                        options: {
+                            type: "array",
+                            items: {
+                                type: "object",
+                                required: ["label", "value"],
+                                additionalProperties: false,
+                                properties: {
+                                    label: { type: "string" },
+                                    value: { type: "string" },
+                                },
+                            },
+                        },
+                    },
+                },
+                roomInfo: {
+                    type: "object",
+                    required: ["type"],
+                    additionalProperties: false,
+                    properties: {
+                        type: { enum: ["room-info"] },
+                        features: { type: "array", items: { type: "string" } },
+                        identities: {
+                            type: "array",
+                            items: {
+                                type: "object",
+                                required: ["category", "type"],
+                                additionalProperties: false,
+                                properties: {
+                                    category: { type: "string" },
+                                    type: { type: "string" },
+                                    name: { type: "string" },
+                                },
+                            },
+                        },
+                        roominfo: {
+                            type: "object",
+                            additionalProperties: {
+                                $ref: "#/definitions/responses/roomInfoField",
+                            },
+                        },
+                        roomconfig: {
+                            type: "object",
+                            additionalProperties: {
+                                $ref: "#/definitions/responses/roomInfoField",
+                            },
+                        },
+                        custom: {
+                            type: "object",
+                            additionalProperties: {
+                                $ref: "#/definitions/responses/roomInfoField",
+                            },
+                        },
+                    },
+                },
+            },
+        },
+    },
     credentials: {
         required: ["object"],
         properties: {

--- a/packages/server/src/platform-instance.test.ts
+++ b/packages/server/src/platform-instance.test.ts
@@ -311,6 +311,33 @@ describe("PlatformInstance", () => {
             });
         });
 
+        test("exempts failure notifications (request echo + error) from validation", () => {
+            pi.contextUrl = RESPONSES_CTX;
+            const errorSpy = sandbox.spy(pi.log, "error");
+            // A failed job echoes the original request (an inbound type, not in
+            // the responses enum) plus an `error` field; it must still deliver.
+            pi.sendToClient("my session id", {
+                type: "fetch", // inbound type, not a respplat response type
+                actor: { id: "a@b", type: "feed" },
+                error: "job failed",
+            });
+            sandbox.assert.notCalled(errorSpy);
+            sandbox.assert.calledOnce(socketMock.emit);
+        });
+
+        test("reportError emits a valid service actor for a global platform", async () => {
+            pi.sessions.add("my session id");
+            await pi.reportError("my session id", "boom");
+            sandbox.assert.calledOnce(socketMock.emit);
+            const emitted = socketMock.emit.firstCall.args[1];
+            expect(emitted.type).toEqual("error");
+            expect(emitted.actor).toEqual({
+                id: "a platform name",
+                type: "service",
+            });
+            expect(emitted.error).toEqual("boom");
+        });
+
         describe("handleJobResult", () => {
             beforeEach(() => {
                 pi.sendToClient = sandbox.fake();

--- a/packages/server/src/platform-instance.test.ts
+++ b/packages/server/src/platform-instance.test.ts
@@ -8,7 +8,7 @@ import {
 } from "@sockethub/schemas";
 
 // A platform context with an outbound `responses` schema (only allows
-// type "collection"), used to exercise warn-only outbound validation.
+// type "collection"), used to exercise enforced outbound validation.
 const RESPONSES_CTX =
     "https://sockethub.org/ns/context/platform/respplat/v1.jsonld";
 addPlatformSchema(
@@ -264,25 +264,39 @@ describe("PlatformInstance", () => {
             sandbox.assert.notCalled(errorSpy);
         });
 
-        test("warns (but still delivers) when an outbound message violates the responses schema", () => {
+        test("drops (no emit) an outbound message that violates the responses schema", () => {
             pi.contextUrl = RESPONSES_CTX;
-            const warnSpy = sandbox.spy(pi.log, "warn");
+            const errorSpy = sandbox.spy(pi.log, "error");
             pi.sendToClient("my session id", {
                 type: "page", // not allowed by respplat responses schema
                 actor: { id: "a@b", type: "feed" },
             });
-            sandbox.assert.calledOnce(warnSpy);
-            sandbox.assert.calledOnce(socketMock.emit); // warn-only: still delivered
+            sandbox.assert.calledOnce(errorSpy);
+            sandbox.assert.notCalled(socketMock.emit); // enforced: dropped
         });
 
-        test("does not warn when an outbound message matches the responses schema", () => {
+        test("delivers an outbound message that matches the responses schema", () => {
             pi.contextUrl = RESPONSES_CTX;
-            const warnSpy = sandbox.spy(pi.log, "warn");
+            const errorSpy = sandbox.spy(pi.log, "error");
             pi.sendToClient("my session id", {
                 type: "collection",
                 actor: { id: "a@b", type: "feed" },
             });
-            sandbox.assert.notCalled(warnSpy);
+            sandbox.assert.notCalled(errorSpy);
+            sandbox.assert.calledOnce(socketMock.emit);
+        });
+
+        test("exempts error envelopes from responses-schema validation", () => {
+            pi.contextUrl = RESPONSES_CTX;
+            const errorSpy = sandbox.spy(pi.log, "error");
+            // `error` is not in respplat's responses enum, but error envelopes
+            // are exempt and must still be delivered.
+            pi.sendToClient("my session id", {
+                type: "error",
+                actor: { id: "a@b", type: "service" },
+                error: "boom",
+            });
+            sandbox.assert.notCalled(errorSpy);
             sandbox.assert.calledOnce(socketMock.emit);
         });
 

--- a/packages/server/src/platform-instance.test.ts
+++ b/packages/server/src/platform-instance.test.ts
@@ -300,6 +300,17 @@ describe("PlatformInstance", () => {
             sandbox.assert.calledOnce(socketMock.emit);
         });
 
+        test("injects a valid actor on actorless errors (global platform)", () => {
+            // pi is constructed without an `actor` (global), so the fallback is
+            // the platform name — never an undefined id.
+            pi.sendToClient("my session id", { type: "error", error: "boom" });
+            sandbox.assert.calledOnce(socketMock.emit);
+            expect(socketMock.emit.firstCall.args[1].actor).toEqual({
+                id: "a platform name",
+                type: "service",
+            });
+        });
+
         describe("handleJobResult", () => {
             beforeEach(() => {
                 pi.sendToClient = sandbox.fake();

--- a/packages/server/src/platform-instance.ts
+++ b/packages/server/src/platform-instance.ts
@@ -253,13 +253,11 @@ export default class PlatformInstance {
             return;
         }
         this.toExternalPayload(msg);
-        if (
-            msg.type === "error" &&
-            typeof msg.actor === "undefined" &&
-            this.actor
-        ) {
-            // ensure an actor is present if not otherwise defined
-            msg.actor = { id: this.actor, type: "service" };
+        if (msg.type === "error" && typeof msg.actor === "undefined") {
+            // ensure an actor is present if not otherwise defined; global
+            // platforms have no `this.actor`, so fall back to the platform name
+            // (an id-bearing, valid actor).
+            msg.actor = { id: this.actor ?? this.name, type: "service" };
         }
         // Validate outbound protocol responses against the platform's
         // `responses` schema and drop malformed messages (#1120). `error`
@@ -389,7 +387,9 @@ export default class PlatformInstance {
                 this.contextUrl ?? INTERNAL_PLATFORM_CONTEXT_URL,
             ),
             type: "error",
-            actor: { id: this.actor, type: "service" },
+            // Global platforms have no `this.actor`; fall back to the platform
+            // name so the error always carries a valid (id-bearing) actor.
+            actor: { id: this.actor ?? this.name, type: "service" },
             error: errorMessage,
         };
 

--- a/packages/server/src/platform-instance.ts
+++ b/packages/server/src/platform-instance.ts
@@ -259,12 +259,14 @@ export default class PlatformInstance {
             // (an id-bearing, valid actor).
             msg.actor = { id: this.actor ?? this.name, type: "service" };
         }
-        // Validate outbound protocol responses against the platform's
-        // `responses` schema and drop malformed messages (#1120). `error`
-        // envelopes are a generic cross-cutting shape (not a platform protocol
-        // response) and are exempt; platforms without a `responses` schema are
-        // a no-op (validateActivityStreamResponse returns "").
-        if (msg.type !== "error") {
+        // Validate successful protocol responses against the platform's
+        // `responses` schema and drop malformed messages (#1120). Error and
+        // failure notifications are exempt: a `type: "error"` envelope, or any
+        // message carrying an `error` field (e.g. a failed job echoes the
+        // original request plus `error`), is a generic cross-cutting shape, not
+        // a protocol response. Platforms without a `responses` schema are a
+        // no-op (validateActivityStreamResponse returns "").
+        if (msg.type !== "error" && typeof msg.error === "undefined") {
             const responseError = validateActivityStreamResponse(
                 msg as ActivityStream,
             );

--- a/packages/server/src/platform-instance.ts
+++ b/packages/server/src/platform-instance.ts
@@ -259,19 +259,23 @@ export default class PlatformInstance {
             this.actor
         ) {
             // ensure an actor is present if not otherwise defined
-            msg.actor = { id: this.actor, type: "unknown" };
+            msg.actor = { id: this.actor, type: "service" };
         }
-        // Warn-only outbound validation (see #1120): no-op until a platform
-        // registers a `responses` schema. Once it does, mismatches are logged
-        // (not dropped) so we can converge schemas against real traffic before
-        // enforcing.
-        const responseError = validateActivityStreamResponse(
-            msg as ActivityStream,
-        );
-        if (responseError) {
-            this.log.warn(
-                `outbound message does not match ${this.name} responses schema [${sessionId}]: ${responseError}`,
+        // Validate outbound protocol responses against the platform's
+        // `responses` schema and drop malformed messages (#1120). `error`
+        // envelopes are a generic cross-cutting shape (not a platform protocol
+        // response) and are exempt; platforms without a `responses` schema are
+        // a no-op (validateActivityStreamResponse returns "").
+        if (msg.type !== "error") {
+            const responseError = validateActivityStreamResponse(
+                msg as ActivityStream,
             );
+            if (responseError) {
+                this.log.error(
+                    `dropping malformed outbound message [${this.name}] to ${sessionId}: ${responseError}`,
+                );
+                return;
+            }
         }
         socket.emit("message", msg as ActivityStream);
     }
@@ -385,7 +389,7 @@ export default class PlatformInstance {
                 this.contextUrl ?? INTERNAL_PLATFORM_CONTEXT_URL,
             ),
             type: "error",
-            actor: { id: this.actor, type: "unknown" },
+            actor: { id: this.actor, type: "service" },
             error: errorMessage,
         };
 


### PR DESCRIPTION
Implements the core of #1120: per-platform **outbound** (`responses`) schemas, fully strict (`additionalProperties: false`), enforced in `PlatformInstance.sendToClient`. Builds on the warn-only infra from #1121.

## What this does
Each protocol platform now declares the exact shape of every message it emits, and the server **drops** (logs at error) any outbound message that doesn't match — symmetric with inbound validation.

- **platform-feeds** — `collection` message + `post` items (feed-channel actor + article/note object).
- **platform-metadata** — `page` response (website actor + open-graph-derived page object incl. the ogImage array shape).
- **platform-xmpp** — every outbound message type (connect/close/error/update/send/query/request-friend/join/leave) and object type (message/presence/attendance/room-info/connect), incl. the top-level `error` field and dynamic room-info form maps.
- **platform-irc** — every outbound type (update/send/join/leave/add/remove) and object type (message/me/presence/topic/address/relationship).
- **server** — `sendToClient` flips warn→**enforce** (drop+log on mismatch). Fixes the injected/error-path actor type `unknown`→`service` (`unknown` isn't a valid actor type).

## Validation — fully strict, verified against real output
Per the agreed approach, schemas are `additionalProperties: false` (no silent passthrough), and every schema is unit-tested against the platform's **real** output (not hand-built fixtures):
- feeds: real `buildFeedItem` output from the RSS fixtures.
- metadata: real `fetch()` output (open-graph-scraper mocked).
- xmpp: every emitted message in the `incoming-handlers` fixtures.
- irc: the canonical `@sockethub/irc2as` translation outputs.

All unit suites green locally: schemas 62, feeds 23, metadata 4, xmpp 118, irc 79, server 121; lint + full build clean. The integration/contract/browser suites (CI) exercise real end-to-end flows and are the backstop for any shape not covered by fixtures.

## Scope notes
- **`error` envelopes are exempt** from responses validation — they're a generic cross-cutting shape (type `error` + `error` string + injected actor), not a platform protocol response; validating them against per-platform schemas would drop them.
- **platform-dummy is intentionally skipped** — it's an echo test-harness that deliberately passes arbitrary/malformed payloads, so a strict outbound schema would defeat its purpose. It remains a no-op (no `responses` schema).
- The base envelope / global object `oneOf` in `objects.ts` is **untouched** here. Outbound validation runs only the per-platform `responses` schema, so it never touches the base envelope. Splitting the `objects.ts` stop-gap is an inbound-only concern, tracked separately.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Outbound message validation is now strictly enforced across platforms; invalid messages are dropped and logged instead of being emitted with warnings.
  * Error envelopes and certain failure notifications bypass schema validation so error reporting remains deliverable.
  * Error responses and error reporting now set the responding service as the actor when an actor is missing.

* **Tests**
  * Added validation tests covering canonical responses and negative cases for unknown types/fields.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->