### PR TITLE
ci: make bun leg of Test NPM Package non-blocking (node gating) (#1118)

### DIFF
--- a/.github/workflows/test-npm-package.yml
+++ b/.github/workflows/test-npm-package.yml
@@ -44,6 +44,15 @@ jobs:
   test-packaged-current:
     runs-on: ubuntu-latest
 
+    # node is the gating runtime. The bun leg is non-blocking: it surfaces a
+    # known bun-runtime issue with engine.io HTTP long-polling on a loopback
+    # socket under XMPP-active load (browser-multiclient "Timeout waiting for
+    # ack") that node does not hit and docker masks. It is NOT a Sockethub code
+    # bug and NOT a bun-version regression (reproduces on the last-known-good
+    # bun 1.3.6). Tracked in #1118; keep it visible but non-blocking until the
+    # upstream bun/engine.io behaviour is resolved.
+    continue-on-error: ${{ matrix.runtime == 'bun' }}
+
     strategy:
       matrix:
         runtime: [bun, node]


### PR DESCRIPTION
## Why
The `Test NPM Package` workflow has been red on master since ~2026-01-23 because its **bun** `browser-multiclient` leg fails with `Timeout waiting for ack … event=credentials`. Investigation (see #1118) established:

- **Not a Sockethub code bug, not a payload-size issue** (dropped packet is 393 B; registry push ~4.8 KB).
- **Not an engine.io/socket.io version issue per se** (node passes with the same deps).
- **Not a bun-version regression** — reproduces on **bun 1.3.6**, the exact last-known-good version from the Jan-23 run.
- It's a **bun runtime** interaction with engine.io HTTP long-polling on a **loopback** socket under XMPP-active load: **node passes**, and the **docker**-based Integration workflow (which runs the same multiclient test) **masks** it.

Every attempt to isolate it further via CI (downgrade deps, check out old code, force websocket transport) introduced a *different* confound, so it isn't root-causable by version-pinning. The real fix needs an upstream bun/engine.io repro.

## What this does
Makes **node the gating runtime** and the **bun leg `continue-on-error`**, so the workflow reflects the supported-runtime status (green) while keeping the bun result **visible but non-blocking**. No production code changes.

## Follow-up
#1118 retains the full investigation and tracks the upstream bun-loopback-long-polling issue. The eventual fix lives there (or in a bun release), not here.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated test workflow configuration to improve reliability of testing process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->