### PR TITLE
fix(platform-feeds): reconcile outbound output with strict responses schema

### DIFF
--- a/packages/platform-feeds/src/index.test.ts
+++ b/packages/platform-feeds/src/index.test.ts
@@ -503,9 +503,46 @@ describe("platform-feeds", () => {
                 const actor = results.items[0].actor;
                 expect(typeof actor?.image).toBe("string");
                 expect(actor?.image).toEqual("https://example.com/logo.png");
+                // podparse maps <author> to the raw text, not an object.
+                expect(actor?.author).toEqual(
+                    "editor@example.com (Jane Editor)",
+                );
                 expect(results.items[0].id).toEqual("image-author-feed-id");
 
                 expect(validateActivityStreamResponse(results)).toEqual("");
+            },
+        );
+    });
+
+    it("emits a schema-valid collection from a feed without channel image/author", () => {
+        platform.makeRequest = (): Promise<string> => {
+            return Promise.resolve(loadFixture("bare-channel-rss.xml"));
+        };
+
+        platform.fetch(
+            {
+                id: "bare-feed-id",
+                actor: {
+                    id: "https://example.com/feed",
+                },
+            },
+            (err, results: ASCollection) => {
+                expect(err).toBeNull();
+                expect(results.totalItems).toEqual(1);
+
+                // Absent channel metadata must not break strict validation:
+                // image/author are undefined and AJV skips undefined-valued
+                // properties (they are also dropped at the JSON/IPC boundary).
+                const actor = results.items[0].actor;
+                expect(actor?.image).toBeUndefined();
+                expect(actor?.author).toBeUndefined();
+
+                expect(validateActivityStreamResponse(results)).toEqual("");
+                expect(
+                    validateActivityStreamResponse(
+                        JSON.parse(JSON.stringify(results)),
+                    ),
+                ).toEqual("");
             },
         );
     });

--- a/packages/platform-feeds/src/index.test.ts
+++ b/packages/platform-feeds/src/index.test.ts
@@ -1,6 +1,6 @@
 import { readFileSync } from "node:fs";
 import path from "node:path";
-import { beforeEach, describe, expect, test } from "bun:test";
+import { beforeEach, describe, expect, it, test } from "bun:test";
 import type { ASCollection, PlatformSession } from "@sockethub/schemas";
 import {
     addPlatformContext,
@@ -478,6 +478,34 @@ describe("platform-feeds", () => {
                 expect(err).toBeInstanceOf(Error);
                 expect(err?.message).toEqual("Network timeout");
                 expect(results).toBeUndefined();
+            },
+        );
+    });
+
+    it("emits a schema-valid collection from a real channel image/author feed", () => {
+        platform.makeRequest = (): Promise<string> => {
+            return Promise.resolve(loadFixture("channel-image-author-rss.xml"));
+        };
+
+        platform.fetch(
+            {
+                id: "image-author-feed-id",
+                actor: {
+                    id: "https://example.com/feed",
+                },
+            },
+            (err, results: ASCollection) => {
+                expect(err).toBeNull();
+                expect(results.totalItems).toEqual(1);
+
+                // The real buildFeedChannel output (image + author) and the
+                // per-post `id` must satisfy the strict outbound schema.
+                const actor = results.items[0].actor;
+                expect(typeof actor?.image).toBe("string");
+                expect(actor?.image).toEqual("https://example.com/logo.png");
+                expect(results.items[0].id).toEqual("image-author-feed-id");
+
+                expect(validateActivityStreamResponse(results)).toEqual("");
             },
         );
     });

--- a/packages/platform-feeds/src/index.ts
+++ b/packages/platform-feeds/src/index.ts
@@ -252,9 +252,9 @@ function buildFeedChannel(url: string, meta: Meta): PlatformFeedsActivityActor {
         name: meta.title ? meta.title : meta.link ? meta.link : url,
         link: meta.link || url,
         description: meta.description ? meta.description : undefined,
-        image: meta.image ? meta.image : undefined,
+        image: meta.image?.url || undefined,
         categories: meta.category ? meta.category : [],
         language: meta.language ? meta.language : undefined,
-        author: meta.author ? meta.author : undefined,
+        author: meta.author?.name || undefined,
     };
 }

--- a/packages/platform-feeds/src/index.ts
+++ b/packages/platform-feeds/src/index.ts
@@ -255,6 +255,11 @@ function buildFeedChannel(url: string, meta: Meta): PlatformFeedsActivityActor {
         image: meta.image?.url || undefined,
         categories: meta.category ? meta.category : [],
         language: meta.language ? meta.language : undefined,
-        author: meta.author?.name || undefined,
+        // podparse's typings declare `author` as an object, but its RSS
+        // mapping emits the raw <author> text as a string; handle both shapes.
+        author:
+            (typeof meta.author === "string"
+                ? meta.author
+                : meta.author?.name) || undefined,
     };
 }

--- a/packages/platform-feeds/src/schema.ts
+++ b/packages/platform-feeds/src/schema.ts
@@ -63,6 +63,7 @@ export default {
                             type: "array",
                             items: { type: "string" },
                         },
+                        id: { type: ["string", "null"] },
                         type: { enum: ["post"] },
                         actor: { $ref: "#/definitions/responses/feedChannel" },
                         object: { $ref: "#/definitions/responses/feedItem" },

--- a/packages/platform-feeds/src/schema.ts
+++ b/packages/platform-feeds/src/schema.ts
@@ -63,7 +63,7 @@ export default {
                             type: "array",
                             items: { type: "string" },
                         },
-                        id: { type: ["string", "null"] },
+                        id: { type: "string" },
                         type: { enum: ["post"] },
                         actor: { $ref: "#/definitions/responses/feedChannel" },
                         object: { $ref: "#/definitions/responses/feedItem" },

--- a/packages/platform-feeds/src/types.ts
+++ b/packages/platform-feeds/src/types.ts
@@ -3,7 +3,6 @@ import type {
     ActivityObject,
     ActivityStream,
 } from "@sockethub/schemas";
-import type { Author } from "podparse";
 
 export enum ASFeedType {
     FEED_CHANNEL = "feed",
@@ -21,10 +20,10 @@ export interface PlatformFeedsActivityActor extends ActivityActor {
     id: string;
     link: string;
     description: string;
-    image: unknown;
+    image: string | undefined;
     categories: Array<string>;
     language: string;
-    author: Author;
+    author: string | undefined;
 }
 
 export interface PlatformFeedsActivityStream extends ActivityStream {

--- a/packages/platform-feeds/test/fixtures/bare-channel-rss.xml
+++ b/packages/platform-feeds/test/fixtures/bare-channel-rss.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<rss version="2.0">
+  <channel>
+    <title>Bare Feed</title>
+    <link>https://example.com/feed</link>
+    <description>A feed with no channel-level image or author</description>
+    <item>
+      <title>First Post</title>
+      <description>Short body content</description>
+      <link>https://example.com/posts/1</link>
+      <guid isPermaLink="true">https://example.com/posts/1</guid>
+      <pubDate>Thu, 01 Jan 2024 00:00:00 GMT</pubDate>
+    </item>
+  </channel>
+</rss>

--- a/packages/platform-feeds/test/fixtures/channel-image-author-rss.xml
+++ b/packages/platform-feeds/test/fixtures/channel-image-author-rss.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<rss version="2.0">
+  <channel>
+    <title>Image Author Feed</title>
+    <link>https://example.com/feed</link>
+    <description>A feed with a channel-level image and author</description>
+    <author>editor@example.com (Jane Editor)</author>
+    <managingEditor>editor@example.com (Jane Editor)</managingEditor>
+    <image>
+      <url>https://example.com/logo.png</url>
+      <title>Image Author Feed</title>
+      <link>https://example.com/feed</link>
+    </image>
+    <item>
+      <title>First Post</title>
+      <description>Short body content</description>
+      <link>https://example.com/posts/1</link>
+      <guid isPermaLink="true">https://example.com/posts/1</guid>
+      <pubDate>Thu, 01 Jan 2024 00:00:00 GMT</pubDate>
+    </item>
+  </channel>
+</rss>


### PR DESCRIPTION
## Problem

The feeds platform emits messages that the server validates against the platform's strict outbound `responses` schema (`src/schema.ts`, `additionalProperties: false`) in `packages/server/src/platform-instance.ts` `sendToClient`. Three fields the platform actually constructs were rejected by that schema, so every collection failed validation:

1. **Per-post `id`** — `fetchFeed` sets `article.id = job.id` on every post, but the `post` definition (`definitions.responses.post`) had no `id` property.
2. **Channel `image`** — `buildFeedChannel` set `image: meta.image`, but podparse's image is an object `{ url, link, title }` while the schema declares `image` as a string.
3. **Channel `author`** — `buildFeedChannel` set `author: meta.author`, but the schema declares `author` as a string. Note: podparse's *typings* declare `meta.author` as an `Author` object, but its RSS mapping (`author: getText`) emits the raw `<author>` text as a **string** at runtime — so the naive `meta.author?.name` extraction would silently drop the author.

## Fix

- Add `id: { type: "string" }` to the `post` schema. The per-post `id` is a string when present and simply absent otherwise (never `null` — only the collection-level `id` is coerced with `|| null`, and its nullability lives on the collection schema).
- Emit `image: meta.image?.url || undefined` (keeps the schema's `image: { type: "string" }` strict).
- Emit `author` handling both shapes: the runtime string directly, or `.name` if podparse ever honors its declared object type.
- Update `PlatformFeedsActivityActor` so `image` and `author` are `string | undefined`, and drop the now-unused podparse `Author` import.

Absent `image`/`author` remain `undefined`-valued keys: AJV skips `undefined`-valued properties during validation, and the keys are dropped at the JSON/IPC boundary anyway — verified by test (see below).

## Test gap closed

The existing `index.test.ts` `buildCollection()` hand-builds conforming actors, so the **real** `buildFeedChannel` output (image/author) was never validated. This adds:

- `test/fixtures/channel-image-author-rss.xml` (channel-level `<image><url>…</url></image>` and `<author>`) plus a test that runs the **real** platform `fetch()` (mocking `makeRequest` to return the fixture) and asserts `actor.image`, `actor.author` (the raw `<author>` text), the per-post `id`, and `validateActivityStreamResponse(results) === ""`.
- `test/fixtures/bare-channel-rss.xml` (no channel image/author) plus a test asserting the collection still passes strict validation both in-memory and after a `JSON.parse(JSON.stringify(...))` round-trip.

## Verification

- `bun test` in `packages/platform-feeds` — 25 pass, 0 fail.
- `bun run lint` (repo root) — clean.
- `bun run build` in `packages/platform-feeds` — bundles cleanly.
- `tsc --noEmit` shows no new errors in `packages/platform-feeds/src`.
- Manually confirmed the fixture test fails if any of the three fixes is reverted (e.g. `actor.image` becomes an object, or `actor.author` goes back to `meta.author?.name` and becomes `undefined`).

## Follow-up / overlap

This overlaps with the dead-mapping-removal refactor on `refactor/feeds-remove-dead-mapping` (#1135) and the since/limit feature (#1134); all touch `src/index.ts`/`index.test.ts`. Suggest merging this PR first, then rebasing the others on top.
