### PR TITLE
feat(platform-feeds): strict fetch object schema with since/limit filtering

### DIFF
--- a/docs/client-guide.md
+++ b/docs/client-guide.md
@@ -277,7 +277,9 @@ sc.socket.emit('message', {
 sc.socket.emit('message', {
     type: 'fetch',
     '@context': sc.contextFor('feeds'),
-    actor: { id: 'https://example.com/feed.xml', type: 'feed' }
+    actor: { id: 'https://example.com/feed.xml', type: 'feed' },
+    // optional filters: entries published at/after `since`, at most `limit`
+    object: { since: '2024-01-01T00:00:00.000Z', limit: 10 }
 });
 ```
 

--- a/packages/platform-feeds/README.md
+++ b/packages/platform-feeds/README.md
@@ -31,6 +31,38 @@ web applications to consume feed content.
 }
 ```
 
+#### Optional Fetch Parameters
+
+A fetch request may carry an `object` with filtering parameters. The `object`
+is strictly validated: only the parameters below are accepted, anything else
+is rejected.
+
+```json
+{
+  "type": "fetch",
+  "@context": [
+    "https://www.w3.org/ns/activitystreams",
+    "https://sockethub.org/ns/context/v1.jsonld",
+    "https://sockethub.org/ns/context/platform/feeds/v1.jsonld"
+  ],
+  "actor": {
+    "id": "https://example.com/feed.xml",
+    "type": "feed"
+  },
+  "object": {
+    "since": "2024-01-01T00:00:00.000Z",
+    "limit": 10
+  }
+}
+```
+
+* **since** (RFC3339 `date-time` string) — only return entries published at or
+  after this instant. Entries without a parseable publication date are
+  excluded when `since` is set, since they cannot be confirmed as recent
+  enough.
+* **limit** (integer, minimum `1`) — return at most this many entries. Applied
+  after `since`, preserving feed order.
+
 ### Response Format
 
 Returns an ActivityStreams Collection with feed entries:
@@ -60,7 +92,7 @@ Returns an ActivityStreams Collection with feed entries:
       },
       "object": {
         "id": "https://example.com/post/1",
-        "type": "article",
+        "type": "note",
         "title": "Blog Post Title",
         "content": "Post content...",
         "url": "https://example.com/post/1",
@@ -96,12 +128,7 @@ Returns an ActivityStreams Collection with feed entries:
         "name": "Best Feed Inc.",
         "id": "http://blog.example.com/rss",
         "description": "Where the best feed comes to be the best",
-        "image": {
-          "width": "144",
-          "height": "144",
-          "url": "http://blog.example.com/images/bestfeed.jpg"
-        },
-        "favicon": "http://blog.example.com/favicon.ico",
+        "image": "http://blog.example.com/images/bestfeed.jpg",
         "link": "http://blog.example.com",
         "categories": ["best", "feed", "animals"],
         "language": "en",
@@ -109,22 +136,14 @@ Returns an ActivityStreams Collection with feed entries:
       },
       "object": {
         "id": "http://blog.example.com/articles/about-stuff",
-        "type": "article",
+        "type": "note",
         "title": "About stuff...",
         "url": "http://blog.example.com/articles/about-stuff",
-        "date": "2013-05-28T12:00:00.000Z",
+        "published": "2013-05-28T12:00:00.000Z",
         "datenum": 1369742400000,
         "brief": "Brief synopsis of stuff...",
         "content": "Once upon a time...",
-        "contentType": "text",
-        "media": [
-          {
-            "length": "13908973",
-            "type": "audio/mpeg",
-            "url": "http://blog.example.com/media/thing.mpg"
-          }
-        ],
-        "tags": ["foo", "bar"]
+        "contentType": "text"
       }
     }
   ]

--- a/packages/platform-feeds/src/index.test.ts
+++ b/packages/platform-feeds/src/index.test.ts
@@ -12,7 +12,13 @@ import {
 import getPodcastFromFeed from "podparse";
 import feedsSchema from "./schema";
 import { RSSFeed } from "./index.test.data";
-import Feeds, { buildFeedItem, datesEqual } from "./index";
+import Feeds, {
+    applyFetchFilters,
+    buildFeedItem,
+    datesEqual,
+    extractFetchParams,
+    type FeedFetchParams,
+} from "./index";
 
 addPlatformSchema(feedsSchema.messages, "feeds/messages");
 addPlatformSchema(feedsSchema.responses, "feeds/responses");
@@ -49,8 +55,8 @@ function loadFixture(name: string): string {
 }
 
 describe("inbound messages schema", () => {
-    it("validates a well-formed fetch activity carrying an object payload", () => {
-        const msg = {
+    function fetchMsg(object?: Record<string, unknown>): ActivityStream {
+        return {
             "@context": [
                 "https://www.w3.org/ns/activitystreams",
                 "https://sockethub.org/ns/context/v1.jsonld",
@@ -61,18 +67,48 @@ describe("inbound messages schema", () => {
                 id: "https://example.com/feed.xml",
                 type: "feed",
             },
-            object: {
-                type: "feed-parameters",
-                url: "https://example.com/feed.xml",
-            },
+            ...(object ? { object } : {}),
         } as unknown as ActivityStream;
-        expect(validateActivityStream(msg)).toEqual("");
+    }
+
+    it("validates a fetch with no object (the common case)", () => {
+        expect(validateActivityStream(fetchMsg())).toEqual("");
     });
 
-    it("has no impossible identical-branch oneOf on object", () => {
+    it("validates a fetch carrying since and limit parameters", () => {
+        expect(
+            validateActivityStream(
+                fetchMsg({ since: "2024-01-01T00:00:00.000Z", limit: 10 }),
+            ),
+        ).toEqual("");
+    });
+
+    it("rejects an unknown parameter on the object", () => {
+        expect(
+            validateActivityStream(fetchMsg({ url: "https://example.com" })),
+        ).not.toEqual("");
+    });
+
+    it("rejects a non-integer or out-of-range limit", () => {
+        expect(validateActivityStream(fetchMsg({ limit: 0 }))).not.toEqual("");
+        expect(validateActivityStream(fetchMsg({ limit: 1.5 }))).not.toEqual(
+            "",
+        );
+    });
+
+    it("rejects a since that is not an RFC3339 date-time", () => {
+        expect(
+            validateActivityStream(fetchMsg({ since: "last tuesday" })),
+        ).not.toEqual("");
+    });
+
+    it("has no permissive additionalProperties hole on object", () => {
         expect(feedsSchema.messages.properties.object).not.toHaveProperty(
             "oneOf",
         );
+        expect(
+            feedsSchema.messages.properties.object.additionalProperties,
+        ).toBe(false);
         expect(feedsSchema.messages).not.toHaveProperty("definitions");
     });
 });
@@ -603,6 +639,109 @@ describe("platform-feeds", () => {
 
                 expect(results.items.length).toEqual(results.totalItems);
             },
+        );
+    });
+
+    it("limit caps the number of returned entries", () => {
+        platform.fetch(
+            { id: "limit-id", actor: { id: "some url" }, object: { limit: 5 } },
+            (err, results: ASCollection) => {
+                expect(err).toBeNull();
+                expect(results.totalItems).toEqual(5);
+                expect(results.items.length).toEqual(5);
+            },
+        );
+    });
+
+    it("since in the future filters out all entries", () => {
+        platform.fetch(
+            {
+                id: "since-future-id",
+                actor: { id: "some url" },
+                object: { since: "2999-01-01T00:00:00.000Z" },
+            },
+            (err, results: ASCollection) => {
+                expect(err).toBeNull();
+                expect(results.totalItems).toEqual(0);
+            },
+        );
+    });
+
+    it("since at the epoch keeps every entry", () => {
+        platform.fetch(
+            {
+                id: "since-epoch-id",
+                actor: { id: "some url" },
+                object: { since: "1970-01-01T00:00:00.000Z" },
+            },
+            (err, results: ASCollection) => {
+                expect(err).toBeNull();
+                expect(results.totalItems).toEqual(20);
+            },
+        );
+    });
+});
+
+describe("extractFetchParams", () => {
+    it("returns empty params for missing or non-object input", () => {
+        expect(extractFetchParams(undefined)).toEqual({});
+        expect(extractFetchParams(null)).toEqual({});
+        expect(extractFetchParams("nope")).toEqual({});
+    });
+
+    it("reads since and a valid integer limit", () => {
+        expect(
+            extractFetchParams({ since: "2024-01-01T00:00:00.000Z", limit: 3 }),
+        ).toEqual({ since: "2024-01-01T00:00:00.000Z", limit: 3 });
+    });
+
+    it("ignores a non-integer or out-of-range limit", () => {
+        expect(extractFetchParams({ limit: 0 })).toEqual({});
+        expect(extractFetchParams({ limit: 2.5 })).toEqual({});
+        expect(extractFetchParams({ limit: "5" })).toEqual({});
+    });
+});
+
+describe("applyFetchFilters", () => {
+    function article(
+        datenum: number,
+    ): Parameters<typeof applyFetchFilters>[0][number] {
+        return {
+            "@context": [feedsSchema.contextUrl],
+            type: "post",
+            actor: { id: "a", type: "feed", name: "n", link: "l" },
+            object: { datenum },
+        } as unknown as Parameters<typeof applyFetchFilters>[0][number];
+    }
+
+    const articles = [article(300), article(200), article(100), article(0)];
+
+    it("returns all entries when no params are given", () => {
+        expect(applyFetchFilters(articles, {}).length).toEqual(4);
+    });
+
+    it("drops entries published before since (undated excluded)", () => {
+        const result = applyFetchFilters(articles, { since: new Date(150).toISOString() });
+        expect(result.map((a) => a.object?.datenum)).toEqual([300, 200]);
+    });
+
+    it("preserves feed order and caps at limit", () => {
+        const result = applyFetchFilters(articles, { limit: 2 });
+        expect(result.map((a) => a.object?.datenum)).toEqual([300, 200]);
+    });
+
+    it("applies since before limit", () => {
+        const params: FeedFetchParams = {
+            since: new Date(50).toISOString(),
+            limit: 2,
+        };
+        const result = applyFetchFilters(articles, params);
+        expect(result.map((a) => a.object?.datenum)).toEqual([300, 200]);
+    });
+
+    it("ignores an unparseable since", () => {
+        expect(applyFetchFilters(articles, { since: "garbage" }).length).toEqual(
+            4,
         );
     });
 });

--- a/packages/platform-feeds/src/index.test.ts
+++ b/packages/platform-feeds/src/index.test.ts
@@ -2,9 +2,11 @@ import { readFileSync } from "node:fs";
 import path from "node:path";
 import { beforeEach, describe, expect, it, test } from "bun:test";
 import type { ASCollection, PlatformSession } from "@sockethub/schemas";
+import type { ActivityStream } from "@sockethub/schemas";
 import {
     addPlatformContext,
     addPlatformSchema,
+    validateActivityStream,
     validateActivityStreamResponse,
 } from "@sockethub/schemas";
 import getPodcastFromFeed from "podparse";
@@ -12,6 +14,7 @@ import feedsSchema from "./schema";
 import { RSSFeed } from "./index.test.data";
 import Feeds, { buildFeedItem, datesEqual } from "./index";
 
+addPlatformSchema(feedsSchema.messages, "feeds/messages");
 addPlatformSchema(feedsSchema.responses, "feeds/responses");
 addPlatformContext("feeds", feedsSchema.contextUrl);
 
@@ -44,6 +47,35 @@ const FIXTURES_DIR = path.join(import.meta.dirname, "../test/fixtures");
 function loadFixture(name: string): string {
     return readFileSync(path.join(FIXTURES_DIR, name), "utf8");
 }
+
+describe("inbound messages schema", () => {
+    it("validates a well-formed fetch activity carrying an object payload", () => {
+        const msg = {
+            "@context": [
+                "https://www.w3.org/ns/activitystreams",
+                "https://sockethub.org/ns/context/v1.jsonld",
+                feedsSchema.contextUrl,
+            ],
+            type: "fetch",
+            actor: {
+                id: "https://example.com/feed.xml",
+                type: "feed",
+            },
+            object: {
+                type: "feed-parameters",
+                url: "https://example.com/feed.xml",
+            },
+        } as unknown as ActivityStream;
+        expect(validateActivityStream(msg)).toEqual("");
+    });
+
+    it("has no impossible identical-branch oneOf on object", () => {
+        expect(feedsSchema.messages.properties.object).not.toHaveProperty(
+            "oneOf",
+        );
+        expect(feedsSchema.messages).not.toHaveProperty("definitions");
+    });
+});
 
 describe("datesEqual", () => {
     test("treats two null/undefined as equal", () => {

--- a/packages/platform-feeds/src/index.test.ts
+++ b/packages/platform-feeds/src/index.test.ts
@@ -744,4 +744,11 @@ describe("applyFetchFilters", () => {
             4,
         );
     });
+
+    it("excludes undated entries even when since is the epoch", () => {
+        const result = applyFetchFilters(articles, {
+            since: "1970-01-01T00:00:00.000Z",
+        });
+        expect(result.map((a) => a.object?.datenum)).toEqual([300, 200, 100]);
+    });
 });

--- a/packages/platform-feeds/src/index.test.ts
+++ b/packages/platform-feeds/src/index.test.ts
@@ -399,6 +399,24 @@ describe("platform-feeds", () => {
         };
     });
 
+    // Promisify platform.fetch so tests await its completion. With the bare
+    // callback style the test body returns before the callback fires, and
+    // assertion failures escape as unhandled rejections instead of failing
+    // the test.
+    function fetchCollection(
+        job: Parameters<Feeds["fetch"]>[0],
+    ): Promise<ASCollection> {
+        return new Promise((resolve, reject) => {
+            platform.fetch(job, (err, results: ASCollection) => {
+                if (err) {
+                    reject(err instanceof Error ? err : new Error(String(err)));
+                } else {
+                    resolve(results);
+                }
+            });
+        });
+    }
+
     test("fetches expected feed", () => {
         platform.fetch(
             {
@@ -550,69 +568,55 @@ describe("platform-feeds", () => {
         );
     });
 
-    it("emits a schema-valid collection from a real channel image/author feed", () => {
+    it("emits a schema-valid collection from a real channel image/author feed", async () => {
         platform.makeRequest = (): Promise<string> => {
             return Promise.resolve(loadFixture("channel-image-author-rss.xml"));
         };
 
-        platform.fetch(
-            {
-                id: "image-author-feed-id",
-                actor: {
-                    id: "https://example.com/feed",
-                },
+        const results = await fetchCollection({
+            id: "image-author-feed-id",
+            actor: {
+                id: "https://example.com/feed",
             },
-            (err, results: ASCollection) => {
-                expect(err).toBeNull();
-                expect(results.totalItems).toEqual(1);
+        });
+        expect(results.totalItems).toEqual(1);
 
-                // The real buildFeedChannel output (image + author) and the
-                // per-post `id` must satisfy the strict outbound schema.
-                const actor = results.items[0].actor;
-                expect(typeof actor?.image).toBe("string");
-                expect(actor?.image).toEqual("https://example.com/logo.png");
-                // podparse maps <author> to the raw text, not an object.
-                expect(actor?.author).toEqual(
-                    "editor@example.com (Jane Editor)",
-                );
-                expect(results.items[0].id).toEqual("image-author-feed-id");
+        // The real buildFeedChannel output (image + author) and the
+        // per-post `id` must satisfy the strict outbound schema.
+        const actor = results.items[0].actor;
+        expect(typeof actor?.image).toBe("string");
+        expect(actor?.image).toEqual("https://example.com/logo.png");
+        // podparse maps <author> to the raw text, not an object.
+        expect(actor?.author).toEqual("editor@example.com (Jane Editor)");
+        expect(results.items[0].id).toEqual("image-author-feed-id");
 
-                expect(validateActivityStreamResponse(results)).toEqual("");
-            },
-        );
+        expect(validateActivityStreamResponse(results)).toEqual("");
     });
 
-    it("emits a schema-valid collection from a feed without channel image/author", () => {
+    it("emits a schema-valid collection from a feed without channel image/author", async () => {
         platform.makeRequest = (): Promise<string> => {
             return Promise.resolve(loadFixture("bare-channel-rss.xml"));
         };
 
-        platform.fetch(
-            {
-                id: "bare-feed-id",
-                actor: {
-                    id: "https://example.com/feed",
-                },
+        const results = await fetchCollection({
+            id: "bare-feed-id",
+            actor: {
+                id: "https://example.com/feed",
             },
-            (err, results: ASCollection) => {
-                expect(err).toBeNull();
-                expect(results.totalItems).toEqual(1);
+        });
+        expect(results.totalItems).toEqual(1);
 
-                // Absent channel metadata must not break strict validation:
-                // image/author are undefined and AJV skips undefined-valued
-                // properties (they are also dropped at the JSON/IPC boundary).
-                const actor = results.items[0].actor;
-                expect(actor?.image).toBeUndefined();
-                expect(actor?.author).toBeUndefined();
+        // Absent channel metadata must not break strict validation:
+        // image/author are undefined and AJV skips undefined-valued
+        // properties (they are also dropped at the JSON/IPC boundary).
+        const actor = results.items[0].actor;
+        expect(actor?.image).toBeUndefined();
+        expect(actor?.author).toBeUndefined();
 
-                expect(validateActivityStreamResponse(results)).toEqual("");
-                expect(
-                    validateActivityStreamResponse(
-                        JSON.parse(JSON.stringify(results)),
-                    ),
-                ).toEqual("");
-            },
-        );
+        expect(validateActivityStreamResponse(results)).toEqual("");
+        expect(
+            validateActivityStreamResponse(JSON.parse(JSON.stringify(results))),
+        ).toEqual("");
     });
 
     test("validates collection structure matches ASCollection interface", () => {
@@ -642,43 +646,32 @@ describe("platform-feeds", () => {
         );
     });
 
-    it("limit caps the number of returned entries", () => {
-        platform.fetch(
-            { id: "limit-id", actor: { id: "some url" }, object: { limit: 5 } },
-            (err, results: ASCollection) => {
-                expect(err).toBeNull();
-                expect(results.totalItems).toEqual(5);
-                expect(results.items.length).toEqual(5);
-            },
-        );
+    it("limit caps the number of returned entries", async () => {
+        const results = await fetchCollection({
+            id: "limit-id",
+            actor: { id: "some url" },
+            object: { limit: 5 },
+        });
+        expect(results.totalItems).toEqual(5);
+        expect(results.items.length).toEqual(5);
     });
 
-    it("since in the future filters out all entries", () => {
-        platform.fetch(
-            {
-                id: "since-future-id",
-                actor: { id: "some url" },
-                object: { since: "2999-01-01T00:00:00.000Z" },
-            },
-            (err, results: ASCollection) => {
-                expect(err).toBeNull();
-                expect(results.totalItems).toEqual(0);
-            },
-        );
+    it("since in the future filters out all entries", async () => {
+        const results = await fetchCollection({
+            id: "since-future-id",
+            actor: { id: "some url" },
+            object: { since: "2999-01-01T00:00:00.000Z" },
+        });
+        expect(results.totalItems).toEqual(0);
     });
 
-    it("since at the epoch keeps every entry", () => {
-        platform.fetch(
-            {
-                id: "since-epoch-id",
-                actor: { id: "some url" },
-                object: { since: "1970-01-01T00:00:00.000Z" },
-            },
-            (err, results: ASCollection) => {
-                expect(err).toBeNull();
-                expect(results.totalItems).toEqual(20);
-            },
-        );
+    it("since at the epoch keeps every entry", async () => {
+        const results = await fetchCollection({
+            id: "since-epoch-id",
+            actor: { id: "some url" },
+            object: { since: "1970-01-01T00:00:00.000Z" },
+        });
+        expect(results.totalItems).toEqual(20);
     });
 });
 

--- a/packages/platform-feeds/src/index.ts
+++ b/packages/platform-feeds/src/index.ts
@@ -108,7 +108,8 @@ export default class Feeds implements PlatformInterface {
      */
     fetch(job: ActivityStream, done: PlatformCallback) {
         // ready to execute job
-        this.fetchFeed(job.actor.id, job.id)
+        const params = extractFetchParams(job.object);
+        this.fetchFeed(job.actor.id, job.id, params)
             .then((results) => {
                 return done(null, {
                     id: job.id || null,
@@ -149,6 +150,7 @@ export default class Feeds implements PlatformInterface {
     private async fetchFeed(
         url: string,
         id: string,
+        params: FeedFetchParams = {},
     ): Promise<Array<PlatformFeedsActivityStream>> {
         this.log.debug(`fetching ${url}`);
         const res = await this.makeRequest(url);
@@ -170,9 +172,70 @@ export default class Feeds implements PlatformInterface {
                 );
             }
         }
-        this.log.debug(`fetched ${articles.length} articles`);
-        return articles;
+        const filtered = applyFetchFilters(articles, params);
+        this.log.debug(
+            `fetched ${articles.length} articles, returning ${filtered.length}`,
+        );
+        return filtered;
     }
+}
+
+/**
+ * Optional parameters a client may attach to a `fetch` request `object`.
+ * Mirrors the strict `messages.object` schema; both must stay in sync.
+ */
+export interface FeedFetchParams {
+    since?: string;
+    limit?: number;
+}
+
+/**
+ * Extract the supported fetch parameters from a request `object`. Inbound
+ * messages are already validated against the strict `messages` schema on the
+ * server, so this only needs to read the recognized fields defensively (the
+ * platform may also be called directly, e.g. in tests).
+ */
+export function extractFetchParams(object: unknown): FeedFetchParams {
+    if (!object || typeof object !== "object") {
+        return {};
+    }
+    const { since, limit } = object as Record<string, unknown>;
+    const params: FeedFetchParams = {};
+    if (typeof since === "string") {
+        params.since = since;
+    }
+    if (typeof limit === "number" && Number.isInteger(limit) && limit >= 1) {
+        params.limit = limit;
+    }
+    return params;
+}
+
+/**
+ * Apply the `since` and `limit` fetch parameters to built feed entries.
+ *
+ * - `since`: drop entries published before the given instant. Entries without a
+ *   parseable date (`datenum === 0`) are excluded when `since` is set, since we
+ *   cannot confirm they are recent enough. An unparseable `since` is ignored.
+ * - `limit`: return at most `limit` entries, preserving feed order.
+ */
+export function applyFetchFilters(
+    articles: Array<PlatformFeedsActivityStream>,
+    params: FeedFetchParams,
+): Array<PlatformFeedsActivityStream> {
+    let result = articles;
+    if (params.since) {
+        const sinceMs = Date.parse(params.since);
+        if (!Number.isNaN(sinceMs)) {
+            result = result.filter((article) => {
+                const datenum = article.object?.datenum;
+                return typeof datenum === "number" && datenum >= sinceMs;
+            });
+        }
+    }
+    if (params.limit !== undefined && result.length > params.limit) {
+        result = result.slice(0, params.limit);
+    }
+    return result;
 }
 
 interface FeedItem extends Episode {

--- a/packages/platform-feeds/src/index.ts
+++ b/packages/platform-feeds/src/index.ts
@@ -228,7 +228,13 @@ export function applyFetchFilters(
         if (!Number.isNaN(sinceMs)) {
             result = result.filter((article) => {
                 const datenum = article.object?.datenum;
-                return typeof datenum === "number" && datenum >= sinceMs;
+                // `datenum === 0` is the unparseable-date sentinel from
+                // buildFeedItem; exclude it even when `since` is the epoch.
+                return (
+                    typeof datenum === "number" &&
+                    datenum !== 0 &&
+                    datenum >= sinceMs
+                );
             });
         }
     }

--- a/packages/platform-feeds/src/index.ts
+++ b/packages/platform-feeds/src/index.ts
@@ -101,6 +101,11 @@ export default class Feeds implements PlatformInterface {
      * response to the original request with a complete ActivityStreams Collection
      * containing all feed items and metadata.
      *
+     * The request may carry an optional `object` with filtering parameters:
+     * `since` (RFC3339 date-time; only entries published at or after this
+     * instant, undated entries excluded) and `limit` (integer >= 1; cap on
+     * returned entries, applied after `since`, feed order preserved).
+     *
      * @param job - Activity streams object containing job data with actor.id as feed URL
      * @param done - Callback function that receives (error, ASCollection)
      * See the package README for canonical request and response payload

--- a/packages/platform-feeds/src/schema.ts
+++ b/packages/platform-feeds/src/schema.ts
@@ -13,9 +13,17 @@ export default {
                 type: "string",
                 enum: ["fetch"],
             },
+            // Optional fetch parameters. When present, strictly validated: only
+            // the parameters the platform actually honors are allowed.
             object: {
                 type: "object",
-                additionalProperties: true,
+                additionalProperties: false,
+                properties: {
+                    // Only return entries published at or after this instant.
+                    since: { type: "string", format: "date-time" },
+                    // Cap the number of returned entries (feed order preserved).
+                    limit: { type: "integer", minimum: 1 },
+                },
             },
         },
     },

--- a/packages/platform-feeds/src/schema.ts
+++ b/packages/platform-feeds/src/schema.ts
@@ -15,22 +15,7 @@ export default {
             },
             object: {
                 type: "object",
-                oneOf: [
-                    { $ref: "#/definitions/objectTypes/feed-parameters-date" },
-                    { $ref: "#/definitions/objectTypes/feed-parameters-url" },
-                ],
-            },
-        },
-        definitions: {
-            objectTypes: {
-                "feed-parameters-date": {
-                    type: "object",
-                    additionalProperties: true,
-                },
-                "feed-parameters-url": {
-                    type: "object",
-                    additionalProperties: true,
-                },
+                additionalProperties: true,
             },
         },
     },


### PR DESCRIPTION
## Problem

The inbound `messages` schema declared `object` with an unsatisfiable `oneOf` (two identical empty branches), so any fetch request carrying an `object` was rejected. Replacing it with `additionalProperties: true` (the first pass on this PR) was rejected in review: it disables validation for that subtree rather than defining the format.

Investigation showed the `object` block — and the `feed-parameters-date`/`feed-parameters-url` definition names — was **dead placeholder scaffolding** for a feed-filtering feature that was never implemented:

- `fetch()` called `fetchFeed(job.actor.id, job.id)` and never read `job.object`.
- The reference feeds client sends only `{ "@context", type: "fetch", actor }` — no `object`.
- The base `activity-stream` schema already enforces the envelope (`additionalProperties: false`, required `@context`/`type`/`actor`) and delegates `object` to the per-platform `messages` schema.

## Change

Define the parameters strictly and actually honor them, rather than leaving a hole or silently dropping a sent `object`.

- **Schema**: `messages.object` is now `additionalProperties: false` with two optional, validated parameters:
  - `since`: RFC3339 `date-time` — only return entries published at or after this instant.
  - `limit`: integer `>= 1` — cap the number of returned entries (feed order preserved).
- **Implementation**: `fetchFeed` applies the filters. `since` drops entries published earlier; entries without a parseable date (`datenum === 0`, `buildFeedItem`'s unparseable-date sentinel) are excluded whenever `since` is set — including `since` exactly at the epoch, where a plain `>=` comparison would otherwise let them through; an unparseable `since` is ignored. `limit` is applied after `since`.
- `extractFetchParams` and `applyFetchFilters` are exported pure helpers.

## Tests

- Schema validation: fetch with no object, with valid `since`+`limit`, and rejection of unknown params / non-integer or out-of-range `limit` / non-date-time `since`.
- Unit tests for `extractFetchParams` and `applyFetchFilters` (ordering, undated exclusion including the epoch boundary, unparseable `since`).
- End-to-end `fetch()` tests for `limit` capping and `since` boundary behavior.

`bun test` (43 pass), `bun run lint`, and `bun run build` all green.

## Docs

The package README documents the optional `since`/`limit` fetch object (and its response examples now match what the platform actually emits: string `image`/`author`, `published`/`datenum`, no never-emitted `media`/`tags`/`favicon`). The client guide's feeds example shows the optional `object`, and the `fetch()` JSDoc describes both parameters.

## Notes

- Rebased onto master after #1132 merged (this branch now includes its channel image/author fixes and tests).
- Companion to #1136 (metadata, merged): feeds defines real `since`/`limit` filtering params because it can support them; metadata has no parameters, so its inbound `object` is forbidden instead.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Feed fetch operations now support optional `since` and `limit` parameters to filter entries by date and control result quantity.
  * Fetch parameters are now strictly validated to ensure proper formatting.

* **Tests**
  * Expanded test coverage for feed parameter handling and filtering behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
