### PR TITLE
docs: clarify client/server responsibilities, validation & replay

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -346,9 +346,18 @@ Redis and BullMQ provide reliable, encrypted communication between server and pl
 
 ### Validation Pipeline
 
+The per-session middleware chain runs on each inbound event; the validated job is
+then handed to the job-queue layer, which encrypts the payload as it enqueues:
+
 ```
-Incoming activity → normalize → schema validation → credential handling → encrypt → enqueue
+middleware:  normalize → schema validation → credential handling
+job queue:   queue.add() → encrypt payload → enqueue (Redis/BullMQ)
 ```
+
+Encryption is not a middleware step — it happens inside `@sockethub/data-layer`
+(`JobQueue.createJob` → `encryptActivityStream`) when `platformInstance.queue.add()`
+is called; the worker decrypts via `decryptJobData` before running the platform
+handler.
 
 ## Platform Types
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -42,8 +42,9 @@ Sockethub is a protocol gateway that runs as four coordinated components:
 └────────────────┘     └─────────────────────┘    └─────────────────┘
 ```
 
-**Data Flow**: All ActivityStreams messages, credentials, and job data are encrypted before
-storage or transmission. Each phase handles specific responsibilities:
+**Data Flow**: Credentials and job payloads are encrypted at rest in Redis and on the
+server↔platform job queue. The browser↔server hop is plain Socket.IO — run it over HTTPS/WSS
+for transport encryption. Each phase handles specific responsibilities:
 
 - **Web App**: Sends standardized ActivityStreams messages
 - **Sockethub Server**: Validates, encrypts, and routes messages  
@@ -270,7 +271,7 @@ Every client WebSocket connection gets its own completely isolated environment:
 
 - **Unique Session ID**: Generated per connection for complete isolation
 - **Dedicated Encryption**: 32-character secret key per session
-- **Redis Namespace**: `session:{sessionId}:*` prevents cross-session data access
+- **Redis Namespace**: keys scoped per session (parent + session id) prevent cross-session access
 - **Automatic Cleanup**: All session data cleared on disconnect
 
 ### Job Queue Coordination
@@ -332,9 +333,9 @@ Redis and BullMQ provide reliable, encrypted communication between server and pl
 ### Encryption Everywhere
 
 - **Session Keys**: Unique 32-character encryption key per client session
-- **All Data Encrypted**: ActivityStreams messages, credentials, job data - everything encrypted
-- **Job Queue**: All messages encrypted before queuing in Redis
-- **No Plaintext**: Sensitive data never stored or transmitted in plaintext
+- **Encrypted at rest**: credentials and job payloads are encrypted before being stored in Redis
+- **Encrypted on the queue**: job messages are encrypted between the server and platform workers
+- **Transport**: the browser↔server Socket.IO hop is not app-encrypted — serve over HTTPS/WSS
 
 ### Multi-Level Isolation
 
@@ -346,7 +347,7 @@ Redis and BullMQ provide reliable, encrypted communication between server and pl
 ### Validation Pipeline
 
 ```
-ActivityStreams Message → Schema Validation → Platform Verification → Encryption → Queue
+Incoming activity → normalize → schema validation → credential handling → encrypt → enqueue
 ```
 
 ## Platform Types

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -50,6 +50,197 @@ storage or transmission. Each phase handles specific responsibilities:
 - **Redis Queue**: Stores encrypted jobs and credentials with session isolation
 - **Platform Worker**: Decrypts jobs and translates to external protocols
 
+## Component Responsibilities
+
+It helps to be precise about which component is responsible for what — especially
+around validation, which is a common point of confusion.
+
+| Concern | Client (`@sockethub/client`) | Server (`@sockethub/server`) | Platform (child process) |
+|---|---|---|---|
+| Authoritative validation | ❌ | ✅ **both directions** | ❌ (trusts server) |
+| Inbound validation (app → platform) | ⚠️ advisory pre-check | ✅ authoritative | — |
+| Outbound validation (platform → app) | ❌ (normalizes only) | ✅ authoritative | — |
+| Normalization (expand `actor`/`target` refs) | ✅ | ✅ inbound | — |
+| Holds the schemas | copy pushed from server | source of truth | — |
+| `@context` composition | ✅ `contextFor()` | — | — |
+| Outbound queue until ready | ✅ | — | — |
+| Reconnect replay (creds/connect/join) | ✅ | — | — |
+| Process isolation / spawning | — | ✅ `ProcessManager` | runs platform code |
+| Talks to external networks | — | — | ✅ |
+| Encrypted credential storage | — | ✅ writes (Redis) | ✅ reads (decrypts) |
+
+The client is an **ergonomic SDK, not a trust boundary**. Anything it does for
+safety, the server also does — authoritatively. You could bypass the SDK and
+emit raw Socket.IO events; the server would still validate everything.
+
+## Validation Model
+
+> **Validation authority lives entirely on the server, in both directions.** The
+> client *also* validates, but only what it is about to send, and only as a local
+> fail-fast convenience. The server never relies on the client having validated
+> anything.
+
+Each platform defines **three** schema kinds, which map to message directions:
+
+| Schema | Describes | Server uses it | Pushed to client | Client uses it |
+|---|---|---|---|---|
+| `credentials` | app→server (set creds) | ✅ inbound (auth) | ✅ yes | ⚠️ advisory |
+| `messages` | app→server (commands) | ✅ inbound (auth) | ✅ yes | ⚠️ advisory + `contextFor` |
+| `responses` | platform→app (replies) | ✅ outbound (auth) | ❌ no | — |
+
+This is why the server publishes schemas yet validation remains a server
+responsibility: it publishes **only the two inbound schemas** (`credentials` +
+`messages`) — exactly what the client needs to (a) sanity-check what *it* is
+about to send and (b) build `@context` arrays. The `responses` schema stays
+**server-side only**, because validating platform replies is the server's job;
+the client simply trusts (and normalizes) what arrives.
+
+Both the client pre-check and the server's inbound check run the **same schema
+rules** — the client just received a copy of those rules over the wire during the
+schema handshake.
+
+## Client ⇄ Server Coordination
+
+### Connect & schema handshake
+
+On connect (and every reconnect) the client fetches the platform schema registry,
+then caches it along with a server-supplied fingerprint. On a later request it
+echoes the fingerprint so the server can skip re-sending an unchanged registry.
+
+```mermaid
+sequenceDiagram
+    participant C as SockethubClient
+    participant S as Server
+
+    C->>S: connect
+    C->>S: emit("schemas", lastFingerprint?)
+    alt first connect (no fingerprint) or registry changed
+        S-->>C: full registry {contexts, per-platform credentials+messages, fingerprint}
+        C->>C: cache registry + fingerprint, register validators
+    else reconnect, fingerprint matches
+        S-->>C: {unchanged: true}  (tiny)
+        C->>C: reuse cached registry
+    end
+    C->>C: ready() resolves — contextFor()/validateActivity usable
+```
+
+Until `ready()` resolves, outbound events from your app are **queued in memory**
+and flushed automatically once the registry is applied.
+
+### Sending a command (outbound)
+
+```mermaid
+sequenceDiagram
+    participant A as Your app
+    participant C as SockethubClient
+    participant S as Server
+    participant Q as Redis queue
+    participant P as Platform child
+
+    A->>C: emit("message", activity)
+    C->>C: normalize (expand actor/target)
+    C->>C: validateActivity ⚠️ advisory
+    alt invalid locally
+        C-->>A: client error (never leaves the process)
+    else valid
+        C->>S: socket.emit("message", activity)
+        S->>S: normalize → validate ✅ authoritative
+        alt invalid
+            S-->>A: error ack (rejected, never queued)
+        else valid
+            S->>Q: enqueue job
+            Q->>P: deliver job
+            P->>P: decrypt creds, act on external network
+            P-->>S: result / error
+            S->>S: validate response ✅ (responses schema)
+            S-->>A: ack (job result)
+        end
+    end
+```
+
+The client check and the server check enforce the **same** `messages` rules; the
+client one just saves a round-trip when the activity is obviously malformed.
+
+### Receiving an event (inbound)
+
+Incoming events flow from the platform outward to every client session attached
+to that platform instance. The client validates what it **sends** but not what it
+**receives**, because the server already validated the outbound side.
+
+```mermaid
+sequenceDiagram
+    participant P as Platform child
+    participant S as Server (PlatformInstance)
+    participant C as SockethubClient
+    participant A as Your app
+
+    P-->>S: activity (incoming event)
+    S->>S: toExternalPayload + validateActivityStreamResponse ✅
+    alt malformed
+        S->>S: drop + log (never reaches any client)
+    else ok
+        S->>C: socket.emit("message", activity)
+        C->>C: normalize (no validation)
+        C->>A: "message" handler
+    end
+```
+
+## Reconnection & Replay
+
+Networks drop. The client makes reconnection transparent by remembering the
+*state-establishing* activities you sent and replaying them — in dependency
+order — once the new connection is ready. This is one of the main reasons to use
+the SDK rather than a raw socket.
+
+### What the client remembers
+
+The client keeps three in-memory maps, updated as you emit:
+
+| Map | Filled by | Cleared by |
+|---|---|---|
+| `credentials` | `credentials` activity (by actor id) | newer `credentials`; `clearCredentials()` |
+| `connect` | a `connect` message | a `disconnect` message |
+| `join` | a `join` message | a `leave` message |
+
+`leave`/`disconnect` are treated as the inverse of `join`/`connect`, so the
+remembered set always reflects your *current intended* state, not raw history.
+
+### What happens on reconnect
+
+```mermaid
+sequenceDiagram
+    participant C as SockethubClient
+    participant S as Server
+    participant P as Platform
+
+    Note over C: socket drops, then reconnects
+    C->>S: connect (new socket) + schema handshake
+    C->>C: ready() resolves
+    Note over C: replay in dependency order
+    C->>S: replay credentials  (re-auth first)
+    C->>S: replay connect      (re-establish platform sessions)
+    C->>S: replay join         (re-join rooms/channels)
+    C->>S: flush queued outbound messages
+    S->>P: re-run as normal validated jobs
+```
+
+Replay order matters — **credentials → connect → join → queued messages** — so
+the platform is authenticated before it's asked to connect, and connected before
+it's asked to join a room.
+
+### Important properties
+
+- **In memory only.** Nothing is persisted to localStorage, cookies, IndexedDB,
+  or disk. State survives a brief network blip but is cleared on page refresh /
+  tab close, and is not shared between tabs.
+- **The server still validates replays.** Replayed credentials may have expired
+  or been revoked; the server re-validates each replayed activity like any other
+  inbound message, and persistent-platform session sharing is re-checked.
+- **Opt out** by calling `sc.clearCredentials()` (e.g. on `disconnect`) if you
+  don't want automatic credential replay.
+
+See the [Client Guide](client-guide.md) for the app-facing API.
+
 ## Core Architectural Decisions
 
 ### Process Isolation


### PR DESCRIPTION
## Why
The existing `docs/architecture.md` explained the server↔platform layer well but said nothing about the **client SDK's role** or the **validation model** — which is a recurring source of confusion: *"I thought validation was server-only, so why does the server publish schemas to every client?"*

## What
Adds the missing pieces (with **Mermaid** diagrams, so they render graphically on GitHub/GitBook), inserted after the System Overview; the existing server↔platform / security / scaling sections are unchanged.

- **Component Responsibilities** table — who owns authoritative validation, normalization, schemas, `@context` composition, outbound queueing, reconnect replay, process isolation, and credential storage.
- **Validation Model** — the server is the *sole authoritative* validator, in **both** directions; the client's outbound check is an **advisory fail-fast**, not a trust boundary. Explains the three per-platform schemas and why only the two **inbound** ones (`credentials` + `messages`) are pushed to clients, while `responses` stays server-only:

  | Schema | Direction | Server | Pushed to client | Client |
  |---|---|---|---|---|
  | `credentials` | app→server | ✅ auth | ✅ | ⚠️ advisory |
  | `messages` | app→server | ✅ auth | ✅ | ⚠️ advisory + `contextFor` |
  | `responses` | platform→app | ✅ auth | ❌ | — |

- **Client⇄Server coordination** — sequence diagrams for the connect/schema handshake (including the #1117 fingerprint dedup), the outbound command flow, and the inbound event flow.
- **Reconnection & Replay** — what the client remembers (`credentials`/`connect`/`join` maps), the dependency-ordered replay on reconnect (credentials → connect → join → queued), and that the server re-validates every replayed activity.

## Notes
- Doc-only change; no code touched.
- Describes the schema-handshake fingerprint dedup landing in #1129. Best merged after (or alongside) #1129; the rest of the doc is independent of it.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Expanded architecture docs with a clear validation model and component responsibilities.
  * Detailed client↔server coordination flow with sequence diagrams for connect, command send, and inbound events.
  * Added reconnection & replay behavior and ordering for credentials/connect/join/queued messages.
  * Clarified session isolation and encryption/security characteristics of transport, storage, and queued payloads.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->