### PR TITLE
feat(util): shared error helpers + guarded safeFetch

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -239,6 +239,7 @@
         "@sockethub/data-layer": "^1.0.0-alpha.12",
         "@sockethub/logger": "^1.0.0-alpha.12",
         "@sockethub/schemas": "^3.0.0-alpha.12",
+        "@sockethub/util": "^1.0.0-alpha.0",
         "body-parser": "^1.20.4",
         "chalk": "^5.6.2",
         "convict": "^6.2.5",

--- a/packages/platform-feeds/src/index.ts
+++ b/packages/platform-feeds/src/index.ts
@@ -26,7 +26,8 @@ import type {
     PlatformSession,
 } from "@sockethub/schemas";
 import { buildCanonicalContext } from "@sockethub/schemas";
-import { createGuardedDispatcher } from "@sockethub/util/net";
+import { errorMessage } from "@sockethub/util/error";
+import { createGuardedDispatcher, safeFetch } from "@sockethub/util/net";
 import htmlTags from "html-tags";
 import getPodcastFromFeed, { type Episode, type Meta } from "podparse";
 
@@ -160,39 +161,13 @@ export default class Feeds implements PlatformInterface {
     }
 
     private async makeRequest(url: string): Promise<string> {
-        // Reject non-http(s) schemes (and malformed URLs) before fetching; the
-        // guarded dispatcher then blocks private/loopback destinations at the
-        // connection layer (including across redirect hops) and caps the body
-        // size — see @sockethub/util/net.
-        let parsed: URL;
-        try {
-            parsed = new URL(url);
-        } catch {
-            throw new Error(`feed request failed: invalid URL ${url}`);
-        }
-        if (parsed.protocol !== "http:" && parsed.protocol !== "https:") {
-            throw new Error(
-                `feed request failed: unsupported scheme ${parsed.protocol} for ${url}`,
-            );
-        }
-
-        const opts: RequestInit & { dispatcher?: unknown } = {
+        // safeFetch validates the scheme, routes through the guarded dispatcher
+        // (blocks private/loopback destinations at the connection layer on every
+        // redirect hop, caps the body), and throws on a non-2xx response.
+        const res = await safeFetch(url, {
             dispatcher: this.getDispatcher(),
-        };
-        if (this.config.connectTimeoutMs) {
-            opts.signal = AbortSignal.timeout(this.config.connectTimeoutMs);
-        }
-        const res = await fetch(url, opts as RequestInit);
-
-        if (!res.ok) {
-            await res.body?.cancel().catch(() => {});
-            // HTTP/2 has no reason phrases, so statusText may be empty.
-            const statusText = res.statusText ? ` ${res.statusText}` : "";
-            throw new Error(
-                `feed request failed: ${res.status}${statusText} for ${url}`,
-            );
-        }
-
+            timeoutMs: this.config.connectTimeoutMs,
+        });
         return await res.text();
     }
 
@@ -216,9 +191,8 @@ export default class Feeds implements PlatformInterface {
                 article.object = buildFeedItem(item, url);
                 articles.push(article);
             } catch (err) {
-                const detail = err instanceof Error ? err.message : String(err);
                 throw new Error(
-                    `Failed to parse feed entry ${index + 1} from ${url}: ${detail}`,
+                    `Failed to parse feed entry ${index + 1} from ${url}: ${errorMessage(err)}`,
                     { cause: err },
                 );
             }

--- a/packages/platform-feeds/src/index.ts
+++ b/packages/platform-feeds/src/index.ts
@@ -27,7 +27,11 @@ import type {
 } from "@sockethub/schemas";
 import { buildCanonicalContext } from "@sockethub/schemas";
 import { errorMessage } from "@sockethub/util/error";
-import { createGuardedDispatcher, safeFetch } from "@sockethub/util/net";
+import {
+    createGuardedDispatcher,
+    redactUrl,
+    safeFetch,
+} from "@sockethub/util/net";
 import htmlTags from "html-tags";
 import getPodcastFromFeed, { type Episode, type Meta } from "podparse";
 
@@ -192,7 +196,7 @@ export default class Feeds implements PlatformInterface {
                 articles.push(article);
             } catch (err) {
                 throw new Error(
-                    `Failed to parse feed entry ${index + 1} from ${url}: ${errorMessage(err)}`,
+                    `Failed to parse feed entry ${index + 1} from ${redactUrl(url)}: ${errorMessage(err)}`,
                     { cause: err },
                 );
             }

--- a/packages/platform-metadata/src/index.ts
+++ b/packages/platform-metadata/src/index.ts
@@ -6,6 +6,7 @@ import type {
     PlatformInterface,
     PlatformSession,
 } from "@sockethub/schemas";
+import { toError } from "@sockethub/util/error";
 import { createGuardedDispatcher } from "@sockethub/util/net";
 import ogs from "open-graph-scraper";
 import { PlatformMetadataSchema } from "./schema";
@@ -101,10 +102,7 @@ export default class Metadata implements PlatformInterface {
                 // dispatcher/abort failure can reject with a plain Error. Handle
                 // both so the real error is reported rather than throwing a
                 // TypeError on `result.error`.
-                const err =
-                    data?.result?.error ??
-                    (data instanceof Error ? data : new Error(String(data)));
-                cb(err instanceof Error ? err : new Error(String(err)));
+                cb(toError(data?.result?.error ?? data));
             });
     }
 

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -56,6 +56,7 @@
     "@sockethub/data-layer": "^1.0.0-alpha.12",
     "@sockethub/logger": "^1.0.0-alpha.12",
     "@sockethub/schemas": "^3.0.0-alpha.12",
+    "@sockethub/util": "^1.0.0-alpha.0",
     "body-parser": "^1.20.4",
     "chalk": "^5.6.2",
     "convict": "^6.2.5",

--- a/packages/server/src/bootstrap/load-platforms.ts
+++ b/packages/server/src/bootstrap/load-platforms.ts
@@ -16,6 +16,7 @@ import {
     type PlatformSession,
     validatePlatformSchema,
 } from "@sockethub/schemas";
+import { errorMessage } from "@sockethub/util/error";
 import type { Schema } from "ajv";
 
 const log = createLogger("server:bootstrap:platforms");
@@ -84,9 +85,9 @@ function resolveModulePath(platformName: string): string | undefined {
         return dirname(filePath);
     } catch (err) {
         log.warn(
-            `failed to resolve module path for ${platformName}: ${
-                err instanceof Error ? err.message : String(err)
-            }`,
+            `failed to resolve module path for ${platformName}: ${errorMessage(
+                err,
+            )}`,
         );
         return undefined;
     }

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -1,5 +1,6 @@
 import path from "node:path";
 import { createLogger, initLogger, setLoggerContext } from "@sockethub/logger";
+import { toError } from "@sockethub/util/error";
 import config from "./config";
 import Sockethub from "./sockethub";
 
@@ -34,7 +35,7 @@ export async function server() {
     try {
         sockethub = new Sockethub();
     } catch (err) {
-        const error = err instanceof Error ? err : new Error(String(err));
+        const error = toError(err);
         sentry.reportError(error);
         console.error(error);
         process.exit(1);
@@ -54,7 +55,7 @@ export async function server() {
             `${(new Date()).toUTCString()} UNHANDLED REJECTION\n`,
             err,
         );
-        sentry.reportError(err instanceof Error ? err : new Error(String(err)));
+        sentry.reportError(toError(err));
         process.exit(1);
     });
 
@@ -64,7 +65,7 @@ export async function server() {
             await sockethub.shutdown();
             process.exit(0);
         } catch (err) {
-            const error = err instanceof Error ? err : new Error(String(err));
+            const error = toError(err);
             sentry.reportError(error);
             console.error(error);
             process.exit(1);
@@ -82,7 +83,7 @@ export async function server() {
     try {
         await sockethub.boot();
     } catch (err) {
-        const error = err instanceof Error ? err : new Error(String(err));
+        const error = toError(err);
         sentry.reportError(error);
         console.error(error);
         process.exit(1);

--- a/packages/server/src/middleware/credential-check.ts
+++ b/packages/server/src/middleware/credential-check.ts
@@ -6,6 +6,7 @@ import {
 } from "@sockethub/data-layer";
 import { createLogger } from "@sockethub/logger";
 import { type ActivityStream, resolvePlatformId } from "@sockethub/schemas";
+import { toError } from "@sockethub/util/error";
 import type { MiddlewareNext } from "../middleware.js";
 import { platformInstances } from "../platform-instance.js";
 
@@ -78,7 +79,7 @@ export default function credentialCheck(
                         err.toString(),
                     );
                 }
-                next(err instanceof Error ? err : new Error(String(err)));
+                next(toError(err));
             });
     };
 }

--- a/packages/server/src/middleware/store-credentials.ts
+++ b/packages/server/src/middleware/store-credentials.ts
@@ -1,5 +1,6 @@
 import type { CredentialsStoreInterface } from "@sockethub/data-layer";
 import type { ActivityStream, CredentialsObject } from "@sockethub/schemas";
+import { toError } from "@sockethub/util/error";
 
 import type { MiddlewareChainInterface } from "../middleware.js";
 
@@ -13,11 +14,9 @@ export default function storeCredentials(store: CredentialsStoreInterface) {
             store
                 .save(credentials.actor.id, credentials)
                 .then(() => done(creds))
-                .catch((err) =>
-                    done(err instanceof Error ? err : new Error(String(err))),
-                );
+                .catch((err) => done(toError(err)));
         } catch (err) {
-            done(err instanceof Error ? err : new Error(String(err)));
+            done(toError(err));
         }
     };
 }

--- a/packages/server/src/platform-instance.ts
+++ b/packages/server/src/platform-instance.ts
@@ -15,6 +15,7 @@ import {
     INTERNAL_PLATFORM_CONTEXT_URL,
     validateActivityStreamResponse,
 } from "@sockethub/schemas";
+import { errorMessage } from "@sockethub/util/error";
 import config from "./config.js";
 import { getSocket } from "./listener.js";
 import { __dirname } from "./util.js";
@@ -397,9 +398,9 @@ export default class PlatformInstance {
     /**
      * Sends error message to client and clears all references to this class.
      * @param sessionId
-     * @param errorMessage
+     * @param message
      */
-    private async reportError(sessionId: string, errorMessage: string) {
+    private async reportError(sessionId: string, message: string) {
         const errorObject: ActivityStream = {
             "@context": buildCanonicalContext(
                 this.contextUrl ?? INTERNAL_PLATFORM_CONTEXT_URL,
@@ -408,7 +409,7 @@ export default class PlatformInstance {
             // Global platforms have no `this.actor`; fall back to the platform
             // name so the error always carries a valid (id-bearing) actor.
             actor: { id: this.actor ?? this.name, type: "service" },
-            error: errorMessage,
+            error: message,
         };
 
         // Only attempt to send to client if we have a valid session
@@ -418,9 +419,7 @@ export default class PlatformInstance {
             }
         } catch (err) {
             this.log.error(
-                `Failed to send error to client: ${
-                    err instanceof Error ? err.message : String(err)
-                }`,
+                `Failed to send error to client: ${errorMessage(err)}`,
             );
         }
 

--- a/packages/server/src/platform.ts
+++ b/packages/server/src/platform.ts
@@ -30,6 +30,7 @@ import {
     buildCanonicalContext,
     INTERNAL_PLATFORM_CONTEXT_URL,
 } from "@sockethub/schemas";
+import { errorMessage, toError } from "@sockethub/util/error";
 import config from "./config";
 
 // Simple wrapper function to help with testing
@@ -140,9 +141,9 @@ async function startPlatformProcess() {
             );
         } catch (err) {
             logger.warn(
-                `ignoring invalid SOCKETHUB_PLATFORM_CONFIG: ${
-                    err instanceof Error ? err.message : String(err)
-                }`,
+                `ignoring invalid SOCKETHUB_PLATFORM_CONFIG: ${errorMessage(
+                    err,
+                )}`,
             );
         }
         logger.info(
@@ -183,11 +184,7 @@ async function startPlatformProcess() {
                 process.send(message);
             } catch (ipcErr) {
                 console.error(
-                    `Failed to report error via IPC: ${
-                        ipcErr instanceof Error
-                            ? ipcErr.message
-                            : String(ipcErr)
-                    }`,
+                    `Failed to report error via IPC: ${errorMessage(ipcErr)}`,
                 );
             }
         } else {
@@ -326,18 +323,16 @@ async function startPlatformProcess() {
                     jobCallbackCalled = true;
                     if (err) {
                         jobLog.error(`failed ${job.title} ${job.msg.type}`);
-                        let errMsg: string | Error;
+                        let message: string;
                         // some error objects (e.g. TimeoutError) don't interpolate correctly
                         // to being human-readable, so we have to do this little dance
                         try {
-                            errMsg = err.toString();
+                            message = err.toString();
                         } catch (err) {
-                            errMsg = err instanceof Error ? err : String(err);
+                            message = errorMessage(err);
                         }
-                        const errorMessage =
-                            errMsg instanceof Error ? errMsg.message : errMsg;
-                        sentry.reportError(new Error(errorMessage));
-                        reject(new Error(errorMessage));
+                        sentry.reportError(new Error(message));
+                        reject(new Error(message));
                     } else {
                         jobLog.debug(`completed ${job.title} ${job.msg.type}`);
 
@@ -440,18 +435,10 @@ async function startPlatformProcess() {
                              */
                             if (platform.isInitialized()) {
                                 // Platform already running - reject job only, preserve platform instance
-                                doneCallback(
-                                    err instanceof Error
-                                        ? err
-                                        : new Error(String(err)),
-                                    null,
-                                );
+                                doneCallback(toError(err), null);
                             } else {
                                 // Platform not initialized - terminate platform process
-                                const error =
-                                    err instanceof Error
-                                        ? err
-                                        : new Error(String(err));
+                                const error = toError(err);
                                 sentry.reportError(error);
                                 reject(error);
                             }
@@ -482,8 +469,7 @@ async function startPlatformProcess() {
                             doneCallback,
                         );
                     } catch (err) {
-                        const error =
-                            err instanceof Error ? err : new Error(String(err));
+                        const error = toError(err);
                         jobLog.error(
                             `platform call failed ${error.toString()}`,
                         );

--- a/packages/server/src/platform.ts
+++ b/packages/server/src/platform.ts
@@ -328,7 +328,8 @@ async function startPlatformProcess() {
                         // to being human-readable, so we have to do this little dance
                         try {
                             message = err.toString();
-                        } catch (err) {
+                        } catch {
+                            // toString() failed; fall back to the original error.
                             message = errorMessage(err);
                         }
                         sentry.reportError(new Error(message));

--- a/packages/server/src/sockethub.ts
+++ b/packages/server/src/sockethub.ts
@@ -12,6 +12,7 @@ import {
     resolvePlatformId,
     SOCKETHUB_BASE_CONTEXT_URL,
 } from "@sockethub/schemas";
+import { errorMessage } from "@sockethub/util/error";
 import type { Socket } from "socket.io";
 import getInitObject from "./bootstrap/init.js";
 import type { PlatformMap } from "./bootstrap/load-platforms.js";
@@ -40,12 +41,12 @@ function attachError<T extends ActivityStream | ActivityObject>(
     err: unknown,
     msg?: T,
 ) {
-    const errorMessage = err instanceof Error ? err.message : String(err);
+    const message = errorMessage(err);
     if (!msg) {
-        return new Error(errorMessage);
+        return new Error(message);
     }
 
-    const cleaned = { ...msg, error: errorMessage } as T & {
+    const cleaned = { ...msg, error: message } as T & {
         sessionSecret?: string;
     };
     if ("sessionSecret" in cleaned) {
@@ -378,11 +379,8 @@ class Sockethub {
                             }
                         } catch (err) {
                             // Queue is closed (platform terminating) - send error to client
-                            const errorMessage =
-                                err instanceof Error
-                                    ? err.message
-                                    : String(err);
-                            msg.error = errorMessage || "platform unavailable";
+                            msg.error =
+                                errorMessage(err) || "platform unavailable";
                             next(msg);
                         }
                     },

--- a/packages/util/package.json
+++ b/packages/util/package.json
@@ -20,6 +20,11 @@
       "types": "./dist/net/index.d.ts",
       "import": "./dist/net/index.js",
       "default": "./dist/net/index.js"
+    },
+    "./error": {
+      "types": "./dist/error/index.d.ts",
+      "import": "./dist/error/index.js",
+      "default": "./dist/error/index.js"
     }
   },
   "files": [
@@ -41,7 +46,7 @@
   },
   "homepage": "https://github.com/sockethub/sockethub/tree/master/packages/util",
   "scripts": {
-    "build": "bun build src/index.ts src/net/index.ts --outdir dist --target node --format esm --sourcemap=external --external undici",
+    "build": "bun build src/index.ts src/net/index.ts src/error/index.ts --outdir dist --target node --format esm --sourcemap=external --external undici",
     "clean": "rm -rf dist",
     "clean:deps": "rm -rf node_modules"
   },

--- a/packages/util/src/error/index.test.ts
+++ b/packages/util/src/error/index.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from "bun:test";
+
+import { errorMessage, toError } from "./index.js";
+
+describe("toError", () => {
+    it("returns the same Error instance unchanged", () => {
+        const err = new Error("boom");
+        expect(toError(err)).toBe(err);
+    });
+
+    it("wraps a string", () => {
+        const err = toError("nope");
+        expect(err).toBeInstanceOf(Error);
+        expect(err.message).toEqual("nope");
+    });
+
+    it("wraps non-string values via String()", () => {
+        expect(toError(42).message).toEqual("42");
+        expect(toError(undefined).message).toEqual("undefined");
+        expect(toError({ a: 1 }).message).toEqual("[object Object]");
+    });
+
+    it("preserves Error subclasses", () => {
+        class CustomError extends Error {}
+        const err = new CustomError("x");
+        expect(toError(err)).toBe(err);
+        expect(toError(err)).toBeInstanceOf(CustomError);
+    });
+});
+
+describe("errorMessage", () => {
+    it("returns the message of an Error", () => {
+        expect(errorMessage(new Error("hello"))).toEqual("hello");
+    });
+
+    it("stringifies non-Error values", () => {
+        expect(errorMessage("plain")).toEqual("plain");
+        expect(errorMessage(7)).toEqual("7");
+        expect(errorMessage(null)).toEqual("null");
+    });
+});

--- a/packages/util/src/error/index.ts
+++ b/packages/util/src/error/index.ts
@@ -1,0 +1,22 @@
+/**
+ * Normalize an unknown thrown/rejected value into an `Error`. Replaces the
+ * repeated `x instanceof Error ? x : new Error(String(x))` idiom so error
+ * handling is consistent across packages.
+ */
+export function toError(value: unknown): Error {
+    if (value instanceof Error) {
+        return value;
+    }
+    return new Error(errorMessage(value));
+}
+
+/**
+ * Extract a human-readable message from an unknown thrown/rejected value.
+ * Returns the `Error.message` for `Error` instances, otherwise `String(value)`.
+ */
+export function errorMessage(value: unknown): string {
+    if (value instanceof Error) {
+        return value.message;
+    }
+    return String(value);
+}

--- a/packages/util/src/index.ts
+++ b/packages/util/src/index.ts
@@ -1,1 +1,2 @@
+export * from "./error/index.js";
 export * from "./net/index.js";

--- a/packages/util/src/net/fetch.test.ts
+++ b/packages/util/src/net/fetch.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from "bun:test";
+
+import { safeFetch } from "./fetch.js";
+
+// The fetch/dispatcher path runs on Node (the Bun runner ignores undici
+// dispatchers), so it is validated in integration. Here we cover the
+// pre-connect validation gate, which is pure and deterministic.
+
+describe("safeFetch validation gate", () => {
+    it("rejects an unsupported scheme before connecting", async () => {
+        await expect(safeFetch("ftp://example.com/x")).rejects.toThrow(
+            /unsupported scheme/,
+        );
+    });
+
+    it("rejects a malformed URL before connecting", async () => {
+        await expect(safeFetch("not a url")).rejects.toThrow(/invalid URL/);
+    });
+});

--- a/packages/util/src/net/fetch.ts
+++ b/packages/util/src/net/fetch.ts
@@ -1,0 +1,67 @@
+import type { Agent } from "undici";
+import { createGuardedDispatcher } from "./dispatcher.js";
+import { assertHttpUrl } from "./url.js";
+
+export interface SafeFetchOptions {
+    /**
+     * Skip the private/loopback destination checks. Dev/test escape hatch only.
+     * Ignored when an explicit `dispatcher` is provided.
+     */
+    allowPrivateAddresses?: boolean;
+    /** Response body cap in bytes. Ignored when `dispatcher` is provided. */
+    maxResponseBytes?: number;
+    /** Per-request timeout (applied via AbortSignal.timeout). */
+    timeoutMs?: number;
+    /**
+     * A pre-built guarded dispatcher to reuse (for connection pooling across
+     * requests). When omitted, a guarded dispatcher is created per call from
+     * `allowPrivateAddresses`/`maxResponseBytes`.
+     */
+    dispatcher?: Agent;
+    /** Extra request headers. */
+    headers?: Record<string, string>;
+}
+
+/**
+ * SSRF- and resource-guarded outbound fetch for client-supplied URLs:
+ *
+ * - rejects non-`http(s)` schemes and malformed URLs before connecting;
+ * - routes the request through a guarded undici dispatcher that refuses
+ *   private/loopback/metadata destinations (every redirect hop) and caps the
+ *   response body;
+ * - applies an optional timeout and throws on a non-2xx response.
+ *
+ * Returns the `Response` (read the body with `.text()`/`.json()`/etc.).
+ */
+export async function safeFetch(
+    url: string,
+    options: SafeFetchOptions = {},
+): Promise<Response> {
+    assertHttpUrl(url);
+
+    const dispatcher =
+        options.dispatcher ??
+        createGuardedDispatcher({
+            allowPrivateAddresses: options.allowPrivateAddresses,
+            maxResponseBytes: options.maxResponseBytes,
+        });
+
+    const init: RequestInit & { dispatcher?: unknown } = { dispatcher };
+    if (options.timeoutMs) {
+        init.signal = AbortSignal.timeout(options.timeoutMs);
+    }
+    if (options.headers) {
+        init.headers = options.headers;
+    }
+
+    const res = await fetch(url, init as RequestInit);
+    if (!res.ok) {
+        // Drain the unused body so the keep-alive connection is returned to the
+        // pool instead of leaking until GC.
+        await res.body?.cancel().catch(() => {});
+        // HTTP/2 has no reason phrases, so statusText may be empty.
+        const statusText = res.statusText ? ` ${res.statusText}` : "";
+        throw new Error(`request failed: ${res.status}${statusText} for ${url}`);
+    }
+    return res;
+}

--- a/packages/util/src/net/fetch.ts
+++ b/packages/util/src/net/fetch.ts
@@ -1,6 +1,6 @@
 import type { Agent } from "undici";
 import { createGuardedDispatcher } from "./dispatcher.js";
-import { assertHttpUrl } from "./url.js";
+import { assertHttpUrl, redactUrl } from "./url.js";
 
 export interface SafeFetchOptions {
     /**
@@ -47,7 +47,7 @@ export async function safeFetch(
         });
 
     const init: RequestInit & { dispatcher?: unknown } = { dispatcher };
-    if (options.timeoutMs) {
+    if (options.timeoutMs !== undefined && options.timeoutMs > 0) {
         init.signal = AbortSignal.timeout(options.timeoutMs);
     }
     if (options.headers) {
@@ -61,7 +61,9 @@ export async function safeFetch(
         await res.body?.cancel().catch(() => {});
         // HTTP/2 has no reason phrases, so statusText may be empty.
         const statusText = res.statusText ? ` ${res.statusText}` : "";
-        throw new Error(`request failed: ${res.status}${statusText} for ${url}`);
+        throw new Error(
+            `request failed: ${res.status}${statusText} for ${redactUrl(url)}`,
+        );
     }
     return res;
 }

--- a/packages/util/src/net/index.ts
+++ b/packages/util/src/net/index.ts
@@ -4,3 +4,5 @@ export {
     DEFAULT_MAX_RESPONSE_BYTES,
     type GuardedDispatcherOptions,
 } from "./dispatcher.js";
+export { safeFetch, type SafeFetchOptions } from "./fetch.js";
+export { assertHttpUrl, isHttpUrl } from "./url.js";

--- a/packages/util/src/net/index.ts
+++ b/packages/util/src/net/index.ts
@@ -4,5 +4,5 @@ export {
     DEFAULT_MAX_RESPONSE_BYTES,
     type GuardedDispatcherOptions,
 } from "./dispatcher.js";
-export { safeFetch, type SafeFetchOptions } from "./fetch.js";
-export { assertHttpUrl, isHttpUrl } from "./url.js";
+export { type SafeFetchOptions, safeFetch } from "./fetch.js";
+export { assertHttpUrl, isHttpUrl, redactUrl } from "./url.js";

--- a/packages/util/src/net/url.test.ts
+++ b/packages/util/src/net/url.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "bun:test";
 
-import { assertHttpUrl, isHttpUrl } from "./url.js";
+import { assertHttpUrl, isHttpUrl, redactUrl } from "./url.js";
 
 describe("assertHttpUrl", () => {
     it("accepts http and https URLs", () => {
@@ -19,6 +19,36 @@ describe("assertHttpUrl", () => {
 
     it("rejects malformed URLs", () => {
         expect(() => assertHttpUrl("not a url")).toThrow(/invalid URL/);
+    });
+
+    it("redacts credentials from error messages", () => {
+        try {
+            assertHttpUrl("ftp://user:secret@example.com");
+            throw new Error("should have thrown");
+        } catch (err) {
+            const msg = (err as Error).message;
+            expect(msg).not.toMatch(/secret/);
+            expect(msg).not.toMatch(/user:/);
+            expect(msg).toMatch(/example\.com/);
+        }
+    });
+});
+
+describe("redactUrl", () => {
+    it("strips userinfo from a URL", () => {
+        expect(redactUrl("https://user:pass@example.com/x")).toEqual(
+            "https://example.com/x",
+        );
+    });
+
+    it("leaves credential-free URLs unchanged", () => {
+        expect(redactUrl("https://example.com/x")).toEqual(
+            "https://example.com/x",
+        );
+    });
+
+    it("best-effort redacts userinfo in unparseable input", () => {
+        expect(redactUrl("//user:pass@host/x")).toMatch(/\/\/\*\*\*@host/);
     });
 });
 

--- a/packages/util/src/net/url.test.ts
+++ b/packages/util/src/net/url.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from "bun:test";
+
+import { assertHttpUrl, isHttpUrl } from "./url.js";
+
+describe("assertHttpUrl", () => {
+    it("accepts http and https URLs", () => {
+        expect(assertHttpUrl("http://example.com/x").protocol).toEqual("http:");
+        expect(assertHttpUrl("https://example.com").protocol).toEqual("https:");
+    });
+
+    it("rejects non-http schemes", () => {
+        expect(() => assertHttpUrl("ftp://example.com")).toThrow(
+            /unsupported scheme/,
+        );
+        expect(() => assertHttpUrl("file:///etc/passwd")).toThrow(
+            /unsupported scheme/,
+        );
+    });
+
+    it("rejects malformed URLs", () => {
+        expect(() => assertHttpUrl("not a url")).toThrow(/invalid URL/);
+    });
+});
+
+describe("isHttpUrl", () => {
+    it("is true for http(s) URLs and false otherwise", () => {
+        expect(isHttpUrl("https://example.com")).toBe(true);
+        expect(isHttpUrl("http://example.com")).toBe(true);
+        expect(isHttpUrl("ftp://example.com")).toBe(false);
+        expect(isHttpUrl("garbage")).toBe(false);
+    });
+});

--- a/packages/util/src/net/url.ts
+++ b/packages/util/src/net/url.ts
@@ -1,17 +1,38 @@
 /**
+ * Strip any `user:password@` userinfo from a URL so it is safe to include in
+ * error messages, logs, or telemetry. Best-effort for unparseable input.
+ */
+export function redactUrl(url: string): string {
+    try {
+        const parsed = new URL(url);
+        if (parsed.username || parsed.password) {
+            parsed.username = "";
+            parsed.password = "";
+            return parsed.toString();
+        }
+        return url;
+    } catch {
+        return url.replace(/\/\/[^/@\s]*@/, "//***@");
+    }
+}
+
+/**
  * Parse `url` and require an `http:`/`https:` scheme, returning the parsed
- * `URL`. Throws a descriptive `Error` on a malformed URL or unsupported scheme.
- * Used to gate outbound fetches of client-supplied URLs.
+ * `URL`. Throws a descriptive `Error` (with credentials redacted) on a
+ * malformed URL or unsupported scheme. Used to gate outbound fetches of
+ * client-supplied URLs.
  */
 export function assertHttpUrl(url: string): URL {
     let parsed: URL;
     try {
         parsed = new URL(url);
     } catch {
-        throw new Error(`invalid URL: ${url}`);
+        throw new Error(`invalid URL: ${redactUrl(url)}`);
     }
     if (parsed.protocol !== "http:" && parsed.protocol !== "https:") {
-        throw new Error(`unsupported scheme ${parsed.protocol} for ${url}`);
+        throw new Error(
+            `unsupported scheme ${parsed.protocol} for ${redactUrl(url)}`,
+        );
     }
     return parsed;
 }

--- a/packages/util/src/net/url.ts
+++ b/packages/util/src/net/url.ts
@@ -1,0 +1,27 @@
+/**
+ * Parse `url` and require an `http:`/`https:` scheme, returning the parsed
+ * `URL`. Throws a descriptive `Error` on a malformed URL or unsupported scheme.
+ * Used to gate outbound fetches of client-supplied URLs.
+ */
+export function assertHttpUrl(url: string): URL {
+    let parsed: URL;
+    try {
+        parsed = new URL(url);
+    } catch {
+        throw new Error(`invalid URL: ${url}`);
+    }
+    if (parsed.protocol !== "http:" && parsed.protocol !== "https:") {
+        throw new Error(`unsupported scheme ${parsed.protocol} for ${url}`);
+    }
+    return parsed;
+}
+
+/** Returns true if `url` parses and uses an `http:`/`https:` scheme. */
+export function isHttpUrl(url: string): boolean {
+    try {
+        assertHttpUrl(url);
+        return true;
+    } catch {
+        return false;
+    }
+}

--- a/scripts/build-types.js
+++ b/scripts/build-types.js
@@ -69,7 +69,7 @@ const packages = [
     },
     {
         dir: "packages/util",
-        entries: ["src/index.ts", "src/net/index.ts"],
+        entries: ["src/index.ts", "src/net/index.ts", "src/error/index.ts"],
     },
 ];
 


### PR DESCRIPTION
> Stacked on #1139 (feeds → `@sockethub/util` dispatcher) — its commits appear in this diff until it merges, after which this rebases to just the helper changes. Implements options A, B, C from the shared-util review.

## A — error helpers (`@sockethub/util/error`)

`toError(unknown): Error` and `errorMessage(unknown): string` replace the `x instanceof Error ? x : new Error(String(x))` idiom that recurs across the codebase (~22 occurrences in 12 files). This PR adopts them in the two platforms touched here; the broader server-wide sweep (7 files, one local-variable name clash to resolve) is a clean mechanical follow-up.

## B/C — URL validation + guarded `safeFetch` (`@sockethub/util/net`)

- `assertHttpUrl(url)` / `isHttpUrl(url)` — parse + require `http(s)` (C).
- `safeFetch(url, opts)` — SSRF/resource-guarded outbound fetch built on the guarded dispatcher (B): validates the scheme, routes through the connection-time SSRF guard (blocks private/loopback/metadata on every redirect hop), caps the body, applies an optional timeout, and throws on non-2xx. Accepts a pre-built `dispatcher` for connection pooling.

## Adoption

- **platform-feeds** `makeRequest` collapses its scheme-check + `fetch(dispatcher)` + `res.ok` boilerplate into a single `safeFetch(...)` call (passing its memoized dispatcher), and uses `errorMessage()`.
- **platform-metadata** error handler uses `toError()`.

## Wiring

New entry points added to the package `exports` map and `scripts/build-types.js` so `dist/error/index.d.ts`, `dist/net/url.d.ts`, and `dist/net/fetch.d.ts` are generated.

## Verification

`@sockethub/util` 27 tests (error, url, safeFetch validation gate, address, dispatcher); feeds 37; metadata 11. Builds + biome lint clean. (Note: `tsc --noEmit` on platforms can't resolve `@sockethub/util/*` subpaths under the repo's classic `moduleResolution: "node"` — a pre-existing local-only limitation that also affects the already-merged metadata import; bun resolves the `exports` map and CI does not gate on platform `tsc`.)

## Server-wide adoption

The `toError`/`errorMessage` idiom is replaced across the server package too — 16 sites in 7 files (platform.ts, platform-instance.ts, sockethub.ts, index.ts, both credential middlewares, load-platforms). Behavior-preserving; legitimate `instanceof Error` type guards are left in place, and two local `errorMessage` bindings were renamed to avoid shadowing the import. Server suite: 140 pass.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `safeFetch` for guarded HTTP(S)-only requests with optional timeouts, response-size limits, and consistent handling of non-success responses.
  * Added URL safety helpers (`redactUrl`, HTTP(S) validation) and standardized error helpers (`toError`, `errorMessage`).
  * Expanded the util package exports to include the new error helpers.
* **Refactor**
  * Updated feed/metadata and server/platform flows to use shared error normalization and safer, human-readable error messaging (with redacted URLs).
* **Tests**
  * Added Bun coverage for `safeFetch`, URL helpers, and error normalization.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
