### PR TITLE
feat(platform-metadata): SSRF-guarded fetch via new @sockethub/util

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -279,6 +279,16 @@
         "@sockethub/server": "^5.0.0-alpha.12",
       },
     },
+    "packages/util": {
+      "name": "@sockethub/util",
+      "version": "1.0.0-alpha.0",
+      "dependencies": {
+        "undici": "^7.19.0",
+      },
+      "devDependencies": {
+        "@types/bun": "latest",
+      },
+    },
   },
   "overrides": {
     "engine.io": "6.6.8",
@@ -1097,6 +1107,8 @@
     "@sockethub/schemas": ["@sockethub/schemas@workspace:packages/schemas"],
 
     "@sockethub/server": ["@sockethub/server@workspace:packages/server"],
+
+    "@sockethub/util": ["@sockethub/util@workspace:packages/util"],
 
     "@standard-schema/spec": ["@standard-schema/spec@1.1.0", "", {}, "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w=="],
 
@@ -3936,6 +3948,8 @@
 
     "@sockethub/server/@types/bun": ["@types/bun@1.3.14", "", { "dependencies": { "bun-types": "1.3.14" } }, "sha512-h1hFqFVcvAvD9j9K7ZW7vd82aSA+rTdznZa+5bwvCwqSB1jmmfLcbIWhOLx1/+boy/xmjgCs/OMUL8hRJSmnPw=="],
 
+    "@sockethub/util/@types/bun": ["@types/bun@1.3.14", "", { "dependencies": { "bun-types": "1.3.14" } }, "sha512-h1hFqFVcvAvD9j9K7ZW7vd82aSA+rTdznZa+5bwvCwqSB1jmmfLcbIWhOLx1/+boy/xmjgCs/OMUL8hRJSmnPw=="],
+
     "@sveltejs/vite-plugin-svelte-inspector/debug": ["debug@4.4.0", "", { "dependencies": { "ms": "^2.1.3" } }, "sha512-6WTZ/IxCY/T6BALoZHaE4ctp9xm+Z5kY/pzYaCHRFeyVhojxlrm+46y68HA6hr0TcwEssoxNiDEUJQjfPZ/RYA=="],
 
     "@tailwindcss/node/magic-string": ["magic-string@0.30.21", "", { "dependencies": { "@jridgewell/sourcemap-codec": "^1.5.5" } }, "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ=="],
@@ -4799,6 +4813,8 @@
     "@sockethub/schemas/@types/bun/bun-types": ["bun-types@1.3.14", "", { "dependencies": { "@types/node": "*" } }, "sha512-4N0ig0fEomHt5R0KCFWjovxow98rIoRwKolrYdCcknNwMekCXRnWEUvgu5soYV8QXtVsrUD8B95MBOZGPvr6KQ=="],
 
     "@sockethub/server/@types/bun/bun-types": ["bun-types@1.3.14", "", { "dependencies": { "@types/node": "*" } }, "sha512-4N0ig0fEomHt5R0KCFWjovxow98rIoRwKolrYdCcknNwMekCXRnWEUvgu5soYV8QXtVsrUD8B95MBOZGPvr6KQ=="],
+
+    "@sockethub/util/@types/bun/bun-types": ["bun-types@1.3.14", "", { "dependencies": { "@types/node": "*" } }, "sha512-4N0ig0fEomHt5R0KCFWjovxow98rIoRwKolrYdCcknNwMekCXRnWEUvgu5soYV8QXtVsrUD8B95MBOZGPvr6KQ=="],
 
     "@tailwindcss/node/magic-string/@jridgewell/sourcemap-codec": ["@jridgewell/sourcemap-codec@1.5.5", "", {}, "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og=="],
 

--- a/integration/sockethub.ci.config.json
+++ b/integration/sockethub.ci.config.json
@@ -3,6 +3,9 @@
   "packageConfig": {
     "@sockethub/platform-feeds": {
       "allowPrivateAddresses": true
+    },
+    "@sockethub/platform-metadata": {
+      "allowPrivateAddresses": true
     }
   }
 }

--- a/packages/platform-metadata/README.md
+++ b/packages/platform-metadata/README.md
@@ -86,10 +86,42 @@ The platform extracts the following metadata when available:
 * **open-graph-scraper**: Core library for extracting Open Graph and metadata from web
   pages
 
+## Request Hardening (SSRF Guard)
+
+Because the server fetches whatever URL a client supplies as `actor.id`, metadata
+requests are hardened against server-side request forgery (SSRF) and resource
+exhaustion. The fetch runs through a guarded connection layer that:
+
+* refuses to connect to loopback, private, link-local, carrier-grade NAT, or
+  cloud-metadata addresses (e.g. `169.254.169.254`), in every IPv4/IPv6 spelling,
+  validated at connection time so it also covers redirect hops;
+* caps the response body size.
+
+### `allowPrivateAddresses`
+
+Set in the Sockethub config file under this platform's `packageConfig` entry:
+
+```json
+{
+  "packageConfig": {
+    "@sockethub/platform-metadata": {
+      "allowPrivateAddresses": true
+    }
+  }
+}
+```
+
+This disables **only** the private/loopback destination checks. **Do not enable
+it on a server that accepts requests from untrusted clients** — it lets any
+client make the server issue requests to internal services. It defaults to off;
+it is an escape hatch for dev/test harnesses serving fixtures from `localhost`,
+or self-hosted deployments that intentionally fetch intranet pages.
+
 ## Error Handling
 
-If metadata extraction fails (invalid URL, network issues, parsing errors), the platform
-will return an error through the standard Sockethub error handling mechanism.
+If metadata extraction fails (invalid URL, network issues, parsing errors, or a
+blocked destination), the platform returns an error through the standard
+Sockethub error handling mechanism.
 
 ## Use Cases
 

--- a/packages/platform-metadata/package.json
+++ b/packages/platform-metadata/package.json
@@ -42,6 +42,7 @@
     "clean:deps": "rm -rf node_modules"
   },
   "dependencies": {
+    "@sockethub/util": "^1.0.0-alpha.0",
     "open-graph-scraper": "^6.11.0"
   },
   "devDependencies": {

--- a/packages/platform-metadata/src/index.test.ts
+++ b/packages/platform-metadata/src/index.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, mock } from "bun:test";
+import { beforeEach, describe, expect, it, mock } from "bun:test";
 import { Agent } from "undici";
 
 // Capture the options passed to open-graph-scraper and control its outcome,
@@ -41,6 +41,13 @@ function runFetch(
 }
 
 describe("metadata fetch SSRF hardening", () => {
+    beforeEach(() => {
+        // Reset shared mock state so a stale value from one test cannot make a
+        // later assertion pass without exercising the current path.
+        ogsOptions = undefined;
+        ogsBehavior = () => Promise.resolve({ result: {} });
+    });
+
     it("passes a guarded undici dispatcher to open-graph-scraper", async () => {
         ogsBehavior = () => Promise.resolve({ result: {} });
         await runFetch(makePlatform());

--- a/packages/platform-metadata/src/index.test.ts
+++ b/packages/platform-metadata/src/index.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, it, mock } from "bun:test";
+import { Agent } from "undici";
+
+// Capture the options passed to open-graph-scraper and control its outcome,
+// so we can assert the platform injects a guarded dispatcher and reports
+// errors robustly — without any network access.
+let ogsOptions: Record<string, unknown> | undefined;
+let ogsBehavior: () => Promise<{ result: Record<string, unknown> }> = () =>
+    Promise.resolve({ result: {} });
+
+mock.module("open-graph-scraper", () => ({
+    default: (options: Record<string, unknown>) => {
+        ogsOptions = options;
+        return ogsBehavior();
+    },
+}));
+
+const { default: Metadata } = await import("./index");
+
+function makePlatform(config?: Record<string, unknown>) {
+    // biome-ignore lint/suspicious/noExplicitAny: minimal fake session
+    const platform = new Metadata({ log: { debug() {} } } as any);
+    if (config) {
+        Object.assign(platform.config, config);
+    }
+    return platform;
+}
+
+function runFetch(
+    platform: ReturnType<typeof makePlatform>,
+): Promise<{ err: unknown; result: unknown }> {
+    const job = {
+        "@context": ["x"],
+        type: "fetch",
+        actor: { id: "https://example.com", type: "website" },
+    };
+    return new Promise((resolve) => {
+        // biome-ignore lint/suspicious/noExplicitAny: test job
+        platform.fetch(job as any, (err, result) => resolve({ err, result }));
+    });
+}
+
+describe("metadata fetch SSRF hardening", () => {
+    it("passes a guarded undici dispatcher to open-graph-scraper", async () => {
+        ogsBehavior = () => Promise.resolve({ result: {} });
+        await runFetch(makePlatform());
+        const fetchOptions = ogsOptions?.fetchOptions as
+            | { dispatcher?: unknown }
+            | undefined;
+        expect(fetchOptions?.dispatcher).toBeInstanceOf(Agent);
+    });
+
+    it("still passes a dispatcher when the escape hatch is enabled", async () => {
+        ogsBehavior = () => Promise.resolve({ result: {} });
+        await runFetch(makePlatform({ allowPrivateAddresses: true }));
+        const fetchOptions = ogsOptions?.fetchOptions as
+            | { dispatcher?: unknown }
+            | undefined;
+        expect(fetchOptions?.dispatcher).toBeInstanceOf(Agent);
+    });
+
+    it("reports the error from open-graph-scraper's { result } rejection", async () => {
+        ogsBehavior = () =>
+            Promise.reject({ result: { error: new Error("ogs failed") } });
+        const { err, result } = await runFetch(makePlatform());
+        expect(err).toBeInstanceOf(Error);
+        expect((err as Error).message).toEqual("ogs failed");
+        expect(result).toBeUndefined();
+    });
+
+    it("reports a plain Error rejection without throwing a TypeError", async () => {
+        ogsBehavior = () => Promise.reject(new Error("blocked non-public"));
+        const { err } = await runFetch(makePlatform());
+        expect(err).toBeInstanceOf(Error);
+        expect((err as Error).message).toMatch(/blocked non-public/);
+    });
+});

--- a/packages/platform-metadata/src/index.ts
+++ b/packages/platform-metadata/src/index.ts
@@ -6,16 +6,32 @@ import type {
     PlatformInterface,
     PlatformSession,
 } from "@sockethub/schemas";
+import { createGuardedDispatcher } from "@sockethub/util/net";
 import ogs from "open-graph-scraper";
 import { PlatformMetadataSchema } from "./schema";
 
 export default class Metadata implements PlatformInterface {
     private readonly log: Logger;
+    private dispatcher?: ReturnType<typeof createGuardedDispatcher>;
     config: PlatformConfig = {
         persist: false,
     };
     constructor(session: PlatformSession) {
         this.log = session.log;
+    }
+
+    /**
+     * The SSRF-guarded undici dispatcher, created once per instance (its
+     * `allowPrivateAddresses` setting comes from packageConfig, fixed before the
+     * first job) and reused across fetches so connections/timers are pooled.
+     */
+    private getDispatcher(): ReturnType<typeof createGuardedDispatcher> {
+        if (!this.dispatcher) {
+            this.dispatcher = createGuardedDispatcher({
+                allowPrivateAddresses: this.config.allowPrivateAddresses === true,
+            });
+        }
+        return this.dispatcher;
     }
 
     get schema() {
@@ -31,14 +47,20 @@ export default class Metadata implements PlatformInterface {
 
     fetch(job: ActivityStream, cb: PlatformCallback) {
         this.log.debug(`fetching ${job.actor.id}`);
+        // The server fetches whatever URL a client puts in actor.id, so guard
+        // it against SSRF and oversized responses. open-graph-scraper forwards
+        // `fetchOptions` to its undici fetch; the guarded dispatcher refuses to
+        // connect to private/loopback/metadata addresses (including across
+        // redirect hops) and caps the response body. The escape hatch is set
+        // via packageConfig — see the package README.
+        const dispatcher = this.getDispatcher();
         ogs({
             url: job.actor.id,
             // open-graph-scraper *replaces* (does not merge) the default URL
             // validator settings, so we restate the defaults and only relax
             // require_tld. This lets the scraper accept TLD-less hosts such as
-            // `localhost` and intranet names. Note: the default validator already
-            // accepts bare IPs, so this does not introduce a new SSRF class on its
-            // own — see the SSRF hardening tracked separately.
+            // `localhost` and intranet names. Private/loopback destinations are
+            // blocked at the connection layer by the guarded dispatcher above.
             urlValidatorSettings: {
                 allow_fragments: true,
                 allow_protocol_relative_urls: false,
@@ -53,6 +75,8 @@ export default class Metadata implements PlatformInterface {
                 require_valid_protocol: true,
                 validate_length: true,
             },
+            // biome-ignore lint/suspicious/noExplicitAny: ogs fetchOptions dispatcher
+            fetchOptions: { dispatcher } as any,
         })
             .then((data) => {
                 const { result } = data;
@@ -72,12 +96,20 @@ export default class Metadata implements PlatformInterface {
                 cb(null, job);
             })
             .catch((data) => {
-                const { result } = data;
-                cb(result.error);
+                // open-graph-scraper rejects with { error, result }, but a
+                // dispatcher/abort failure can reject with a plain Error. Handle
+                // both so the real error is reported rather than throwing a
+                // TypeError on `result.error`.
+                const err =
+                    data?.result?.error ??
+                    (data instanceof Error ? data : new Error(String(data)));
+                cb(err instanceof Error ? err : new Error(String(err)));
             });
     }
 
     cleanup(cb: PlatformCallback) {
+        // Release the guarded dispatcher's pooled connections on shutdown.
+        this.dispatcher?.close().catch(() => {});
         cb();
     }
 }

--- a/packages/platform-metadata/src/index.ts
+++ b/packages/platform-metadata/src/index.ts
@@ -28,7 +28,8 @@ export default class Metadata implements PlatformInterface {
     private getDispatcher(): ReturnType<typeof createGuardedDispatcher> {
         if (!this.dispatcher) {
             this.dispatcher = createGuardedDispatcher({
-                allowPrivateAddresses: this.config.allowPrivateAddresses === true,
+                allowPrivateAddresses:
+                    this.config.allowPrivateAddresses === true,
             });
         }
         return this.dispatcher;

--- a/packages/schemas/src/config-validator.test.ts
+++ b/packages/schemas/src/config-validator.test.ts
@@ -46,6 +46,30 @@ describe("validateSockethubConfig", () => {
         ).not.toEqual("");
     });
 
+    it("accepts the metadata allowPrivateAddresses boolean", () => {
+        expect(
+            validateSockethubConfig({
+                ...base,
+                packageConfig: {
+                    "@sockethub/platform-metadata": {
+                        allowPrivateAddresses: true,
+                    },
+                },
+            }),
+        ).toEqual("");
+    });
+
+    it("rejects an unknown key in the metadata packageConfig entry", () => {
+        expect(
+            validateSockethubConfig({
+                ...base,
+                packageConfig: {
+                    "@sockethub/platform-metadata": { bogus: true },
+                },
+            }),
+        ).not.toEqual("");
+    });
+
     it("rejects an unknown top-level key", () => {
         expect(validateSockethubConfig({ ...base, nope: 1 })).not.toEqual("");
     });

--- a/packages/schemas/src/schemas/sockethub-config.ts
+++ b/packages/schemas/src/schemas/sockethub-config.ts
@@ -84,6 +84,13 @@ export const SockethubConfigSchema = {
                         connectTimeoutMs: { type: "number" },
                     },
                 },
+                "@sockethub/platform-metadata": {
+                    type: "object",
+                    additionalProperties: false,
+                    properties: {
+                        allowPrivateAddresses: { type: "boolean" },
+                    },
+                },
             },
         },
         credentialCheck: {

--- a/packages/util/package.json
+++ b/packages/util/package.json
@@ -1,0 +1,54 @@
+{
+  "name": "@sockethub/util",
+  "description": "Shared utilities for Sockethub (networking/SSRF helpers, etc.)",
+  "version": "1.0.0-alpha.0",
+  "type": "module",
+  "private": false,
+  "author": "Nick Jennings <nick@silverbucket.net>",
+  "license": "MIT",
+  "publishConfig": {
+    "access": "public"
+  },
+  "main": "dist/index.js",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js",
+      "default": "./dist/index.js"
+    },
+    "./net": {
+      "types": "./dist/net/index.d.ts",
+      "import": "./dist/net/index.js",
+      "default": "./dist/net/index.js"
+    }
+  },
+  "files": [
+    "dist/"
+  ],
+  "engines": {
+    "node": ">=20"
+  },
+  "keywords": [
+    "sockethub",
+    "ssrf",
+    "networking",
+    "utilities"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/sockethub/sockethub.git",
+    "directory": "packages/util"
+  },
+  "homepage": "https://github.com/sockethub/sockethub/tree/master/packages/util",
+  "scripts": {
+    "build": "bun build src/index.ts src/net/index.ts --outdir dist --target node --format esm --sourcemap=external --external undici",
+    "clean": "rm -rf dist",
+    "clean:deps": "rm -rf node_modules"
+  },
+  "dependencies": {
+    "undici": "^7.19.0"
+  },
+  "devDependencies": {
+    "@types/bun": "latest"
+  }
+}

--- a/packages/util/src/index.ts
+++ b/packages/util/src/index.ts
@@ -1,0 +1,1 @@
+export * from "./net/index.js";

--- a/packages/util/src/net/address.test.ts
+++ b/packages/util/src/net/address.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from "bun:test";
+
+import { isBlockedAddress } from "./address.js";
+
+describe("isBlockedAddress", () => {
+    it("blocks IPv4 loopback (127.0.0.0/8)", () => {
+        expect(isBlockedAddress("127.0.0.1")).toBe(true);
+        expect(isBlockedAddress("127.255.255.254")).toBe(true);
+    });
+
+    it("blocks private IPv4 ranges", () => {
+        expect(isBlockedAddress("10.0.0.1")).toBe(true);
+        expect(isBlockedAddress("172.16.5.4")).toBe(true);
+        expect(isBlockedAddress("172.31.255.255")).toBe(true);
+        expect(isBlockedAddress("192.168.1.1")).toBe(true);
+    });
+
+    it("blocks link-local and metadata addresses", () => {
+        expect(isBlockedAddress("169.254.1.1")).toBe(true);
+        expect(isBlockedAddress("169.254.169.254")).toBe(true);
+    });
+
+    it("blocks 0.0.0.0 and carrier-grade NAT", () => {
+        expect(isBlockedAddress("0.0.0.0")).toBe(true);
+        expect(isBlockedAddress("100.64.0.1")).toBe(true);
+        expect(isBlockedAddress("100.127.255.255")).toBe(true);
+    });
+
+    it("blocks IPv6 loopback and unique/link-local", () => {
+        expect(isBlockedAddress("::1")).toBe(true);
+        expect(isBlockedAddress("fc00::1")).toBe(true);
+        expect(isBlockedAddress("fd12:3456::1")).toBe(true);
+        expect(isBlockedAddress("fe80::1")).toBe(true);
+    });
+
+    it("blocks IPv4-mapped IPv6 private addresses in every spelling", () => {
+        expect(isBlockedAddress("::ffff:127.0.0.1")).toBe(true);
+        expect(isBlockedAddress("::ffff:7f00:1")).toBe(true);
+        expect(isBlockedAddress("0:0:0:0:0:ffff:7f00:1")).toBe(true);
+        expect(isBlockedAddress("::FFFF:7F00:1")).toBe(true);
+        expect(isBlockedAddress("::ffff:169.254.169.254")).toBe(true);
+    });
+
+    it("blocks IPv4-compatible and NAT64 embeddings", () => {
+        expect(isBlockedAddress("::7f00:1")).toBe(true);
+        expect(isBlockedAddress("64:ff9b::7f00:1")).toBe(true);
+    });
+
+    it("blocks unparseable literals conservatively", () => {
+        expect(isBlockedAddress("not-an-ip")).toBe(true);
+        expect(isBlockedAddress("999.1.1.1")).toBe(true);
+    });
+
+    it("does not block representative public addresses", () => {
+        expect(isBlockedAddress("8.8.8.8")).toBe(false);
+        expect(isBlockedAddress("1.1.1.1")).toBe(false);
+        expect(isBlockedAddress("2606:4700:4700::1111")).toBe(false);
+        expect(isBlockedAddress("::ffff:8.8.8.8")).toBe(false);
+        expect(isBlockedAddress("64:ff9b::8.8.8.8")).toBe(false);
+    });
+});

--- a/packages/util/src/net/address.ts
+++ b/packages/util/src/net/address.ts
@@ -1,0 +1,130 @@
+/**
+ * IP address classification for SSRF defense. Used to decide whether a server
+ * fetching client-supplied URLs may connect to a given resolved address.
+ */
+
+/**
+ * Returns true if `ip` is a loopback, private, link-local, or otherwise
+ * non-public address that should not be reachable by a server fetching
+ * client-supplied URLs (SSRF defense). Handles IPv4, IPv6, and IPv4-mapped
+ * IPv6 addresses.
+ */
+export function isBlockedAddress(ip: string): boolean {
+    const addr = ip.trim().toLowerCase();
+
+    if (addr.includes(":")) {
+        return isBlockedIpv6(addr);
+    }
+
+    return isBlockedIpv4(addr);
+}
+
+function isBlockedIpv4(ip: string): boolean {
+    const parts = ip.split(".").map((p) => Number(p));
+    if (
+        parts.length !== 4 ||
+        parts.some((p) => !Number.isInteger(p) || p < 0 || p > 255)
+    ) {
+        // Not a parseable IPv4 literal; block conservatively.
+        return true;
+    }
+    const [a, b] = parts;
+    // 0.0.0.0/8 ("this network", commonly routes to localhost)
+    if (a === 0) return true;
+    // 127.0.0.0/8 loopback
+    if (a === 127) return true;
+    // 10.0.0.0/8 private
+    if (a === 10) return true;
+    // 172.16.0.0/12 private
+    if (a === 172 && b >= 16 && b <= 31) return true;
+    // 192.168.0.0/16 private
+    if (a === 192 && b === 168) return true;
+    // 169.254.0.0/16 link-local (incl. 169.254.169.254 cloud metadata)
+    if (a === 169 && b === 254) return true;
+    // 100.64.0.0/10 carrier-grade NAT shared address space
+    if (a === 100 && b >= 64 && b <= 127) return true;
+    return false;
+}
+
+/**
+ * Expand an IPv6 literal (lowercased, zone index already stripped) to its
+ * eight 16-bit groups, or null if unparseable. A trailing dotted-quad
+ * (e.g. ::ffff:127.0.0.1) is converted to two hex groups first, so every
+ * notation of the same address normalizes identically.
+ */
+function expandIpv6(address: string): Array<number> | null {
+    let addr = address;
+    const dotted = addr.match(/^(.+:)(\d{1,3}(?:\.\d{1,3}){3})$/);
+    if (dotted) {
+        const octets = dotted[2].split(".").map(Number);
+        if (octets.some((o) => !Number.isInteger(o) || o < 0 || o > 255)) {
+            return null;
+        }
+        const hi = ((octets[0] << 8) | octets[1]).toString(16);
+        const lo = ((octets[2] << 8) | octets[3]).toString(16);
+        addr = `${dotted[1]}${hi}:${lo}`;
+    }
+
+    const halves = addr.split("::");
+    if (halves.length > 2) return null;
+    const head = halves[0] ? halves[0].split(":") : [];
+    const tail = halves.length === 2 && halves[1] ? halves[1].split(":") : [];
+    if (halves.length === 2 ? head.length + tail.length > 8 : head.length !== 8)
+        return null;
+    const groupsStr =
+        halves.length === 2
+            ? [
+                  ...head,
+                  ...new Array(8 - head.length - tail.length).fill("0"),
+                  ...tail,
+              ]
+            : head;
+
+    const groups: Array<number> = [];
+    for (const group of groupsStr) {
+        if (!/^[0-9a-f]{1,4}$/.test(group)) return null;
+        groups.push(Number.parseInt(group, 16));
+    }
+    return groups;
+}
+
+/**
+ * If the expanded IPv6 groups embed an IPv4 address — IPv4-mapped
+ * (::ffff:0:0/96), deprecated IPv4-compatible (::/96, which also covers
+ * `::`/`::1`), or the NAT64 well-known prefix (64:ff9b::/96) — return it in
+ * dotted-quad form so IPv4 rules apply; otherwise return null.
+ */
+function extractEmbeddedIpv4(groups: Array<number>): string | null {
+    const [a, b, c, d, e, f, g, h] = groups;
+    const zeroPrefix = a === 0 && b === 0 && c === 0 && d === 0 && e === 0;
+    const mapped = zeroPrefix && f === 0xffff;
+    const compat = zeroPrefix && f === 0;
+    const nat64 =
+        a === 0x64 && b === 0xff9b && c === 0 && d === 0 && e === 0 && f === 0;
+    if (!mapped && !compat && !nat64) return null;
+    return `${g >> 8}.${g & 0xff}.${h >> 8}.${h & 0xff}`;
+}
+
+function isBlockedIpv6(ip: string): boolean {
+    // Strip zone index (e.g. fe80::1%eth0).
+    const addr = ip.split("%")[0];
+    // Normalize to 8 groups so hex/dotted/compressed/uppercase spellings of
+    // the same address are classified identically (e.g. ::ffff:7f00:1 and
+    // ::ffff:127.0.0.1 are both IPv4-mapped loopback).
+    const groups = expandIpv6(addr);
+    if (!groups) {
+        // Not a parseable IPv6 literal; block conservatively.
+        return true;
+    }
+    // Embedded IPv4 (mapped/compat/NAT64) -> apply IPv4 rules. This also
+    // covers :: (0.0.0.0) and ::1 (0.0.0.1), both within blocked 0.0.0.0/8.
+    const embedded = extractEmbeddedIpv4(groups);
+    if (embedded) {
+        return isBlockedIpv4(embedded);
+    }
+    // fc00::/7 unique-local.
+    if ((groups[0] & 0xfe00) === 0xfc00) return true;
+    // fe80::/10 link-local.
+    if ((groups[0] & 0xffc0) === 0xfe80) return true;
+    return false;
+}

--- a/packages/util/src/net/dispatcher.test.ts
+++ b/packages/util/src/net/dispatcher.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it } from "bun:test";
+import { Agent } from "undici";
+
+import {
+    createGuardedDispatcher,
+    createGuardedLookup,
+} from "./dispatcher.js";
+
+// The guarded lookup is the SSRF decision point. It is tested directly (rather
+// than through an end-to-end fetch) because the Bun test runner intercepts
+// `fetch` and ignores undici dispatchers; production code paths run on Node,
+// where undici honors the dispatcher's `connect.lookup`. IP-literal hosts are
+// resolved by dns.lookup without a network query, so these are deterministic.
+
+function runLookup(
+    allowPrivate: boolean,
+    host: string,
+): Promise<{ err: Error | null; addresses?: Array<{ address: string }> }> {
+    return new Promise((resolve) => {
+        createGuardedLookup(allowPrivate)(
+            host,
+            { all: true },
+            (err, addresses) => {
+                resolve({
+                    err: err ?? null,
+                    addresses: addresses as Array<{ address: string }>,
+                });
+            },
+        );
+    });
+}
+
+describe("createGuardedLookup", () => {
+    it("blocks a loopback IPv4 literal", async () => {
+        const { err } = await runLookup(false, "127.0.0.1");
+        expect(err).toBeInstanceOf(Error);
+        expect(err?.message).toMatch(/blocked non-public address 127\.0\.0\.1/);
+    });
+
+    it("blocks the cloud metadata address", async () => {
+        const { err } = await runLookup(false, "169.254.169.254");
+        expect(err?.message).toMatch(/blocked non-public address/);
+    });
+
+    it("blocks an IPv4-mapped IPv6 loopback literal", async () => {
+        const { err } = await runLookup(false, "::ffff:7f00:1");
+        expect(err).toBeInstanceOf(Error);
+    });
+
+    it("allows a public address", async () => {
+        const { err, addresses } = await runLookup(false, "8.8.8.8");
+        expect(err).toBeNull();
+        expect(addresses?.[0]?.address).toEqual("8.8.8.8");
+    });
+
+    it("allows a loopback address when the escape hatch is enabled", async () => {
+        const { err, addresses } = await runLookup(true, "127.0.0.1");
+        expect(err).toBeNull();
+        expect(addresses?.[0]?.address).toEqual("127.0.0.1");
+    });
+});
+
+describe("createGuardedDispatcher", () => {
+    it("constructs an undici Agent without throwing", () => {
+        // Behavior (lookup blocking, size cap) is exercised in production via
+        // undici on Node; the Bun runner's undici Agent is a stub, so only
+        // construction is asserted here.
+        const dispatcher = createGuardedDispatcher({
+            allowPrivateAddresses: true,
+            maxResponseBytes: 1024,
+        });
+        expect(dispatcher).toBeInstanceOf(Agent);
+    });
+});

--- a/packages/util/src/net/dispatcher.ts
+++ b/packages/util/src/net/dispatcher.ts
@@ -1,0 +1,101 @@
+import { lookup as dnsLookup } from "node:dns";
+import { Agent } from "undici";
+import { isBlockedAddress } from "./address.js";
+
+/** Default response-body cap (5 MiB) applied by a guarded dispatcher. */
+export const DEFAULT_MAX_RESPONSE_BYTES = 5 * 1024 * 1024;
+
+export interface GuardedDispatcherOptions {
+    /**
+     * When true, skip the private/loopback destination checks. Dev/test escape
+     * hatch only — never enable on a server that accepts untrusted requests.
+     */
+    allowPrivateAddresses?: boolean;
+    /** Cap on response body size in bytes. Defaults to 5 MiB. */
+    maxResponseBytes?: number;
+}
+
+// Node's net `lookup` callback shapes: single-address (all=false) and
+// all-addresses (all=true). undici/net may request either form.
+type LookupAddress = { address: string; family: number };
+type LookupOptions = { all?: boolean } & Record<string, unknown>;
+type LookupCallback = (
+    err: NodeJS.ErrnoException | null,
+    address?: string | Array<LookupAddress>,
+    family?: number,
+) => void;
+
+/**
+ * A DNS lookup that resolves a hostname and rejects the connection if any
+ * resolved address is private/loopback/blocked. Because this runs at the
+ * connection layer, it validates the address actually being connected to —
+ * including on every redirect hop — closing the check-then-fetch (TOCTOU)
+ * rebinding gap that a pre-fetch URL check leaves open.
+ *
+ * Exported for direct unit testing: the Bun test runner intercepts `fetch` and
+ * ignores undici dispatchers, so the lookup decision is verified here rather
+ * than through an end-to-end fetch.
+ */
+export function createGuardedLookup(allowPrivateAddresses: boolean) {
+    return (
+        hostname: string,
+        options: LookupOptions | number,
+        callback: LookupCallback,
+    ): void => {
+        const opts: LookupOptions =
+            typeof options === "object" && options !== null ? options : {};
+        dnsLookup(hostname, { ...opts, all: true }, (err, result) => {
+            if (err) {
+                callback(err);
+                return;
+            }
+            const addresses = result as unknown as Array<LookupAddress>;
+            if (!allowPrivateAddresses) {
+                for (const { address } of addresses) {
+                    if (isBlockedAddress(address)) {
+                        callback(
+                            new Error(
+                                `blocked non-public address ${address} for ${hostname}`,
+                            ),
+                        );
+                        return;
+                    }
+                }
+            }
+            if (opts.all) {
+                callback(null, addresses);
+            } else {
+                callback(null, addresses[0].address, addresses[0].family);
+            }
+        });
+    };
+}
+
+/**
+ * Build an undici {@link Agent} that defends a server fetching client-supplied
+ * URLs against SSRF and memory exhaustion:
+ *
+ * - Every connection (including each redirect hop) resolves DNS and refuses to
+ *   connect to a private/loopback/link-local/metadata address (unless
+ *   `allowPrivateAddresses` is set).
+ * - Responses larger than `maxResponseBytes` are aborted.
+ *
+ * Pass the returned dispatcher to `fetch(url, { dispatcher })`, or to any
+ * library that forwards fetch options (e.g. open-graph-scraper's
+ * `fetchOptions`).
+ */
+export function createGuardedDispatcher(
+    options: GuardedDispatcherOptions = {},
+): Agent {
+    const {
+        allowPrivateAddresses = false,
+        maxResponseBytes = DEFAULT_MAX_RESPONSE_BYTES,
+    } = options;
+    return new Agent({
+        maxResponseSize: maxResponseBytes,
+        connect: {
+            // biome-ignore lint/suspicious/noExplicitAny: net lookup signature
+            lookup: createGuardedLookup(allowPrivateAddresses) as any,
+        },
+    });
+}

--- a/packages/util/src/net/dispatcher.ts
+++ b/packages/util/src/net/dispatcher.ts
@@ -1,4 +1,5 @@
-import { lookup as dnsLookup } from "node:dns";
+import { lookup as dnsLookup, type LookupAddress } from "node:dns";
+import type { LookupFunction } from "node:net";
 import { Agent } from "undici";
 import { isBlockedAddress } from "./address.js";
 
@@ -15,10 +16,10 @@ export interface GuardedDispatcherOptions {
     maxResponseBytes?: number;
 }
 
-// Node's net `lookup` callback shapes: single-address (all=false) and
-// all-addresses (all=true). undici/net may request either form.
-type LookupAddress = { address: string; family: number };
-type LookupOptions = { all?: boolean } & Record<string, unknown>;
+type LookupOptions = { all?: boolean; family?: number } & Record<
+    string,
+    unknown
+>;
 type LookupCallback = (
     err: NodeJS.ErrnoException | null,
     address?: string | Array<LookupAddress>,
@@ -36,20 +37,31 @@ type LookupCallback = (
  * ignores undici dispatchers, so the lookup decision is verified here rather
  * than through an end-to-end fetch.
  */
-export function createGuardedLookup(allowPrivateAddresses: boolean) {
+export function createGuardedLookup(
+    allowPrivateAddresses: boolean,
+): LookupFunction {
     return (
         hostname: string,
+        // net.connect passes a LookupOptions object; the legacy dns.lookup
+        // signature allows a numeric `family`, which we preserve.
         options: LookupOptions | number,
         callback: LookupCallback,
     ): void => {
         const opts: LookupOptions =
-            typeof options === "object" && options !== null ? options : {};
-        dnsLookup(hostname, { ...opts, all: true }, (err, result) => {
+            typeof options === "number" ? { family: options } : (options ?? {});
+        dnsLookup(hostname, { ...opts, all: true }, (err, addresses) => {
             if (err) {
                 callback(err);
                 return;
             }
-            const addresses = result as unknown as Array<LookupAddress>;
+            if (!addresses || addresses.length === 0) {
+                callback(
+                    Object.assign(new Error(`could not resolve ${hostname}`), {
+                        code: "ENOTFOUND",
+                    }),
+                );
+                return;
+            }
             if (!allowPrivateAddresses) {
                 for (const { address } of addresses) {
                     if (isBlockedAddress(address)) {
@@ -94,8 +106,7 @@ export function createGuardedDispatcher(
     return new Agent({
         maxResponseSize: maxResponseBytes,
         connect: {
-            // biome-ignore lint/suspicious/noExplicitAny: net lookup signature
-            lookup: createGuardedLookup(allowPrivateAddresses) as any,
+            lookup: createGuardedLookup(allowPrivateAddresses),
         },
     });
 }

--- a/packages/util/src/net/index.ts
+++ b/packages/util/src/net/index.ts
@@ -1,0 +1,6 @@
+export { isBlockedAddress } from "./address.js";
+export {
+    createGuardedDispatcher,
+    DEFAULT_MAX_RESPONSE_BYTES,
+    type GuardedDispatcherOptions,
+} from "./dispatcher.js";

--- a/scripts/build-types.js
+++ b/scripts/build-types.js
@@ -67,6 +67,10 @@ const packages = [
         dir: "packages/server",
         entries: ["src/index.ts", "src/platform.ts"],
     },
+    {
+        dir: "packages/util",
+        entries: ["src/index.ts", "src/net/index.ts"],
+    },
 ];
 
 const repoRoot = process.cwd();


### PR DESCRIPTION
## Problem

`platform-metadata` fetches whatever URL a client supplies in `actor.id` (via `open-graph-scraper`) with **no destination restriction and no response size cap** — the same SSRF and memory-DoS surface the feeds platform had (#1133), and explicitly *widened*: it relaxes `require_tld` so `localhost`/intranet hosts pass, and the default validator already accepts bare IPs. A client could make the server fetch `http://169.254.169.254/`, `http://127.0.0.1/`, or internal services; undici also follows redirects, so a public URL can redirect to a private IP. The code even carried a comment noting "the SSRF hardening tracked separately."

(The inbound/outbound schemas were already hardened in #1136 + strict responses, and ogs applies a default 10s timeout — so those feeds issues don't apply here.)

## Approach

Feeds owns its `fetch()` and wraps it, but metadata's fetch happens *inside* ogs. ogs forwards `fetchOptions` to its `undici.fetch`, so the fix injects a custom undici **dispatcher** — one Agent that solves both problems and is stronger than feeds' current check-then-fetch:

- **`connect.lookup`** validates the address actually being connected to, on every redirect hop — no check-then-fetch (TOCTOU) rebinding gap.
- **`maxResponseSize`** aborts oversized responses before they're read.

## Changes

- **New `@sockethub/util`** package (general shared utilities; `net` module for now). Exposes `isBlockedAddress` (private/loopback/link-local/CGNAT/metadata across all IPv4/IPv6 spellings — mapped/compat/NAT64/hex) and `createGuardedDispatcher({ allowPrivateAddresses, maxResponseBytes })`. `undici` is an external dep (single shared copy) so the Agent is compatible with ogs's undici.
- **platform-metadata**: passes the guarded dispatcher to ogs via `fetchOptions`; reads `allowPrivateAddresses` from `packageConfig['@sockethub/platform-metadata']` (added to the config schema, validated at startup); dispatcher is memoized per instance and closed on cleanup; the error handler now tolerates both ogs's `{result.error}` shape and plain `Error` rejections (previously a plain Error threw a `TypeError` in the catch).
- **CI**: the integration metadata fixture is served from loopback, so `integration/sockethub.ci.config.json` enables the metadata escape hatch (same mechanism as feeds).

## Testing notes

Bun's test runner intercepts `fetch` and ignores undici dispatchers, so the dispatcher's SSRF decision is unit-tested at the **lookup** layer (deterministic, no network) rather than end-to-end; the real dispatcher runs on Node via ogs's undici. Address classification, the guarded lookup (block/allow/escape-hatch), metadata's dispatcher injection, and the hardened error path are all covered.

- `@sockethub/util` — 15 pass. `platform-metadata` — 11 pass. `schemas` — 50 pass (incl. metadata packageConfig validation). `server` config — 20 pass. Builds + lint + typecheck clean.

## Follow-up

A companion PR migrates **platform-feeds** onto the same `@sockethub/util` dispatcher, which closes feeds' residual DNS-rebinding TOCTOU window and removes its bespoke streaming-cap/redirect code.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Metadata fetching now includes SSRF and resource-exhaustion protections, plus a configurable escape hatch to allow private/loopback addresses.
  * Fetches enforce a response size cap to limit large responses.

* **Documentation**
  * Updated metadata platform docs to describe the guarded connection behavior and error cases.

* **Tests**
  * Added test coverage for guarded networking and metadata fetch error handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->