### PR TITLE
fix(platform-feeds): harden makeRequest against HTTP errors, large bodies, and SSRF

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,7 +8,7 @@ services:
             # This compose file is the dev/CI harness; its feed fixtures are
             # served from loopback, which the feeds SSRF guard blocks by
             # default. Never set this in production.
-            - SOCKETHUB_FEEDS_ALLOW_PRIVATE_ADDRESSES=true
+            - SOCKETHUB_PLATFORM_FEEDS_ALLOW_PRIVATE_ADDRESSES=true
         ports:
             - "10550:10550"
         networks:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,8 +7,11 @@ services:
             - REDIS_URL=redis://redis:6379
             # This compose file is the dev/CI harness; its feed fixtures are
             # served from loopback, which the feeds SSRF guard blocks by
-            # default. Never set this in production.
-            - SOCKETHUB_PLATFORM_FEEDS_ALLOW_PRIVATE_ADDRESSES=true
+            # default. The mounted config enables the feeds escape hatch via
+            # packageConfig. Never enable it in production.
+            - SOCKETHUB_CONFIG=/app/sockethub.ci.config.json
+        volumes:
+            - ./integration/sockethub.ci.config.json:/app/sockethub.ci.config.json:ro
         ports:
             - "10550:10550"
         networks:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,6 +5,10 @@ services:
             target: prod
         environment:
             - REDIS_URL=redis://redis:6379
+            # This compose file is the dev/CI harness; its feed fixtures are
+            # served from loopback, which the feeds SSRF guard blocks by
+            # default. Never set this in production.
+            - SOCKETHUB_FEEDS_ALLOW_PRIVATE_ADDRESSES=true
         ports:
             - "10550:10550"
         networks:

--- a/integration/sockethub.ci.config.json
+++ b/integration/sockethub.ci.config.json
@@ -1,0 +1,8 @@
+{
+  "$schema": "../packages/schemas/src/schemas/json/sockethub-config.json",
+  "packageConfig": {
+    "@sockethub/platform-feeds": {
+      "allowPrivateAddresses": true
+    }
+  }
+}

--- a/packages/examples/scripts/smoke-server.mjs
+++ b/packages/examples/scripts/smoke-server.mjs
@@ -90,9 +90,13 @@ const sockethub = spawn(
             ...process.env,
             REDIS_URL: "redis://127.0.0.1:6379",
             PORT: "10550",
-            // The smoke test serves its feed fixture from loopback, which
-            // the feeds SSRF guard blocks by default. Dev/test only.
-            SOCKETHUB_PLATFORM_FEEDS_ALLOW_PRIVATE_ADDRESSES: "true",
+            // The smoke test serves its feed fixture from loopback, which the
+            // feeds SSRF guard blocks by default. This config enables the
+            // escape hatch via packageConfig. Dev/test only.
+            SOCKETHUB_CONFIG: path.join(
+                root,
+                "integration/sockethub.ci.config.json",
+            ),
         },
     },
 );

--- a/packages/examples/scripts/smoke-server.mjs
+++ b/packages/examples/scripts/smoke-server.mjs
@@ -92,7 +92,7 @@ const sockethub = spawn(
             PORT: "10550",
             // The smoke test serves its feed fixture from loopback, which
             // the feeds SSRF guard blocks by default. Dev/test only.
-            SOCKETHUB_FEEDS_ALLOW_PRIVATE_ADDRESSES: "true",
+            SOCKETHUB_PLATFORM_FEEDS_ALLOW_PRIVATE_ADDRESSES: "true",
         },
     },
 );

--- a/packages/examples/scripts/smoke-server.mjs
+++ b/packages/examples/scripts/smoke-server.mjs
@@ -90,6 +90,9 @@ const sockethub = spawn(
             ...process.env,
             REDIS_URL: "redis://127.0.0.1:6379",
             PORT: "10550",
+            // The smoke test serves its feed fixture from loopback, which
+            // the feeds SSRF guard blocks by default. Dev/test only.
+            SOCKETHUB_FEEDS_ALLOW_PRIVATE_ADDRESSES: "true",
         },
     },
 );

--- a/packages/platform-feeds/README.md
+++ b/packages/platform-feeds/README.md
@@ -150,6 +150,38 @@ Returns an ActivityStreams Collection with feed entries:
 }
 ```
 
+## Request Hardening (SSRF Guard)
+
+Because the server fetches whatever URL a client supplies as `actor.id`, feed
+requests are hardened against server-side request forgery (SSRF) and resource
+exhaustion:
+
+* Only `http:` and `https:` URLs are accepted.
+* The destination hostname is resolved and the request is rejected if any
+  resolved address (or an IP literal in the URL) is loopback, private,
+  link-local, carrier-grade NAT, or otherwise non-public. IPv4-mapped,
+  IPv4-compatible, and NAT64 IPv6 spellings of those ranges are normalized
+  and blocked as well.
+* Redirects are followed manually with a bounded hop count, and every hop is
+  re-validated before being fetched.
+* Response bodies are capped at 5 MiB, enforced while streaming (a missing or
+  lying `Content-Length` does not bypass the cap).
+* Non-2xx responses fail the job with a descriptive error.
+
+### `SOCKETHUB_FEEDS_ALLOW_PRIVATE_ADDRESSES`
+
+Setting the environment variable `SOCKETHUB_FEEDS_ALLOW_PRIVATE_ADDRESSES=true`
+disables **only** the private/loopback destination checks. Scheme validation,
+the redirect limit, and the response size cap always remain in effect.
+
+This is an escape hatch for development and test harnesses that serve feed
+fixtures from `localhost`, or for self-hosted deployments that intentionally
+fetch intranet feeds. **Do not enable it on a server that accepts requests
+from untrusted clients** — it allows any client to make the server issue HTTP
+requests to internal services, including cloud metadata endpoints such as
+`169.254.169.254`. The flag defaults to off; the full guard is active unless
+it is explicitly set to the string `true`.
+
 ## Supported Feed Formats
 
 * **RSS 2.0**: Standard RSS feeds

--- a/packages/platform-feeds/README.md
+++ b/packages/platform-feeds/README.md
@@ -168,11 +168,12 @@ exhaustion:
   lying `Content-Length` does not bypass the cap).
 * Non-2xx responses fail the job with a descriptive error.
 
-### `SOCKETHUB_FEEDS_ALLOW_PRIVATE_ADDRESSES`
+### `SOCKETHUB_PLATFORM_FEEDS_ALLOW_PRIVATE_ADDRESSES`
 
-Setting the environment variable `SOCKETHUB_FEEDS_ALLOW_PRIVATE_ADDRESSES=true`
-disables **only** the private/loopback destination checks. Scheme validation,
-the redirect limit, and the response size cap always remain in effect.
+Setting the environment variable
+`SOCKETHUB_PLATFORM_FEEDS_ALLOW_PRIVATE_ADDRESSES=true` disables **only** the
+private/loopback destination checks. Scheme validation, the redirect limit, and
+the response size cap always remain in effect.
 
 This is an escape hatch for development and test harnesses that serve feed
 fixtures from `localhost`, or for self-hosted deployments that intentionally

--- a/packages/platform-feeds/README.md
+++ b/packages/platform-feeds/README.md
@@ -168,20 +168,31 @@ exhaustion:
   lying `Content-Length` does not bypass the cap).
 * Non-2xx responses fail the job with a descriptive error.
 
-### `SOCKETHUB_PLATFORM_FEEDS_ALLOW_PRIVATE_ADDRESSES`
+### `allowPrivateAddresses`
 
-Setting the environment variable
-`SOCKETHUB_PLATFORM_FEEDS_ALLOW_PRIVATE_ADDRESSES=true` disables **only** the
-private/loopback destination checks. Scheme validation, the redirect limit, and
-the response size cap always remain in effect.
+Set in the Sockethub config file under this platform's `packageConfig` entry:
+
+```json
+{
+  "packageConfig": {
+    "@sockethub/platform-feeds": {
+      "allowPrivateAddresses": true
+    }
+  }
+}
+```
+
+This disables **only** the private/loopback destination checks. Scheme
+validation, the redirect limit, and the response size cap always remain in
+effect.
 
 This is an escape hatch for development and test harnesses that serve feed
 fixtures from `localhost`, or for self-hosted deployments that intentionally
 fetch intranet feeds. **Do not enable it on a server that accepts requests
 from untrusted clients** — it allows any client to make the server issue HTTP
 requests to internal services, including cloud metadata endpoints such as
-`169.254.169.254`. The flag defaults to off; the full guard is active unless
-it is explicitly set to the string `true`.
+`169.254.169.254`. It defaults to off; the full guard is active unless
+`allowPrivateAddresses` is explicitly `true`.
 
 ## Supported Feed Formats
 

--- a/packages/platform-feeds/src/index.test.ts
+++ b/packages/platform-feeds/src/index.test.ts
@@ -14,9 +14,11 @@ import feedsSchema from "./schema";
 import { RSSFeed } from "./index.test.data";
 import Feeds, {
     applyFetchFilters,
+    assertUrlAllowed,
     buildFeedItem,
     extractFetchParams,
     type FeedFetchParams,
+    isBlockedAddress,
 } from "./index";
 
 addPlatformSchema(feedsSchema.messages, "feeds/messages");
@@ -618,5 +620,82 @@ describe("applyFetchFilters", () => {
             since: "1970-01-01T00:00:00.000Z",
         });
         expect(result.map((a) => a.object?.datenum)).toEqual([300, 200, 100]);
+    });
+});
+
+describe("assertUrlAllowed (SSRF guard)", () => {
+    it("rejects ftp: scheme", async () => {
+        await expect(
+            assertUrlAllowed("ftp://example.com/feed"),
+        ).rejects.toThrow(/unsupported scheme/);
+    });
+
+    it("rejects file: scheme", async () => {
+        await expect(
+            assertUrlAllowed("file:///etc/passwd"),
+        ).rejects.toThrow(/unsupported scheme/);
+    });
+
+    it("rejects a malformed URL", async () => {
+        await expect(assertUrlAllowed("not a url")).rejects.toThrow(
+            /invalid URL/,
+        );
+    });
+
+    it("rejects an http URL pointing directly at a loopback IP", async () => {
+        await expect(
+            assertUrlAllowed("http://127.0.0.1/feed"),
+        ).rejects.toThrow(/not a public address/);
+    });
+
+    it("rejects the cloud metadata address", async () => {
+        await expect(
+            assertUrlAllowed("http://169.254.169.254/latest/meta-data/"),
+        ).rejects.toThrow(/not a public address/);
+    });
+});
+
+describe("isBlockedAddress", () => {
+    it("blocks IPv4 loopback (127.0.0.0/8)", () => {
+        expect(isBlockedAddress("127.0.0.1")).toBe(true);
+        expect(isBlockedAddress("127.255.255.254")).toBe(true);
+    });
+
+    it("blocks private IPv4 ranges", () => {
+        expect(isBlockedAddress("10.0.0.1")).toBe(true);
+        expect(isBlockedAddress("172.16.5.4")).toBe(true);
+        expect(isBlockedAddress("172.31.255.255")).toBe(true);
+        expect(isBlockedAddress("192.168.1.1")).toBe(true);
+    });
+
+    it("blocks link-local and metadata addresses", () => {
+        expect(isBlockedAddress("169.254.1.1")).toBe(true);
+        expect(isBlockedAddress("169.254.169.254")).toBe(true);
+    });
+
+    it("blocks 0.0.0.0", () => {
+        expect(isBlockedAddress("0.0.0.0")).toBe(true);
+    });
+
+    it("blocks IPv6 loopback and unique/link-local", () => {
+        expect(isBlockedAddress("::1")).toBe(true);
+        expect(isBlockedAddress("fc00::1")).toBe(true);
+        expect(isBlockedAddress("fd12:3456::1")).toBe(true);
+        expect(isBlockedAddress("fe80::1")).toBe(true);
+    });
+
+    it("blocks IPv4-mapped IPv6 private addresses", () => {
+        expect(isBlockedAddress("::ffff:127.0.0.1")).toBe(true);
+        expect(isBlockedAddress("::ffff:169.254.169.254")).toBe(true);
+    });
+
+    it("does not block representative public addresses", () => {
+        expect(isBlockedAddress("8.8.8.8")).toBe(false);
+        expect(isBlockedAddress("1.1.1.1")).toBe(false);
+        expect(isBlockedAddress("2606:4700:4700::1111")).toBe(false);
+    });
+
+    it("does not block IPv4-mapped public addresses", () => {
+        expect(isBlockedAddress("::ffff:8.8.8.8")).toBe(false);
     });
 });

--- a/packages/platform-feeds/src/index.test.ts
+++ b/packages/platform-feeds/src/index.test.ts
@@ -653,6 +653,64 @@ describe("assertUrlAllowed (SSRF guard)", () => {
             assertUrlAllowed("http://169.254.169.254/latest/meta-data/"),
         ).rejects.toThrow(/not a public address/);
     });
+
+    it("rejects a hex-form IPv4-mapped IPv6 loopback literal", async () => {
+        await expect(
+            assertUrlAllowed("http://[::ffff:7f00:1]/feed"),
+        ).rejects.toThrow(/not a public address/);
+    });
+
+    it("routes non-IP hostnames to DNS resolution instead of blocking them as literals", async () => {
+        // A guaranteed-unresolvable name (RFC 2606 .invalid) must fail with
+        // the "could not resolve" error, proving it passed the IP-literal
+        // check rather than being conservatively blocked as a non-IPv4
+        // string ("not a public address").
+        await expect(
+            assertUrlAllowed("http://feeds.sockethub-test.invalid/feed.xml"),
+        ).rejects.toThrow(/could not resolve/);
+    });
+
+    describe("allowPrivateAddresses escape hatch", () => {
+        it("allows a loopback IP literal when enabled", async () => {
+            await expect(
+                assertUrlAllowed("http://127.0.0.1:10550/feed.xml", {
+                    allowPrivateAddresses: true,
+                }),
+            ).resolves.toBeUndefined();
+        });
+
+        it("allows a localhost hostname when enabled", async () => {
+            await expect(
+                assertUrlAllowed("http://localhost:10550/feed.xml", {
+                    allowPrivateAddresses: true,
+                }),
+            ).resolves.toBeUndefined();
+        });
+
+        it("still rejects unsupported schemes when enabled", async () => {
+            await expect(
+                assertUrlAllowed("file:///etc/passwd", {
+                    allowPrivateAddresses: true,
+                }),
+            ).rejects.toThrow(/unsupported scheme/);
+        });
+
+        it("still rejects malformed URLs when enabled", async () => {
+            await expect(
+                assertUrlAllowed("not a url", {
+                    allowPrivateAddresses: true,
+                }),
+            ).rejects.toThrow(/invalid URL/);
+        });
+
+        it("still blocks loopback when explicitly disabled", async () => {
+            await expect(
+                assertUrlAllowed("http://127.0.0.1:10550/feed.xml", {
+                    allowPrivateAddresses: false,
+                }),
+            ).rejects.toThrow(/not a public address/);
+        });
+    });
 });
 
 describe("isBlockedAddress", () => {
@@ -697,5 +755,59 @@ describe("isBlockedAddress", () => {
 
     it("does not block IPv4-mapped public addresses", () => {
         expect(isBlockedAddress("::ffff:8.8.8.8")).toBe(false);
+    });
+
+    it("blocks hex-form IPv4-mapped IPv6 loopback (::ffff:7f00:1)", () => {
+        expect(isBlockedAddress("::ffff:7f00:1")).toBe(true);
+    });
+
+    it("blocks non-compressed IPv4-mapped IPv6 loopback", () => {
+        expect(isBlockedAddress("0:0:0:0:0:ffff:7f00:1")).toBe(true);
+        expect(isBlockedAddress("0:0:0:0:0:ffff:127.0.0.1")).toBe(true);
+    });
+
+    it("blocks uppercase hex-form IPv4-mapped IPv6 loopback", () => {
+        expect(isBlockedAddress("::FFFF:7F00:1")).toBe(true);
+    });
+
+    it("blocks hex-form IPv4-mapped link-local/metadata (::ffff:a9fe:a9fe)", () => {
+        expect(isBlockedAddress("::ffff:a9fe:a9fe")).toBe(true);
+    });
+
+    it("does not block hex-form IPv4-mapped public addresses (::ffff:808:808)", () => {
+        expect(isBlockedAddress("::ffff:808:808")).toBe(false);
+    });
+
+    it("blocks IPv4-compatible IPv6 spellings of blocked ranges", () => {
+        expect(isBlockedAddress("::7f00:1")).toBe(true);
+        expect(isBlockedAddress("::127.0.0.1")).toBe(true);
+    });
+
+    it("blocks NAT64 (64:ff9b::/96) spellings of blocked ranges", () => {
+        expect(isBlockedAddress("64:ff9b::7f00:1")).toBe(true);
+        expect(isBlockedAddress("64:ff9b::127.0.0.1")).toBe(true);
+        expect(isBlockedAddress("64:ff9b::a9fe:a9fe")).toBe(true);
+    });
+
+    it("does not block NAT64 spellings of public addresses", () => {
+        expect(isBlockedAddress("64:ff9b::808:808")).toBe(false);
+    });
+
+    it("blocks carrier-grade NAT (100.64.0.0/10)", () => {
+        expect(isBlockedAddress("100.64.0.1")).toBe(true);
+        expect(isBlockedAddress("100.127.255.254")).toBe(true);
+        expect(isBlockedAddress("100.63.255.254")).toBe(false);
+        expect(isBlockedAddress("100.128.0.1")).toBe(false);
+    });
+
+    it("blocks unparseable address strings conservatively", () => {
+        expect(isBlockedAddress("not-an-ip")).toBe(true);
+        expect(isBlockedAddress(":::1")).toBe(true);
+        expect(isBlockedAddress("1:2:3:4:5:6:7:8:9")).toBe(true);
+        expect(isBlockedAddress("::ffff:999.0.0.1")).toBe(true);
+    });
+
+    it("strips zone indexes before classification", () => {
+        expect(isBlockedAddress("fe80::1%eth0")).toBe(true);
     });
 });

--- a/packages/platform-feeds/src/index.test.ts
+++ b/packages/platform-feeds/src/index.test.ts
@@ -1,6 +1,6 @@
 import { readFileSync } from "node:fs";
 import path from "node:path";
-import { beforeEach, describe, expect, it, test } from "bun:test";
+import { beforeEach, describe, expect, it, mock, test } from "bun:test";
 import type { ASCollection, PlatformSession } from "@sockethub/schemas";
 import type { ActivityStream } from "@sockethub/schemas";
 import {
@@ -661,13 +661,23 @@ describe("assertUrlAllowed (SSRF guard)", () => {
     });
 
     it("routes non-IP hostnames to DNS resolution instead of blocking them as literals", async () => {
-        // A guaranteed-unresolvable name (RFC 2606 .invalid) must fail with
-        // the "could not resolve" error, proving it passed the IP-literal
-        // check rather than being conservatively blocked as a non-IPv4
-        // string ("not a public address").
-        await expect(
-            assertUrlAllowed("http://feeds.sockethub-test.invalid/feed.xml"),
-        ).rejects.toThrow(/could not resolve/);
+        // Mock node:dns/promises so the test is deterministic and never makes a
+        // real DNS query. A rejected lookup must surface as the "could not
+        // resolve" error, proving the hostname passed the IP-literal check and
+        // reached the DNS path rather than being conservatively blocked as a
+        // non-IPv4 string ("not a public address").
+        const realDns = await import("node:dns/promises");
+        mock.module("node:dns/promises", () => ({
+            ...realDns,
+            lookup: () => Promise.reject(new Error("mocked unresolvable host")),
+        }));
+        try {
+            await expect(
+                assertUrlAllowed("http://feeds.example.test/feed.xml"),
+            ).rejects.toThrow(/could not resolve/);
+        } finally {
+            mock.module("node:dns/promises", () => realDns);
+        }
     });
 
     describe("allowPrivateAddresses escape hatch", () => {

--- a/packages/platform-feeds/src/index.ts
+++ b/packages/platform-feeds/src/index.ts
@@ -17,6 +17,7 @@
  */
 
 import { lookup } from "node:dns/promises";
+import { isIP } from "node:net";
 import type {
     ActivityStream,
     Logger,
@@ -82,12 +83,6 @@ function isRedirect(status: number): boolean {
 export function isBlockedAddress(ip: string): boolean {
     const addr = ip.trim().toLowerCase();
 
-    // IPv4-mapped IPv6 (e.g. ::ffff:169.254.169.254) -> apply IPv4 rules.
-    const mapped = addr.match(/^::ffff:(\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3})$/);
-    if (mapped) {
-        return isBlockedIpv4(mapped[1]);
-    }
-
     if (addr.includes(":")) {
         return isBlockedIpv6(addr);
     }
@@ -117,27 +112,146 @@ function isBlockedIpv4(ip: string): boolean {
     if (a === 192 && b === 168) return true;
     // 169.254.0.0/16 link-local (incl. 169.254.169.254 cloud metadata)
     if (a === 169 && b === 254) return true;
+    // 100.64.0.0/10 carrier-grade NAT shared address space
+    if (a === 100 && b >= 64 && b <= 127) return true;
     return false;
+}
+
+/**
+ * Expand an IPv6 literal (lowercased, zone index already stripped) to its
+ * eight 16-bit groups, or null if unparseable. A trailing dotted-quad
+ * (e.g. ::ffff:127.0.0.1) is converted to two hex groups first, so every
+ * notation of the same address normalizes identically.
+ */
+function expandIpv6(address: string): Array<number> | null {
+    let addr = address;
+    const dotted = addr.match(/^(.+:)(\d{1,3}(?:\.\d{1,3}){3})$/);
+    if (dotted) {
+        const octets = dotted[2].split(".").map(Number);
+        if (octets.some((o) => !Number.isInteger(o) || o < 0 || o > 255)) {
+            return null;
+        }
+        const hi = ((octets[0] << 8) | octets[1]).toString(16);
+        const lo = ((octets[2] << 8) | octets[3]).toString(16);
+        addr = `${dotted[1]}${hi}:${lo}`;
+    }
+
+    const halves = addr.split("::");
+    if (halves.length > 2) return null;
+    const head = halves[0] ? halves[0].split(":") : [];
+    const tail = halves.length === 2 && halves[1] ? halves[1].split(":") : [];
+    if (halves.length === 2 ? head.length + tail.length > 8 : head.length !== 8)
+        return null;
+    const groupsStr =
+        halves.length === 2
+            ? [
+                  ...head,
+                  ...new Array(8 - head.length - tail.length).fill("0"),
+                  ...tail,
+              ]
+            : head;
+
+    const groups: Array<number> = [];
+    for (const group of groupsStr) {
+        if (!/^[0-9a-f]{1,4}$/.test(group)) return null;
+        groups.push(Number.parseInt(group, 16));
+    }
+    return groups;
+}
+
+/**
+ * If the expanded IPv6 groups embed an IPv4 address — IPv4-mapped
+ * (::ffff:0:0/96), deprecated IPv4-compatible (::/96, which also covers
+ * `::`/`::1`), or the NAT64 well-known prefix (64:ff9b::/96) — return it in
+ * dotted-quad form so IPv4 rules apply; otherwise return null.
+ */
+function extractEmbeddedIpv4(groups: Array<number>): string | null {
+    const [a, b, c, d, e, f, g, h] = groups;
+    const zeroPrefix = a === 0 && b === 0 && c === 0 && d === 0 && e === 0;
+    const mapped = zeroPrefix && f === 0xffff;
+    const compat = zeroPrefix && f === 0;
+    const nat64 =
+        a === 0x64 && b === 0xff9b && c === 0 && d === 0 && e === 0 && f === 0;
+    if (!mapped && !compat && !nat64) return null;
+    return `${g >> 8}.${g & 0xff}.${h >> 8}.${h & 0xff}`;
 }
 
 function isBlockedIpv6(ip: string): boolean {
     // Strip zone index (e.g. fe80::1%eth0).
     const addr = ip.split("%")[0];
-    // ::1 loopback (and :: unspecified).
-    if (addr === "::1" || addr === "::") return true;
-    // fc00::/7 unique-local (fc.. or fd..).
-    if (/^f[cd][0-9a-f]{0,2}:/.test(addr)) return true;
-    // fe80::/10 link-local (fe8, fe9, fea, feb).
-    if (/^fe[89ab][0-9a-f]?:/.test(addr)) return true;
+    // Normalize to 8 groups so hex/dotted/compressed/uppercase spellings of
+    // the same address are classified identically (e.g. ::ffff:7f00:1 and
+    // ::ffff:127.0.0.1 are both IPv4-mapped loopback).
+    const groups = expandIpv6(addr);
+    if (!groups) {
+        // Not a parseable IPv6 literal; block conservatively.
+        return true;
+    }
+    // Embedded IPv4 (mapped/compat/NAT64) -> apply IPv4 rules. This also
+    // covers :: (0.0.0.0) and ::1 (0.0.0.1), both within blocked 0.0.0.0/8.
+    const embedded = extractEmbeddedIpv4(groups);
+    if (embedded) {
+        return isBlockedIpv4(embedded);
+    }
+    // fc00::/7 unique-local.
+    if ((groups[0] & 0xfe00) === 0xfc00) return true;
+    // fe80::/10 link-local.
+    if ((groups[0] & 0xffc0) === 0xfe80) return true;
     return false;
+}
+
+/**
+ * Options for {@link assertUrlAllowed}.
+ */
+export interface AssertUrlAllowedOptions {
+    /**
+     * When true, skip the private/loopback destination checks (scheme and URL
+     * validation still apply). Dev/test escape hatch only; see README.
+     */
+    allowPrivateAddresses?: boolean;
+    /** Abort signal bounding the DNS lookup (shared with the fetch budget). */
+    signal?: AbortSignal;
+}
+
+/**
+ * Resolve `hostname` to all of its addresses, bounded by `signal` so a slow
+ * or unresponsive DNS server cannot stall a job past its abort budget.
+ */
+async function lookupAll(
+    hostname: string,
+    signal?: AbortSignal,
+): Promise<Array<{ address: string }>> {
+    const pending = lookup(hostname, { all: true });
+    if (!signal) {
+        return pending;
+    }
+    signal.throwIfAborted();
+    return await new Promise((resolve, reject) => {
+        const onAbort = () => reject(signal.reason);
+        signal.addEventListener("abort", onAbort, { once: true });
+        pending.then(resolve, reject).finally(() => {
+            signal.removeEventListener("abort", onAbort);
+        });
+    });
 }
 
 /**
  * Validates that `url` is an http(s) URL whose hostname resolves only to
  * public addresses. Throws a clear Error otherwise. Used before every fetch
  * (including each redirect hop) to defend against SSRF.
+ *
+ * Note: this is a check-then-fetch guard. The subsequent fetch performs its
+ * own DNS resolution, so a rebinding DNS server could in principle answer the
+ * guard with a public address and the fetch with a private one (TOCTOU).
+ * Closing that residual gap requires pinning the validated address at
+ * connection time (e.g. a custom undici dispatcher with a validating
+ * `connect.lookup`); tracked as a follow-up. The platform also runs in an
+ * isolated child process, limiting blast radius.
  */
-export async function assertUrlAllowed(url: string): Promise<void> {
+export async function assertUrlAllowed(
+    url: string,
+    options: AssertUrlAllowedOptions = {},
+): Promise<void> {
     let parsed: URL;
     try {
         parsed = new URL(url);
@@ -151,19 +265,28 @@ export async function assertUrlAllowed(url: string): Promise<void> {
         );
     }
 
+    if (options.allowPrivateAddresses) {
+        // Explicitly configured escape hatch (dev/test harnesses): skip only
+        // the private/loopback destination checks below.
+        return;
+    }
+
     const hostname = parsed.hostname.replace(/^\[|\]$/g, "");
 
-    // If the host is already an IP literal, check it directly.
-    if (isBlockedAddress(hostname)) {
-        throw new Error(
-            `feed request blocked: destination ${hostname} is not a public address (${url})`,
-        );
+    if (isIP(hostname) !== 0) {
+        // The host is an IP literal; check it directly.
+        if (isBlockedAddress(hostname)) {
+            throw new Error(
+                `feed request blocked: destination ${hostname} is not a public address (${url})`,
+            );
+        }
+        return;
     }
 
     // Otherwise resolve all records and reject if ANY is private/loopback.
     let addresses: Array<{ address: string }>;
     try {
-        addresses = await lookup(hostname, { all: true });
+        addresses = await lookupAll(hostname, options.signal);
     } catch (err) {
         const detail = err instanceof Error ? err.message : String(err);
         throw new Error(
@@ -324,11 +447,18 @@ export default class Feeds implements PlatformInterface {
         if (this.config.connectTimeoutMs) {
             signal = AbortSignal.timeout(this.config.connectTimeoutMs);
         }
+        // Dev/test escape hatch: allow loopback/private feed destinations.
+        // Never enable in production; see the package README.
+        const allowPrivateAddresses =
+            process.env.SOCKETHUB_FEEDS_ALLOW_PRIVATE_ADDRESSES === "true";
 
         for (let hop = 0; ; hop++) {
             // Validate scheme + resolve DNS and block private destinations
             // before every fetch, including each redirect hop.
-            await assertUrlAllowed(currentUrl);
+            await assertUrlAllowed(currentUrl, {
+                allowPrivateAddresses,
+                signal,
+            });
 
             const opts: RequestInit = { redirect: "manual" };
             if (signal) {
@@ -337,6 +467,9 @@ export default class Feeds implements PlatformInterface {
             const res = await fetch(currentUrl, opts);
 
             if (isRedirect(res.status)) {
+                // Drain the unused body so the keep-alive connection is
+                // returned to the pool instead of leaking until GC.
+                await res.body?.cancel().catch(() => {});
                 if (hop >= MAX_REDIRECTS) {
                     throw new Error(
                         `feed request failed: too many redirects for ${url}`,
@@ -349,13 +482,22 @@ export default class Feeds implements PlatformInterface {
                     );
                 }
                 // Resolve relative redirects against the current URL.
-                currentUrl = new URL(location, currentUrl).toString();
+                try {
+                    currentUrl = new URL(location, currentUrl).toString();
+                } catch {
+                    throw new Error(
+                        `feed request failed: invalid redirect Location "${location}" for ${currentUrl}`,
+                    );
+                }
                 continue;
             }
 
             if (!res.ok) {
+                await res.body?.cancel().catch(() => {});
+                // HTTP/2 has no reason phrases, so statusText may be empty.
+                const statusText = res.statusText ? ` ${res.statusText}` : "";
                 throw new Error(
-                    `feed request failed: ${res.status} ${res.statusText} for ${url}`,
+                    `feed request failed: ${res.status}${statusText} for ${url}`,
                 );
             }
 

--- a/packages/platform-feeds/src/index.ts
+++ b/packages/platform-feeds/src/index.ts
@@ -312,6 +312,8 @@ async function readCappedBody(res: Response, url: string): Promise<string> {
     if (contentLength) {
         const declared = Number(contentLength);
         if (Number.isFinite(declared) && declared > MAX_RESPONSE_BYTES) {
+            // Drain the body so the connection can be reused rather than leaked.
+            await res.body?.cancel().catch(() => {});
             throw new Error(
                 `feed request failed: response too large (${declared} bytes) for ${url}`,
             );
@@ -450,7 +452,8 @@ export default class Feeds implements PlatformInterface {
         // Dev/test escape hatch: allow loopback/private feed destinations.
         // Never enable in production; see the package README.
         const allowPrivateAddresses =
-            process.env.SOCKETHUB_FEEDS_ALLOW_PRIVATE_ADDRESSES === "true";
+            process.env.SOCKETHUB_PLATFORM_FEEDS_ALLOW_PRIVATE_ADDRESSES ===
+            "true";
 
         for (let hop = 0; ; hop++) {
             // Validate scheme + resolve DNS and block private destinations

--- a/packages/platform-feeds/src/index.ts
+++ b/packages/platform-feeds/src/index.ts
@@ -16,6 +16,7 @@
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
  */
 
+import { lookup } from "node:dns/promises";
 import type {
     ActivityStream,
     Logger,
@@ -41,6 +42,15 @@ import {
 const MAX_NOTE_LENGTH = 256;
 const FEEDS_CONTEXT = buildCanonicalContext(PlatformSchema.contextUrl);
 
+// Cap the amount of data read from a single feed response. AbortSignal.timeout
+// bounds how long a request may take; this bounds how many bytes it may return,
+// guarding against unbounded (or lying-Content-Length) bodies exhausting memory.
+const MAX_RESPONSE_BYTES = 5 * 1024 * 1024;
+
+// Bound how many redirects we follow. Each hop is re-validated (scheme + DNS)
+// to prevent redirect-based DNS rebinding past the SSRF guard.
+const MAX_REDIRECTS = 5;
+
 const basic = /\s?<!doctype html>|(<html\b[^>]*>|<body\b[^>]*>|<x-[^>]+>)+/i;
 const full = new RegExp(
     htmlTags.map((tag) => `<${tag}\\b[^>]*>`).join("|"),
@@ -51,6 +61,173 @@ function isHtml(s: string): boolean {
     // limit it to a reasonable length to improve performance.
     const limitedString = s.trim().slice(0, 1000);
     return basic.test(limitedString) || full.test(s);
+}
+
+function isRedirect(status: number): boolean {
+    return (
+        status === 301 ||
+        status === 302 ||
+        status === 303 ||
+        status === 307 ||
+        status === 308
+    );
+}
+
+/**
+ * Returns true if `ip` is a loopback, private, link-local, or otherwise
+ * non-public address that should not be reachable by a server fetching
+ * client-supplied URLs (SSRF defense). Handles IPv4, IPv6, and IPv4-mapped
+ * IPv6 addresses.
+ */
+export function isBlockedAddress(ip: string): boolean {
+    const addr = ip.trim().toLowerCase();
+
+    // IPv4-mapped IPv6 (e.g. ::ffff:169.254.169.254) -> apply IPv4 rules.
+    const mapped = addr.match(/^::ffff:(\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3})$/);
+    if (mapped) {
+        return isBlockedIpv4(mapped[1]);
+    }
+
+    if (addr.includes(":")) {
+        return isBlockedIpv6(addr);
+    }
+
+    return isBlockedIpv4(addr);
+}
+
+function isBlockedIpv4(ip: string): boolean {
+    const parts = ip.split(".").map((p) => Number(p));
+    if (
+        parts.length !== 4 ||
+        parts.some((p) => !Number.isInteger(p) || p < 0 || p > 255)
+    ) {
+        // Not a parseable IPv4 literal; block conservatively.
+        return true;
+    }
+    const [a, b] = parts;
+    // 0.0.0.0/8 ("this network", commonly routes to localhost)
+    if (a === 0) return true;
+    // 127.0.0.0/8 loopback
+    if (a === 127) return true;
+    // 10.0.0.0/8 private
+    if (a === 10) return true;
+    // 172.16.0.0/12 private
+    if (a === 172 && b >= 16 && b <= 31) return true;
+    // 192.168.0.0/16 private
+    if (a === 192 && b === 168) return true;
+    // 169.254.0.0/16 link-local (incl. 169.254.169.254 cloud metadata)
+    if (a === 169 && b === 254) return true;
+    return false;
+}
+
+function isBlockedIpv6(ip: string): boolean {
+    // Strip zone index (e.g. fe80::1%eth0).
+    const addr = ip.split("%")[0];
+    // ::1 loopback (and :: unspecified).
+    if (addr === "::1" || addr === "::") return true;
+    // fc00::/7 unique-local (fc.. or fd..).
+    if (/^f[cd][0-9a-f]{0,2}:/.test(addr)) return true;
+    // fe80::/10 link-local (fe8, fe9, fea, feb).
+    if (/^fe[89ab][0-9a-f]?:/.test(addr)) return true;
+    return false;
+}
+
+/**
+ * Validates that `url` is an http(s) URL whose hostname resolves only to
+ * public addresses. Throws a clear Error otherwise. Used before every fetch
+ * (including each redirect hop) to defend against SSRF.
+ */
+export async function assertUrlAllowed(url: string): Promise<void> {
+    let parsed: URL;
+    try {
+        parsed = new URL(url);
+    } catch {
+        throw new Error(`feed request blocked: invalid URL ${url}`);
+    }
+
+    if (parsed.protocol !== "http:" && parsed.protocol !== "https:") {
+        throw new Error(
+            `feed request blocked: unsupported scheme ${parsed.protocol} for ${url}`,
+        );
+    }
+
+    const hostname = parsed.hostname.replace(/^\[|\]$/g, "");
+
+    // If the host is already an IP literal, check it directly.
+    if (isBlockedAddress(hostname)) {
+        throw new Error(
+            `feed request blocked: destination ${hostname} is not a public address (${url})`,
+        );
+    }
+
+    // Otherwise resolve all records and reject if ANY is private/loopback.
+    let addresses: Array<{ address: string }>;
+    try {
+        addresses = await lookup(hostname, { all: true });
+    } catch (err) {
+        const detail = err instanceof Error ? err.message : String(err);
+        throw new Error(
+            `feed request blocked: could not resolve ${hostname} (${detail})`,
+        );
+    }
+    for (const { address } of addresses) {
+        if (isBlockedAddress(address)) {
+            throw new Error(
+                `feed request blocked: ${hostname} resolves to non-public address ${address} (${url})`,
+            );
+        }
+    }
+}
+
+/**
+ * Reads a response body, enforcing MAX_RESPONSE_BYTES. Rejects up front on an
+ * oversized Content-Length and defensively while streaming (in case the header
+ * is missing or lies). Returns the decoded body as a string.
+ */
+async function readCappedBody(res: Response, url: string): Promise<string> {
+    const contentLength = res.headers.get("content-length");
+    if (contentLength) {
+        const declared = Number(contentLength);
+        if (Number.isFinite(declared) && declared > MAX_RESPONSE_BYTES) {
+            throw new Error(
+                `feed request failed: response too large (${declared} bytes) for ${url}`,
+            );
+        }
+    }
+
+    if (!res.body) {
+        return await res.text();
+    }
+
+    const reader = res.body.getReader();
+    const chunks: Array<Uint8Array> = [];
+    let total = 0;
+    try {
+        while (true) {
+            const { done, value } = await reader.read();
+            if (done) break;
+            if (value) {
+                total += value.byteLength;
+                if (total > MAX_RESPONSE_BYTES) {
+                    await reader.cancel();
+                    throw new Error(
+                        `feed request failed: response exceeded ${MAX_RESPONSE_BYTES} bytes for ${url}`,
+                    );
+                }
+                chunks.push(value);
+            }
+        }
+    } finally {
+        reader.releaseLock();
+    }
+
+    const combined = new Uint8Array(total);
+    let offset = 0;
+    for (const chunk of chunks) {
+        combined.set(chunk, offset);
+        offset += chunk.byteLength;
+    }
+    return new TextDecoder().decode(combined);
 }
 
 /**
@@ -142,12 +319,48 @@ export default class Feeds implements PlatformInterface {
     }
 
     private async makeRequest(url: string): Promise<string> {
-        const opts: RequestInit = {};
+        let currentUrl = url;
+        let signal: AbortSignal | undefined;
         if (this.config.connectTimeoutMs) {
-            opts.signal = AbortSignal.timeout(this.config.connectTimeoutMs);
+            signal = AbortSignal.timeout(this.config.connectTimeoutMs);
         }
-        const res = await fetch(url, opts);
-        return await res.text();
+
+        for (let hop = 0; ; hop++) {
+            // Validate scheme + resolve DNS and block private destinations
+            // before every fetch, including each redirect hop.
+            await assertUrlAllowed(currentUrl);
+
+            const opts: RequestInit = { redirect: "manual" };
+            if (signal) {
+                opts.signal = signal;
+            }
+            const res = await fetch(currentUrl, opts);
+
+            if (isRedirect(res.status)) {
+                if (hop >= MAX_REDIRECTS) {
+                    throw new Error(
+                        `feed request failed: too many redirects for ${url}`,
+                    );
+                }
+                const location = res.headers.get("location");
+                if (!location) {
+                    throw new Error(
+                        `feed request failed: ${res.status} redirect without Location for ${currentUrl}`,
+                    );
+                }
+                // Resolve relative redirects against the current URL.
+                currentUrl = new URL(location, currentUrl).toString();
+                continue;
+            }
+
+            if (!res.ok) {
+                throw new Error(
+                    `feed request failed: ${res.status} ${res.statusText} for ${url}`,
+                );
+            }
+
+            return await readCappedBody(res, currentUrl);
+        }
     }
 
     // fetches the articles from a feed, adding them to an array

--- a/packages/platform-feeds/src/index.ts
+++ b/packages/platform-feeds/src/index.ts
@@ -450,10 +450,9 @@ export default class Feeds implements PlatformInterface {
             signal = AbortSignal.timeout(this.config.connectTimeoutMs);
         }
         // Dev/test escape hatch: allow loopback/private feed destinations.
-        // Never enable in production; see the package README.
+        // Set via packageConfig (see the package README); never in production.
         const allowPrivateAddresses =
-            process.env.SOCKETHUB_PLATFORM_FEEDS_ALLOW_PRIVATE_ADDRESSES ===
-            "true";
+            this.config.allowPrivateAddresses === true;
 
         for (let hop = 0; ; hop++) {
             // Validate scheme + resolve DNS and block private destinations

--- a/packages/schemas/src/config-validator.test.ts
+++ b/packages/schemas/src/config-validator.test.ts
@@ -20,6 +20,32 @@ describe("validateSockethubConfig", () => {
         ).toEqual("");
     });
 
+    it("accepts the feeds allowPrivateAddresses boolean", () => {
+        expect(
+            validateSockethubConfig({
+                ...base,
+                packageConfig: {
+                    "@sockethub/platform-feeds": {
+                        allowPrivateAddresses: true,
+                    },
+                },
+            }),
+        ).toEqual("");
+    });
+
+    it("rejects a non-boolean allowPrivateAddresses", () => {
+        expect(
+            validateSockethubConfig({
+                ...base,
+                packageConfig: {
+                    "@sockethub/platform-feeds": {
+                        allowPrivateAddresses: "true",
+                    },
+                },
+            }),
+        ).not.toEqual("");
+    });
+
     it("rejects an unknown top-level key", () => {
         expect(validateSockethubConfig({ ...base, nope: 1 })).not.toEqual("");
     });

--- a/packages/schemas/src/schemas/sockethub-config.ts
+++ b/packages/schemas/src/schemas/sockethub-config.ts
@@ -67,6 +67,7 @@ export const SockethubConfigSchema = {
                     additionalProperties: false,
                     properties: {
                         connectTimeoutMs: { type: "number" },
+                        allowPrivateAddresses: { type: "boolean" },
                     },
                 },
                 "@sockethub/platform-irc": {

--- a/packages/schemas/src/types.ts
+++ b/packages/schemas/src/types.ts
@@ -105,6 +105,9 @@ export type PlatformConfig = StatelessPlatformConfig | PersistentPlatformConfig;
 
 interface BasePlatformConfig {
     connectTimeoutMs?: number;
+    // feeds: allow fetching loopback/private destinations (SSRF escape hatch,
+    // dev/test only). Set via packageConfig; see platform-feeds README.
+    allowPrivateAddresses?: boolean;
 }
 
 /** Configuration for stateless platforms that start/stop per-request */

--- a/packages/server/src/platform-instance.ts
+++ b/packages/server/src/platform-instance.ts
@@ -32,6 +32,7 @@ export interface PlatformInstanceParams {
 type EnvFormat = {
     LOG_LEVEL?: string;
     REDIS_URL: string;
+    SOCKETHUB_FEEDS_ALLOW_PRIVATE_ADDRESSES?: string;
     SOCKETHUB_PLATFORM_CHILD?: string;
     SOCKETHUB_PLATFORM_CONFIG?: string;
     SOCKETHUB_PLATFORM_HEARTBEAT_INTERVAL_MS?: string;
@@ -103,6 +104,10 @@ export default class PlatformInstance {
         };
         if (process.env.LOG_LEVEL) {
             env.LOG_LEVEL = process.env.LOG_LEVEL;
+        }
+        if (process.env.SOCKETHUB_FEEDS_ALLOW_PRIVATE_ADDRESSES) {
+            env.SOCKETHUB_FEEDS_ALLOW_PRIVATE_ADDRESSES =
+                process.env.SOCKETHUB_FEEDS_ALLOW_PRIVATE_ADDRESSES;
         }
         const heartbeatInterval = config.get("platformHeartbeat:intervalMs");
         if (typeof heartbeatInterval !== "undefined") {

--- a/packages/server/src/platform-instance.ts
+++ b/packages/server/src/platform-instance.ts
@@ -32,7 +32,6 @@ export interface PlatformInstanceParams {
 type EnvFormat = {
     LOG_LEVEL?: string;
     REDIS_URL: string;
-    SOCKETHUB_FEEDS_ALLOW_PRIVATE_ADDRESSES?: string;
     SOCKETHUB_PLATFORM_CHILD?: string;
     SOCKETHUB_PLATFORM_CONFIG?: string;
     SOCKETHUB_PLATFORM_HEARTBEAT_INTERVAL_MS?: string;
@@ -104,10 +103,6 @@ export default class PlatformInstance {
         };
         if (process.env.LOG_LEVEL) {
             env.LOG_LEVEL = process.env.LOG_LEVEL;
-        }
-        if (process.env.SOCKETHUB_FEEDS_ALLOW_PRIVATE_ADDRESSES) {
-            env.SOCKETHUB_FEEDS_ALLOW_PRIVATE_ADDRESSES =
-                process.env.SOCKETHUB_FEEDS_ALLOW_PRIVATE_ADDRESSES;
         }
         const heartbeatInterval = config.get("platformHeartbeat:intervalMs");
         if (typeof heartbeatInterval !== "undefined") {


### PR DESCRIPTION
## Problem

`Feeds.makeRequest` did `fetch(url, opts)` then `res.text()` with **no status check, no size cap, and no destination restriction**. The server fetches whatever URL a client places in `actor.id`, so this was both an **SSRF** surface (a client could make the server hit internal services, cloud metadata endpoints like `169.254.169.254`, loopback, etc.) and a **memory-DoS** surface (an attacker-controlled endpoint could stream an unbounded body into memory). On error responses it also silently returned a bogus empty "Unknown Feed" collection instead of failing the job.

## Fix

Implemented in `packages/platform-feeds/src/index.ts`:

1. **`res.ok` check** — on a non-ok response, throw `feed request failed: <status> <statusText> for <url>` so the job fails loudly instead of producing a bogus empty collection. The reason phrase is omitted when empty (HTTP/2 has none), and the unused error body is drained so the keep-alive connection returns to the pool.

2. **Response size cap** — new `MAX_RESPONSE_BYTES` (5 MiB). If `Content-Length` is present and exceeds the cap, throw before reading. The body is then read defensively via the response stream, accumulating bytes and aborting once the cap is exceeded — guarding against a missing or lying `Content-Length`. This **complements the existing time-based `AbortSignal.timeout`**: that bounds *time*, this bounds *bytes*.

3. **SSRF guard** (`assertUrlAllowed`, `isBlockedAddress`):
   - Reject any scheme other than `http:`/`https:`.
   - IP-literal hostnames (detected with `net.isIP`) are checked directly; domain names are resolved with `dns.lookup({ all: true })` and rejected if **any** resolved address is private/loopback/link-local/unique-local/CGNAT. Blocked IPv4 ranges: `0/8`, `127/8`, `10/8`, `172.16/12`, `192.168/16`, `169.254/16` (incl. cloud metadata), `100.64/10` (CGNAT). Blocked IPv6: `::`/`::1`, `fc00::/7`, `fe80::/10`.
   - **IPv6 is normalized before classification** (lowercased, `::` compression expanded, trailing dotted quads converted), so IPv4-mapped (`::ffff:7f00:1`, `0:0:0:0:0:ffff:7f00:1`, `::FFFF:7F00:1`), IPv4-compatible (`::7f00:1`), and NAT64 (`64:ff9b::7f00:1`) spellings of blocked ranges are all caught by the embedded-IPv4 rules. Unparseable literals are blocked conservatively.
   - DNS lookups are bounded by the same `AbortSignal` as the fetch, so a slow/unresponsive resolver cannot stall a job past `connectTimeoutMs`.
   - `redirect: "manual"` with a bounded redirect limit (`MAX_REDIRECTS = 5`); each `Location` is re-validated (scheme + DNS) before being followed. Redirect bodies are drained before following; malformed `Location` values produce a descriptive feed error.
   - Known residual: the guard validates via its own `dns.lookup` while the fetch resolves independently, leaving a check-then-fetch DNS rebinding window. This is documented in a code comment; closing it requires pinning the validated address at connection time (custom undici dispatcher with a validating `connect.lookup`) and is left as a follow-up. The platform runs in an isolated child process, limiting blast radius.

   The URL/scheme/IP validation is factored into small pure helpers (`assertUrlAllowed`, `isBlockedAddress`) so they are unit-testable without real network access.

4. **`allowPrivateAddresses` escape hatch (default off)** — skips **only** the private/loopback destination checks; scheme validation, the size cap, and the redirect limit always remain in effect. Set in the Sockethub config file under `packageConfig["@sockethub/platform-feeds"].allowPrivateAddresses` (the per-platform config mechanism added in #1137). The server forwards the platform's `packageConfig` entry to its forked child, which merges it onto the platform config; the platform reads `this.config.allowPrivateAddresses`. It is a boolean, validated at startup against the canonical config schema. Documented (with its security implications) in the package README. This exists for dev/test harnesses serving fixtures from loopback and for self-hosted deployments that intentionally fetch intranet feeds.
   - The dev/CI harnesses enable it via a checked-in config file (`integration/sockethub.ci.config.json`) referenced through `SOCKETHUB_CONFIG`: `docker-compose.yml` mounts it for the `sockethub` service (fixes the `browser`/`contract` jobs that fetch `http://localhost:10550/feed.xml` from inside the container), and `packages/examples/scripts/smoke-server.mjs` points the spawned server at it (fixes the `examples` job).

`config.connectTimeoutMs` behavior is preserved unchanged (the same `AbortSignal` is reused across redirect hops and DNS lookups).

### Why not `ssrf-req-filter`?

The commonly suggested `ssrf-req-filter` library hooks Node's `http`/`https` **Agents** and does **not** work with global `fetch` (undici), which platform-feeds uses. A DNS-resolve-and-block check is the appropriate approach here.

## Verification

- `bun test` in `packages/platform-feeds` — 68 pass / 0 fail. Tests (`describe -> it`) cover scheme rejection, direct loopback/metadata IPs, the IPv6 bypass spellings (hex/non-compressed/uppercase mapped, IPv4-compatible, NAT64), CGNAT, unparseable literals, zone indexes, the hostname-vs-literal path (a mocked `node:dns/promises` rejection surfaces as `could not resolve`, proving domains reach DNS resolution — no real DNS query), and the escape hatch (allows loopback/localhost when enabled; scheme/URL validation still enforced; blocking intact when disabled). `packages/server` `platform-instance` tests also pass.
- `bun run lint` (repo root) — clean.
- `bun run build` in `packages/platform-feeds` and `packages/server` — clean.
- `tsc --noEmit` introduces no new errors (pre-existing errors unchanged).
- Branch rebased onto master (includes #1132, #1134, #1136); the integration `browser`/`contract`/`examples` jobs that previously failed on the blocked loopback fixture are expected to pass via the harness env flag — verified through CI on this push (local docker is not used).

## Notes / overlap

Rebased onto current master (includes #1132/#1134/#1135). Body-cap, DNS-test, and env-var-naming review feedback addressed.

Rebased onto master after #1137 (the `nconf`→`convict` migration that makes `packageConfig` real). The feeds escape hatch now uses that mechanism rather than a bespoke env var.

Follow-up candidate kept out of scope (tracked separately):
- Connection-time address pinning to close the residual DNS-rebinding window (custom undici dispatcher with a validating `connect.lookup`).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added SSRF protections for feed fetching: only http(s) allowed, DNS-backed destination checks, redirect hop limits, and capped response streaming (5 MiB).
  * Escape hatch via environment variable to allow private/loopback destinations for dev/test only.

* **Documentation**
  * Expanded feed docs explaining SSRF guard, redirect handling, size caps, and the dev/test escape hatch.

* **Tests**
  * Added comprehensive tests covering address classification, URL validation, and the escape-hatch behavior.

* **Chores**
  * Dev/CI compose and smoke-test configs updated to enable the dev-only escape hatch.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

