### PR TITLE
fix(platform-metadata): strictly forbid inbound fetch object

### DIFF
--- a/packages/platform-metadata/src/schema.test.ts
+++ b/packages/platform-metadata/src/schema.test.ts
@@ -1,15 +1,24 @@
-import { describe, expect, mock, test } from "bun:test";
+import { describe, expect, it, mock, test } from "bun:test";
 import {
     addPlatformContext,
     addPlatformSchema,
+    validateActivityStream,
     validateActivityStreamResponse,
 } from "@sockethub/schemas";
 import { PlatformMetadataSchema } from "./schema";
 
 addPlatformSchema(PlatformMetadataSchema.responses, "metadata/responses");
+addPlatformSchema(PlatformMetadataSchema.messages, "metadata/messages");
 addPlatformContext("metadata", PlatformMetadataSchema.contextUrl);
 
 const CTX = [PlatformMetadataSchema.contextUrl];
+// Full envelope context required by the base activity-stream schema (exactly
+// three entries) for inbound message validation.
+const MSG_CTX = [
+    "https://www.w3.org/ns/activitystreams",
+    "https://sockethub.org/ns/context/v1.jsonld",
+    PlatformMetadataSchema.contextUrl,
+];
 
 // Mock open-graph-scraper so we exercise the platform's real fetch() output
 // path against the strict responses schema, without network access.
@@ -89,5 +98,37 @@ describe("metadata responses schema", () => {
         };
         // biome-ignore lint/suspicious/noExplicitAny: assertion
         expect(validateActivityStreamResponse(msg as any)).not.toEqual("");
+    });
+});
+
+describe("metadata inbound messages schema", () => {
+    function fetchMsg(object?: Record<string, unknown>) {
+        return {
+            "@context": MSG_CTX,
+            type: "fetch",
+            actor: { id: "https://example.com", type: "website" },
+            ...(object ? { object } : {}),
+        };
+    }
+
+    it("validates a fetch with only an actor (no object)", () => {
+        // biome-ignore lint/suspicious/noExplicitAny: assertion
+        expect(validateActivityStream(fetchMsg() as any)).toEqual("");
+    });
+
+    it("rejects a fetch carrying any inbound object", () => {
+        expect(
+            // biome-ignore lint/suspicious/noExplicitAny: assertion
+            validateActivityStream(fetchMsg({ url: "https://example.com" }) as any),
+        ).not.toEqual("");
+        // biome-ignore lint/suspicious/noExplicitAny: assertion
+        expect(validateActivityStream(fetchMsg({}) as any)).not.toEqual("");
+    });
+
+    it("has no permissive placeholder left on the messages schema", () => {
+        expect(PlatformMetadataSchema.messages.properties.object).toBe(false);
+        expect(PlatformMetadataSchema.messages).not.toHaveProperty(
+            "definitions",
+        );
     });
 });

--- a/packages/platform-metadata/src/schema.ts
+++ b/packages/platform-metadata/src/schema.ts
@@ -15,20 +15,11 @@ export const PlatformMetadataSchema = {
                 type: "string",
                 enum: ["fetch"],
             },
-            object: {
-                type: "object",
-                oneOf: [
-                    { $ref: "#/definitions/objectTypes/feed-parameters-url" },
-                ],
-            },
-        },
-        definitions: {
-            objectTypes: {
-                "feed-parameters-url": {
-                    type: "object",
-                    additionalProperties: true,
-                },
-            },
+            // A metadata fetch takes no parameters — the target URL is the
+            // actor id. Strictly reject any inbound `object` rather than leave
+            // a permissive, unenforced placeholder. (The outbound response
+            // carries an `object`/`page`, validated by the `responses` schema.)
+            object: false,
         },
     },
     // Outbound (platform -> client): the metadata platform echoes the `fetch`


### PR DESCRIPTION
## Problem

The metadata `messages` schema declared `object` as a single-branch `oneOf` over a `feed-parameters-url` definition that was `additionalProperties: true` — a permissive placeholder that disables validation for that subtree. (Same anti-pattern flagged on the feeds platform in #1134.)

A metadata `fetch` takes **no parameters**: the target URL is the actor id, and the platform's `fetch()` reads only `job.actor.id` (it *writes* `job.object` as the response). The reference metadata example client sends no `object` either.

## Change

Strictly reject any inbound `object` on a metadata fetch by setting `messages.properties.object` to `false`, and remove the dead `objectTypes` definitions. The base `activity-stream` envelope still enforces `@context`/`type`/`actor`; the outbound response `object`/`page` is unaffected (validated by the `responses` schema).

## Tests

Added an inbound messages-schema test block: a fetch with only an actor validates, a fetch carrying any `object` (including `{}`) is rejected, and a structural assertion that the permissive placeholder is gone.

`bun test` (7 pass), `bun run lint`, and `bun run build` all green.

## Notes

Companion to #1134 (feeds): feeds defines real `since`/`limit` filtering params because it can support them; metadata has no parameters, so its inbound `object` is forbidden instead.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Strengthened validation for metadata fetch operations to properly enforce parameter constraints and reject invalid requests that previously were accepted.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->