### PR TITLE
feat(server): dedup platform registry pushes by fingerprint (#1117)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -129,7 +129,7 @@ using ActivityStreams as the uniform message format.
 
 - **TypeScript**: Use proper types from `@sockethub/schemas`. Avoid `any`.
 - **Linting**: Biome handles formatting and style. Don't comment on style.
-- **Testing**: Test files named `*.test.ts`. Use `describe` and `test` (not `it`).
+- **Testing**: Test files named `*.test.ts`. Use `describe` and `it` (not `test`).
   Mock external dependencies. Test error paths, not just happy paths.
 - **Error Handling**: Always propagate errors to the caller. Never silently swallow errors.
   Log errors with context (session ID, platform, action).

--- a/docs/client-guide.md
+++ b/docs/client-guide.md
@@ -296,11 +296,14 @@ sc.socket.emit('message', {
 ## Client Features
 
 - **Schema-driven init**: `ready()` resolves when the server's schema registry is loaded
+- **Registry caching**: the registry is fetched once and cached; on reconnect the
+  client echoes a fingerprint so the server skips re-sending an unchanged registry
 - **Context composition**: `contextFor(platform)` builds canonical `@context` arrays
 - **Outbound queueing**: Messages sent before `ready()` are queued and flushed automatically
 - **Auto-replay**: Credentials and connections restored on reconnect
-- **ActivityStream helpers**: Normalization and property linting via `@sockethub/schemas`
-  (can be called explicitly, but also automatically by the client on send/receive)
+- **ActivityStream handling**: outbound messages are normalized and validated against
+  the platform's schema (via `@sockethub/schemas`) before sending; incoming messages
+  are normalized before delivery
 - **Connection state**: Check `sc.socket.connected` for status
 
 ## Reference

--- a/packages/client/README.md
+++ b/packages/client/README.md
@@ -8,12 +8,40 @@ reconnection, and credential replay.
 ## What's Included
 
 - `SockethubClient` for connection and message handling
-- Schema-driven ActivityStreams validation and property linting (via `@sockethub/schemas`)
+- Schema-driven validation of outbound ActivityStreams messages (via `@sockethub/schemas`)
 - `contextFor(platform)` builds canonical `@context` arrays from server metadata
 - `ready()` promise and `ready`/`init_error` observability events
 - Automatic outbound queuing until initialization is complete
 - Auto-replay of credentials and connections on reconnect
 - A browser-ready bundle in `dist/`
+
+## How It Works
+
+`SockethubClient` wraps a [Socket.IO](https://socket.io) connection and manages
+everything between your app and the Sockethub server:
+
+1. **Schema registry handshake.** On connect (and every reconnect) the client
+   requests the server's *platform schema registry* — the contexts, versions,
+   and JSON schemas for each platform the server has loaded. It caches that
+   registry along with a content fingerprint the server provides. On reconnect
+   the client echoes the fingerprint; if nothing has changed the server replies
+   `unchanged` instead of re-sending the full schema set, so the (potentially
+   large) registry crosses the wire only when it actually changes.
+2. **Initialization lifecycle.** `ready()` resolves once the registry is
+   applied; `getInitState()` and the `ready` / `init_error` events expose the
+   same lifecycle. Outbound events emitted before the client is ready are queued
+   in memory and flushed automatically once initialization completes.
+3. **Message handling.** Outgoing `message`/`credentials` events are normalized
+   (string `actor`/`target` references are expanded to objects) and validated
+   against the originating platform's schema before they leave the client;
+   incoming platform events are normalized before being handed to your
+   `message` listener. Validation uses the same schemas the server enforces, so
+   malformed activities are caught locally rather than round-tripping.
+4. **Context composition.** `contextFor(platform)` builds the canonical
+   `@context` array for a platform from the cached registry.
+5. **Reconnect resilience.** Credentials, platform connections, and room joins
+   are kept in memory and replayed when the socket reconnects (see
+   [Security & State Management](#security--state-management)).
 
 ## Install
 
@@ -150,8 +178,9 @@ sc.socket.on("message", (msg) => {
 ## Sending messages
 
 Include `id`, `type`, and usually `name` on the `actor` for `credentials` and
-`message` events. The client lints unknown object properties using schemas from
-the server registry.
+`message` events. Before sending, the client validates each outgoing activity
+against the originating platform's schema from the server registry, surfacing a
+client-side error instead of dispatching a malformed message.
 
 ```javascript
 sc.socket.emit("message", {

--- a/packages/client/src/sockethub-client.test.ts
+++ b/packages/client/src/sockethub-client.test.ts
@@ -109,8 +109,9 @@ describe("SockethubClient", () => {
             socket.io = {};
             socket.connected = true;
             sc.socket.connected = true;
-            socket.on("schemas", (ack: any) => {
-                if (typeof ack === "function") {
+            socket.on("schemas", (...args: any[]) => {
+                const ack = args.find((a) => typeof a === "function");
+                if (ack) {
                     ack(TEST_REGISTRY);
                 }
             });
@@ -158,8 +159,9 @@ describe("SockethubClient", () => {
             socket.io = {};
             socket.connected = true;
             sc.socket.connected = true;
-            socket.on("schemas", (ack: any) => {
-                if (typeof ack === "function") {
+            socket.on("schemas", (...args: any[]) => {
+                const ack = args.find((a) => typeof a === "function");
+                if (ack) {
                     ack(TEST_REGISTRY);
                 }
             });
@@ -175,6 +177,42 @@ describe("SockethubClient", () => {
             socket.emit("schemas", TEST_REGISTRY);
             const info = await sc.ready();
             expect(info.state).to.equal("ready");
+        });
+
+        it("echoes the fingerprint and reuses the registry on an 'unchanged' reply (#1117)", () => {
+            socket.io = {};
+            socket.connected = true;
+            sc.socket.connected = true;
+            const FP = "deadbeefdeadbeef";
+            const fingerprinted = { ...TEST_REGISTRY, fingerprint: FP };
+            const echoed: unknown[] = [];
+            socket.on("schemas", (...args: any[]) => {
+                const ack = args.find((a) => typeof a === "function");
+                const clientFp = args.find((a) => typeof a === "string");
+                echoed.push(clientFp);
+                if (!ack) {
+                    return;
+                }
+                ack(
+                    clientFp === FP
+                        ? { fingerprint: FP, unchanged: true }
+                        : fingerprinted,
+                );
+            });
+
+            // initial connect: no fingerprint echoed -> full registry sent
+            socket.emit("connect");
+            expect(sc.isSchemasReady()).to.equal(true);
+            expect(echoed[0]).to.equal(undefined);
+            const ctxBefore = sc.contextFor("test-xmpp");
+
+            // reconnect: client echoes the stored fingerprint and the server
+            // replies "unchanged"; the cached registry must survive.
+            socket.emit("disconnect");
+            socket.emit("connect");
+            expect(echoed).to.contain(FP);
+            expect(sc.isSchemasReady()).to.equal(true);
+            expect(sc.contextFor("test-xmpp")).to.eql(ctxBefore);
         });
 
         it("ready() rejects on timeout when schemas never arrive", async () => {
@@ -242,8 +280,9 @@ describe("SockethubClient", () => {
         it("connect", (done) => {
             expect(sc.socket.connected).to.be.false;
             socket.io = {};
-            socket.on("schemas", (ack: any) => {
-                if (typeof ack === "function") {
+            socket.on("schemas", (...args: any[]) => {
+                const ack = args.find((a) => typeof a === "function");
+                if (ack) {
                     ack({
                         contexts: {
                             as: "https://example.com/as2",

--- a/packages/client/src/sockethub-client.test.ts
+++ b/packages/client/src/sockethub-client.test.ts
@@ -215,6 +215,20 @@ describe("SockethubClient", () => {
             expect(sc.contextFor("test-xmpp")).to.eql(ctxBefore);
         });
 
+        it("ignores an 'unchanged' reply when no registry is cached (#1117)", () => {
+            // A malformed or premature "unchanged" reply must not fast-path the
+            // client to ready with no validators registered.
+            expect(sc.isSchemasReady()).to.equal(false);
+            socket.emit("schemas", {
+                fingerprint: "deadbeefdeadbeef",
+                unchanged: true,
+            });
+            expect(sc.isSchemasReady()).to.equal(false);
+            expect(() => sc.contextFor("test-xmpp")).to.throw(
+                "Schema registry not loaded yet",
+            );
+        });
+
         it("ready() rejects on timeout when schemas never arrive", async () => {
             const timeoutSocket = new EventEmitter();
             timeoutSocket.connected = true;

--- a/packages/client/src/sockethub-client.ts
+++ b/packages/client/src/sockethub-client.ts
@@ -513,13 +513,14 @@ export default class SockethubClient {
             }
         }
         const normalizedPayload = this.buildPlatformRegistryPayload();
-        // Prefer the server-supplied fingerprint (what we echo back for #1117
-        // dedup); fall back to a locally-computed one for payloads that predate
-        // the fingerprint field (e.g. test fixtures).
+        // Dedup only on the server's fingerprint, which is computed over the
+        // full payload (including schema bodies and types). Without one we leave
+        // the fingerprint unset so handleSchemasPayload never short-circuits and
+        // a schema change can't be silently missed (#1117 review).
         this.registryFingerprint =
             typeof registry.fingerprint === "string"
                 ? registry.fingerprint
-                : this.computePayloadFingerprint(normalizedPayload);
+                : undefined;
         // Emit normalized registry payload so app code receives a stable shape.
         this.socket._emit("schemas", normalizedPayload);
         return normalizedPayload;
@@ -754,57 +755,33 @@ export default class SockethubClient {
         this.flushOutboundQueue();
     }
 
-    private computePayloadFingerprint(payload: unknown): string | undefined {
-        if (!payload || typeof payload !== "object") {
-            return undefined;
-        }
-        const registry = payload as PlatformRegistryPayload;
-        if (
-            typeof registry.contexts?.as !== "string" ||
-            typeof registry.contexts?.sockethub !== "string" ||
-            !Array.isArray(registry.platforms)
-        ) {
-            return undefined;
-        }
-        const normalizedPlatforms = registry.platforms
-            .map((platform) => ({
-                id: platform.id,
-                version: platform.version,
-                contextUrl: platform.contextUrl,
-                contextVersion: platform.contextVersion,
-                schemaVersion: platform.schemaVersion,
-            }))
-            .sort((a, b) => a.id.localeCompare(b.id));
-        return JSON.stringify({
-            version: registry.version,
-            contexts: registry.contexts,
-            platforms: normalizedPlatforms,
-        });
-    }
-
     private handleSchemasPayload(payload: unknown) {
         if (!payload || typeof payload !== "object") {
             return;
         }
         // Server short-circuit: the registry matches the fingerprint we echoed,
-        // so nothing was re-sent (#1117). Our cached registry is still valid —
-        // just complete any pending init cycle.
+        // so nothing was re-sent (#1117). Only honor this when we actually hold
+        // a cached registry to reuse — a malformed or empty "unchanged" reply
+        // must not fast-path init to ready with no validators registered.
         if ((payload as PlatformRegistryPayload).unchanged === true) {
-            if (this.initCycle) {
-                this.markReady(this.initCycle.reason);
-            } else if (this.initState !== "ready") {
-                this.markReady("schemas-update");
+            const haveCachedRegistry =
+                typeof this.registryFingerprint === "string" &&
+                this.platformRegistry.size > 0;
+            if (haveCachedRegistry) {
+                if (this.initCycle) {
+                    this.markReady(this.initCycle.reason);
+                } else if (this.initState !== "ready") {
+                    this.markReady("schemas-update");
+                }
+                return;
             }
-            return;
+            // Nothing cached to reuse: fall through so applyPlatformRegistry
+            // rejects the contentless payload and surfaces an init error.
         }
-        // Prefer the server-supplied fingerprint so this dedup check compares
-        // like-for-like with the value stored in applyPlatformRegistry.
-        const serverFingerprint = (payload as PlatformRegistryPayload)
+        // Dedup only against the server-supplied fingerprint (which is what we
+        // stored in applyPlatformRegistry); absent one, always re-apply.
+        const incomingFingerprint = (payload as PlatformRegistryPayload)
             .fingerprint;
-        const incomingFingerprint =
-            typeof serverFingerprint === "string"
-                ? serverFingerprint
-                : this.computePayloadFingerprint(payload);
         if (
             this.initState === "ready" &&
             !this.initCycle &&

--- a/packages/client/src/sockethub-client.ts
+++ b/packages/client/src/sockethub-client.ts
@@ -83,6 +83,13 @@ export interface PlatformRegistryEntry {
 
 export interface PlatformRegistryPayload {
     version?: string;
+    // Server-computed content fingerprint of the registry. The client echoes
+    // this on re-request so the server can reply "unchanged" instead of
+    // re-sending the full schema set (#1117).
+    fingerprint?: string;
+    // Set by the server when the echoed fingerprint matches: the registry is
+    // identical to what the client already holds, so no platforms are included.
+    unchanged?: boolean;
     contexts?: {
         as?: string;
         sockethub?: string;
@@ -425,9 +432,15 @@ export default class SockethubClient {
         if (!("io" in socketLike)) {
             return;
         }
-        this._socket.emit("schemas", (payload: unknown) => {
-            this.handleSchemasPayload(payload);
-        });
+        // Echo the fingerprint we last applied so the server can short-circuit
+        // with an "unchanged" reply on reconnect/re-request (#1117).
+        this._socket.emit(
+            "schemas",
+            this.registryFingerprint,
+            (payload: unknown) => {
+                this.handleSchemasPayload(payload);
+            },
+        );
     }
 
     /**
@@ -500,8 +513,13 @@ export default class SockethubClient {
             }
         }
         const normalizedPayload = this.buildPlatformRegistryPayload();
+        // Prefer the server-supplied fingerprint (what we echo back for #1117
+        // dedup); fall back to a locally-computed one for payloads that predate
+        // the fingerprint field (e.g. test fixtures).
         this.registryFingerprint =
-            this.computePayloadFingerprint(normalizedPayload);
+            typeof registry.fingerprint === "string"
+                ? registry.fingerprint
+                : this.computePayloadFingerprint(normalizedPayload);
         // Emit normalized registry payload so app code receives a stable shape.
         this.socket._emit("schemas", normalizedPayload);
         return normalizedPayload;
@@ -768,7 +786,25 @@ export default class SockethubClient {
         if (!payload || typeof payload !== "object") {
             return;
         }
-        const incomingFingerprint = this.computePayloadFingerprint(payload);
+        // Server short-circuit: the registry matches the fingerprint we echoed,
+        // so nothing was re-sent (#1117). Our cached registry is still valid —
+        // just complete any pending init cycle.
+        if ((payload as PlatformRegistryPayload).unchanged === true) {
+            if (this.initCycle) {
+                this.markReady(this.initCycle.reason);
+            } else if (this.initState !== "ready") {
+                this.markReady("schemas-update");
+            }
+            return;
+        }
+        // Prefer the server-supplied fingerprint so this dedup check compares
+        // like-for-like with the value stored in applyPlatformRegistry.
+        const serverFingerprint = (payload as PlatformRegistryPayload)
+            .fingerprint;
+        const incomingFingerprint =
+            typeof serverFingerprint === "string"
+                ? serverFingerprint
+                : this.computePayloadFingerprint(payload);
         if (
             this.initState === "ready" &&
             !this.initCycle &&

--- a/packages/server/src/sockethub.ts
+++ b/packages/server/src/sockethub.ts
@@ -1,3 +1,4 @@
+import { createHash } from "node:crypto";
 import { crypto } from "@sockethub/crypto";
 import type { CredentialsStoreInterface } from "@sockethub/data-layer";
 import { CredentialsStore } from "@sockethub/data-layer";
@@ -111,6 +112,12 @@ class Sockethub {
     processManager!: ProcessManager;
     private rateLimiter!: ReturnType<typeof createRateLimiter>;
     private serverVersion?: string;
+    private platformRegistryPayloadCache?: {
+        payload: ReturnType<Sockethub["buildPlatformRegistryPayload"]> & {
+            fingerprint: string;
+        };
+        fingerprint: string;
+    };
 
     /**
      * Build the platform registry payload sent to clients.
@@ -138,6 +145,28 @@ class Sockethub {
                 }),
             ),
         };
+    }
+
+    /**
+     * Return the platform registry payload plus a content fingerprint, computed
+     * once and cached. The registry is static after platform load, so clients
+     * that already hold a matching fingerprint can be told "unchanged" instead
+     * of being re-sent the full (tens-of-KB) schema set on every reconnect or
+     * re-request (see #1117).
+     */
+    private getPlatformRegistryPayload() {
+        if (!this.platformRegistryPayloadCache) {
+            const base = this.buildPlatformRegistryPayload();
+            const fingerprint = createHash("sha256")
+                .update(JSON.stringify(base))
+                .digest("hex")
+                .slice(0, 16);
+            this.platformRegistryPayloadCache = {
+                payload: { fingerprint, ...base },
+                fingerprint,
+            };
+        }
+        return this.platformRegistryPayloadCache;
     }
 
     constructor() {
@@ -215,23 +244,33 @@ class Sockethub {
             );
 
         sessionLog.debug("socket.io connection");
-        const platformRegistryPayload = this.buildPlatformRegistryPayload();
+        const { payload: platformRegistryPayload, fingerprint } =
+            this.getPlatformRegistryPayload();
 
         // Rate limiting middleware - runs on every incoming event
         socket.use((event, next) => {
             this.rateLimiter(socket, event[0], next);
         });
 
-        // Send schema metadata to clients immediately and on-demand.
-        socket.emit("schemas", platformRegistryPayload);
+        // Serve the platform registry on demand. The client (SockethubClient)
+        // requests it on every connect/reconnect and echoes the fingerprint it
+        // last received; when that matches we reply "unchanged" so a reconnect
+        // or re-request doesn't re-transmit the full schema set (#1117).
         socket.on("schemas", (...args: unknown[]) => {
             const ack = args.find(
                 (a): a is (payload: unknown) => void => typeof a === "function",
             );
+            const clientFingerprint = args.find(
+                (a): a is string => typeof a === "string",
+            );
+            const response =
+                clientFingerprint === fingerprint
+                    ? { fingerprint, unchanged: true }
+                    : platformRegistryPayload;
             if (ack) {
-                ack(platformRegistryPayload);
+                ack(response);
             } else {
-                socket.emit("schemas", platformRegistryPayload);
+                socket.emit("schemas", response);
             }
         });
 


### PR DESCRIPTION
Closes #1117.

## Problem
On every connection the server emitted the **entire** platform schemas registry (full JSON schemas for all platforms — tens of KB) unconditionally via `socket.emit("schemas", …)`, and the client *also* re-requested it during `ready()`. So each connection transferred the full schema set at least twice, and every reconnect re-sent it again. Over HTTP long-polling these large pushes concatenate toward `maxPayload`.

## Approach
The client genuinely needs the schemas (it registers them locally and validates outgoing messages with `validateActivity`), so we can't simply stop sending them. Instead we **dedup by fingerprint** — the issue's secondary proposal — and make delivery **on-demand**:

**Server**
- Compute the registry payload + a SHA-256 content fingerprint **once** and cache it (the registry is static after platform load).
- Drop the unconditional on-connect push; serve the registry only in response to the client's `"schemas"` request.
- When the client echoes a fingerprint that matches, reply `{ fingerprint, unchanged: true }` instead of the full payload.

**Client**
- Echo the last-applied fingerprint on each `"schemas"` request.
- Store the **server-supplied** fingerprint (so the echo compares like-for-like).
- On an `unchanged` reply, reuse the cached registry and just complete the init cycle. Falls back to a locally computed fingerprint for payloads without one (e.g. test fixtures), so older payloads still work.

## Result
- **Fresh client / browser refresh:** full registry once (no prior fingerprint).
- **Transport-level reconnect (same client instance):** a tiny `unchanged` reply instead of the full schema set.
- No more per-connection double-send (proactive push + ready() re-request).

`SockethubClient` already requests schemas on every connect/reconnect (`startInitialization → requestSchemaRegistry`), so dropping the proactive push is transparent to it. (Note: a raw, non-`SockethubClient` socket that relied on the unsolicited push must now request it — a minor protocol change.)

## Tests
- New client unit test: echoes the stored fingerprint on reconnect and reuses the cached registry on an `unchanged` reply.
- Updated existing client mocks to find the ack callback among args (the request now carries a fingerprint arg before the callback).
- Full-payload path (fresh connect) is exercised by every integration/browser test.

Local: build + types green, biome clean, client/server/schemas suites 192/192 pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Registry fingerprinting and caching to optimize schema delivery; client echoes fingerprint on reconnect for an unchanged-schema fast path.

* **Bug Fixes**
  * Fixes for fingerprint/unchanged handling so reconnects reuse cached registries without invalidating contexts (regression `#1117`).
  * Client ignores premature/malformed "unchanged" replies when no registry is cached.

* **Tests**
  * Added/updated tests for fingerprint echoing, reconnect registry reuse, and event ack argument handling.

* **Documentation**
  * Clarified client initialization, registry handshake, validation, and reconnect behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->