### PR TITLE
fix(platform-irc): never send bare NAMES on attendance query

### DIFF
--- a/packages/platform-irc/src/index.test.ts
+++ b/packages/platform-irc/src/index.test.ts
@@ -500,18 +500,74 @@ describe("Initialize IRC Platform", () => {
                 platform.completeJob();
             });
 
-            it("query()", (done) => {
-                platform.query(
-                    {
-                        "@context": IRC_CONTEXT,
-                        type: "query",
-                        actor: actor,
-                        target: targetRoom,
-                        object: { type: "attendance" },
-                    },
-                    done,
-                );
-                platform.completeJob();
+            describe("query() attendance", () => {
+                let rawCalls;
+                beforeEach(() => {
+                    rawCalls = [];
+                    platform.client.raw = (...args) => {
+                        rawCalls.push(args);
+                    };
+                });
+
+                it("sends NAMES for the target channel name", (done) => {
+                    platform.query(
+                        {
+                            "@context": IRC_CONTEXT,
+                            type: "query",
+                            actor: actor,
+                            target: targetRoom,
+                            object: { type: "attendance" },
+                        },
+                        (err) => {
+                            expect(err).toBeUndefined();
+                            expect(rawCalls).toEqual([[["NAMES", "#a-room"]]]);
+                            done();
+                        },
+                    );
+                });
+
+                it("derives the channel from target.id when name is missing", (done) => {
+                    platform.query(
+                        {
+                            "@context": IRC_CONTEXT,
+                            type: "query",
+                            actor: actor,
+                            target: {
+                                type: "room",
+                                id: "irc.example.com/#a-room",
+                            },
+                            object: { type: "attendance" },
+                        },
+                        (err) => {
+                            expect(err).toBeUndefined();
+                            expect(rawCalls).toEqual([[["NAMES", "#a-room"]]]);
+                            done();
+                        },
+                    );
+                });
+
+                // Regression coverage for sockethub/sockethub#1085: a query
+                // with no resolvable channel must error rather than emit a
+                // bare `NAMES`, which the server answers with the entire
+                // network channel list (presence flood for unjoined rooms).
+                it("rejects without sending a bare NAMES when no channel resolves", (done) => {
+                    platform.query(
+                        {
+                            "@context": IRC_CONTEXT,
+                            type: "query",
+                            actor: actor,
+                            target: { type: "room", id: "irc.example.com/" },
+                            object: { type: "attendance" },
+                        },
+                        (err) => {
+                            expect(err).toEqual(
+                                "cannot query attendance without a valid channel name",
+                            );
+                            expect(rawCalls).toEqual([]);
+                            done();
+                        },
+                    );
+                });
             });
 
             it("disconnect()", (done) => {

--- a/packages/platform-irc/src/index.ts
+++ b/packages/platform-irc/src/index.ts
@@ -20,6 +20,7 @@ import net from "node:net";
 import tls from "node:tls";
 import { IrcToActivityStreams } from "@sockethub/irc2as";
 import type {
+    ActivityActor,
     ActivityStream,
     Logger,
     PersistentPlatformConfig,
@@ -340,10 +341,18 @@ export class IRC implements PersistentPlatformInterface {
             }
 
             if (job.object.type === "attendance") {
-                this.log.debug(
-                    `query() - sending NAMES for ${job.target.name}`,
-                );
-                client.raw(["NAMES", job.target.name]);
+                const channel = this.resolveChannelName(job.target);
+                if (!channel) {
+                    // Never emit a bare `NAMES` (no channel argument): IRC
+                    // servers answer it with the entire network channel list,
+                    // flooding the client with presence for rooms it never
+                    // joined. See sockethub/sockethub#1085.
+                    return done(
+                        "cannot query attendance without a valid channel name",
+                    );
+                }
+                this.log.debug(`query() - sending NAMES for ${channel}`);
+                client.raw(["NAMES", channel]);
                 done();
             } else {
                 done(`unknown 'type' '${job.object.type}'`);
@@ -377,6 +386,28 @@ export class IRC implements PersistentPlatformInterface {
     //
     // Private methods
     //
+    /**
+     * Resolve an IRC channel name from a job target. Prefers `target.name`,
+     * falling back to the channel segment of `target.id` (`<server>/<channel>`).
+     * Returns undefined when no valid `#channel` can be determined, so callers
+     * never emit a bare `NAMES` command (which floods the client with the
+     * server's entire channel list).
+     */
+    private resolveChannelName(target?: ActivityActor): string | undefined {
+        if (typeof target?.name === "string" && target.name.startsWith("#")) {
+            return target.name;
+        }
+        if (typeof target?.id === "string") {
+            const slash = target.id.indexOf("/");
+            const candidate =
+                slash >= 0 ? target.id.slice(slash + 1) : target.id;
+            if (candidate.startsWith("#")) {
+                return candidate;
+            }
+        }
+        return undefined;
+    }
+
     private isJoined(channel: string) {
         if (channel.indexOf("#") === 0) {
             // valid channel name


### PR DESCRIPTION
## Summary

Fixes the IRC presence flood in #1085. An attendance `query` whose target carried only an `id` (no `name`) caused the platform to emit a **bare `NAMES`** command, which IRC servers answer with the entire network channel list — flooding the client with presence for rooms it never joined.

`query()` now resolves the channel from `target.name`, falling back to the channel segment of `target.id` (`<server>/<channel>`), and **rejects the query when no valid `#channel` can be determined**, so a bare `NAMES` is never sent.

## How it happened

- `query()` built the command as `client.raw(["NAMES", job.target.name])`.
- Clients that send `target: { id, type: "room" }` without `name` (e.g. Hyperchannel's `queryAttendance`, see 67P/hyperchannel#312) leave `target.name` undefined.
- `["NAMES", undefined].join(" ")` → `"NAMES "` → bare NAMES → server returns `353` for every visible channel → `irc2as` emits a presence per user per channel → all forwarded to the client.

Deriving from `target.id` means the flood is prevented even for clients that only send an id.

## Changes

- `packages/platform-irc/src/index.ts`: add `resolveChannelName()`; guard `query()` against an unresolvable channel.
- `packages/platform-irc/src/index.test.ts`: regression coverage — NAMES from `target.name`, channel derived from `target.id`, and rejection without a bare NAMES when no channel resolves.

## Verification

- `bun test packages/platform-irc/` → 84 pass / 0 fail
- `bun run build` (platform-irc) succeeds; biome clean

## Notes

Defense-in-depth filtering of inbound presence by joined channels was considered but deferred: with the bare-NAMES source closed and nothing in the stack issuing `WHO`, its marginal value is low while it risks dropping the legitimate initial `353` that arrives after a `JOIN` (membership is recorded only on the subsequent `PING`/`PONG`). Can follow up if wanted.

Closes #1085


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Expanded test coverage for attendance query functionality, including channel name resolution scenarios and error cases.

* **Bug Fixes**
  * Improved channel name resolution for attendance queries with better error handling when valid channels cannot be determined.
  * Added logging for resolved channel names to aid in debugging.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->