### PR TITLE
fix(platform-irc): explicit TLS cert validation + working self-signed opt-out

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -152,7 +152,7 @@
       "version": "4.0.0-alpha.12",
       "dependencies": {
         "@sockethub/irc2as": "^4.0.0-alpha.12",
-        "irc-socket-sasl": "^4.1.1",
+        "irc-socket-sasl": "^4.1.2",
       },
       "devDependencies": {
         "@sockethub/schemas": "^3.0.0-alpha.12",
@@ -2333,7 +2333,7 @@
 
     "ipaddr.js": ["ipaddr.js@1.9.1", "", {}, "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g=="],
 
-    "irc-socket-sasl": ["irc-socket-sasl@4.1.1", "", { "dependencies": { "r-result": "^1.5.1" } }, "sha512-uqCSRFu61VUfRAhYit6tOgX7Ln2FEJqiGQLYhB0HMEWnWQ5fMcWAFhefggu7Q+PjdLlP5dOPOiw6Z50J5tE0Ew=="],
+    "irc-socket-sasl": ["irc-socket-sasl@4.1.2", "", {}, "sha512-ioBVPtvQE3bBNZAqLF8XnWj4/pSEsGvsrq2j8OErDScc3Xvwf/9kmUFLdOrEY7YqugwPmkloVKH7UQngtkUOlQ=="],
 
     "is-alphabetical": ["is-alphabetical@2.0.1", "", {}, "sha512-FWyyY60MeTNyeSRpkM2Iry0G9hpr7/9kD40mD/cGQEuilcZYS4okz8SN2Q6rLCJ8gbCt6fN+rC+6tMGS99LaxQ=="],
 
@@ -3090,8 +3090,6 @@
     "quick-lru": ["quick-lru@5.1.1", "", {}, "sha512-WuyALRjWPDGtt/wzJiadO5AXY+8hZ80hVpe6MyivgraREW751X3SbhRvG3eLKOYN+8VEvqLcf3wdnt44Z4S4SA=="],
 
     "quote-unquote": ["quote-unquote@1.0.0", "", {}, "sha512-twwRO/ilhlG/FIgYeKGFqyHhoEhqgnKVkcmqMKi2r524gz3ZbDTcyFt38E9xjJI2vT+KbRNHVbnJ/e0I25Azwg=="],
-
-    "r-result": ["r-result@1.5.1", "", {}, "sha512-L5dlAU3rNZCcdEXC1xQzzSGgcTma0x/v4KiihuQ1s0E800pdX5mzLyfRJmSRS61Z4ITan4No/dNsDkxjYJDkPA=="],
 
     "railroad-diagrams": ["railroad-diagrams@1.0.0", "", {}, "sha512-cz93DjNeLY0idrCNOH6PviZGRN9GJhsdm9hpn1YCS879fj4W+x5IFJhhkRZcwVgMmFF7R82UA/7Oh+R8lLZg6A=="],
 

--- a/packages/platform-irc/README.md
+++ b/packages/platform-irc/README.md
@@ -222,6 +222,10 @@ Authenticated connections use SASL. Two mechanisms are supported:
 
 `password` and `token` are mutually exclusive. Both default to SASL PLAIN;
 set `saslMechanism: "OAUTHBEARER"` explicitly for OAuth 2.0 bearer tokens.
+Secure connections validate the IRC server's TLS certificate by default. The
+optional `allowInvalidCert` field defaults to `false`; when set to `true`, it
+disables TLS certificate validation for secure connections. Use this
+security-relevant opt-out only for trusted self-signed IRC networks.
 
 ### Credentials with password (SASL PLAIN)
 

--- a/packages/platform-irc/package.json
+++ b/packages/platform-irc/package.json
@@ -46,7 +46,7 @@
   },
   "dependencies": {
     "@sockethub/irc2as": "^4.0.0-alpha.12",
-    "irc-socket-sasl": "^4.1.1"
+    "irc-socket-sasl": "^4.1.2"
   },
   "devDependencies": {
     "@sockethub/schemas": "^3.0.0-alpha.12",

--- a/packages/platform-irc/src/index.test.ts
+++ b/packages/platform-irc/src/index.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it } from "bun:test";
+import { beforeEach, describe, expect, it, mock } from "bun:test";
 
 import {
     type ActivityStream,
@@ -12,7 +12,38 @@ import {
 } from "@sockethub/schemas";
 import type { GetClientCallback } from "./index";
 
-import IRC from "./index";
+let capturedIrcSocketOptions:
+    | { connectOptions?: { rejectUnauthorized: boolean } }
+    | undefined;
+
+mock.module("irc-socket-sasl", () => ({
+    default: class FakeIrcSocket {
+        constructor(options: {
+            connectOptions?: { rejectUnauthorized: boolean };
+        }) {
+            capturedIrcSocketOptions = options;
+        }
+
+        connect() {
+            return Promise.resolve({
+                isFail: () => false,
+                fail: () => "",
+                ok: () => true,
+                end: () => {},
+            });
+        }
+
+        once() {}
+
+        end() {}
+
+        raw() {}
+
+        on() {}
+    },
+}));
+
+const { default: IRC, flattenConnectOptions } = await import("./index");
 
 const actor = {
     type: "person",
@@ -225,6 +256,39 @@ describe("Initialize IRC Platform", () => {
                     },
                 }),
             ).toEqual("");
+        });
+
+        it("valid credentials with allowInvalidCert", () => {
+            expect(
+                validateCredentials({
+                    "@context": IRC_CONTEXT,
+                    type: "credentials",
+                    actor,
+                    object: {
+                        type: "credentials",
+                        nick: "testingham",
+                        server: "irc.example.com",
+                        allowInvalidCert: true,
+                    },
+                }),
+            ).toEqual("");
+        });
+
+        it("rejects non-boolean allowInvalidCert", () => {
+            const result = validateCredentials({
+                "@context": IRC_CONTEXT,
+                type: "credentials",
+                actor,
+                object: {
+                    type: "credentials",
+                    nick: "testingham",
+                    server: "irc.example.com",
+                    // @ts-expect-error test invalid params
+                    allowInvalidCert: "yes",
+                },
+            });
+            expect(result).toContain("/object/allowInvalidCert");
+            expect(result).toContain("must be boolean");
         });
 
         it("rejects unknown saslMechanism", () => {
@@ -597,5 +661,95 @@ describe("Initialize IRC Platform", () => {
                 });
             });
         });
+    });
+});
+
+describe("ircConnect TLS certificate validation", () => {
+    let platform;
+
+    beforeEach(() => {
+        capturedIrcSocketOptions = undefined;
+        platform = new IRC({
+            log: {
+                error: () => {},
+                warn: () => {},
+                info: () => {},
+                debug: () => {},
+            },
+            updateActor: function async() {
+                return Promise.resolve();
+            },
+            sendToClient: () => {},
+        });
+    });
+
+    const connect = (credentials) =>
+        new Promise((resolve, reject) => {
+            platform.ircConnect(credentials, (err) => {
+                if (err) {
+                    reject(new Error(String(err)));
+                    return;
+                }
+                resolve(undefined);
+            });
+        });
+
+    it("validates secure server certificates by default", async () => {
+        await connect({
+            ...validCredentials,
+            object: {
+                ...validCredentials.object,
+                secure: true,
+            },
+        });
+
+        expect(
+            capturedIrcSocketOptions?.connectOptions?.rejectUnauthorized,
+        ).toEqual(true);
+    });
+
+    it("allows explicit invalid certificate opt-out for secure connections", async () => {
+        await connect({
+            ...validCredentials,
+            object: {
+                ...validCredentials.object,
+                secure: true,
+                allowInvalidCert: true,
+            },
+        });
+
+        expect(
+            capturedIrcSocketOptions?.connectOptions?.rejectUnauthorized,
+        ).toEqual(false);
+    });
+
+    it("does not set TLS connect options for cleartext connections", async () => {
+        await connect({
+            ...validCredentials,
+            object: {
+                ...validCredentials.object,
+                secure: false,
+            },
+        });
+
+        expect(capturedIrcSocketOptions?.connectOptions).toBeUndefined();
+    });
+});
+
+describe("TLS connect option flattening", () => {
+    it("copies inherited rejectUnauthorized into an own property", () => {
+        const inheritedOptions = Object.create({
+            rejectUnauthorized: false,
+        }) as Record<string, unknown>;
+
+        const flattened = flattenConnectOptions(inheritedOptions);
+
+        expect(
+            Object.prototype.hasOwnProperty.call(
+                flattened,
+                "rejectUnauthorized",
+            ),
+        ).toEqual(true);
+        expect(flattened.rejectUnauthorized).toEqual(false);
     });
 });

--- a/packages/platform-irc/src/index.ts
+++ b/packages/platform-irc/src/index.ts
@@ -41,13 +41,14 @@ import type { PlatformIrcCredentialsObject } from "./types.js";
 export type { IrcSocketInstance } from "irc-socket-sasl";
 export type { PlatformIrcCredentialsObject } from "./types.js";
 
-// irc-socket-sasl builds the options object it passes to the transport via
-// `Object.create(connectOptions)`, which places our `rejectUnauthorized`
-// setting on the prototype rather than as an own property. Node's
-// `tls.connect` only honors `rejectUnauthorized` as an own property, so we
-// flatten the options (own + inherited) into a plain object before handing
-// them to the real TLS transport. Without this the `allowInvalidCert`
-// opt-out (and, defensively, the secure default) would be silently ignored.
+// irc-socket-sasl >=4.1.2 already flattens connectOptions into a plain
+// object before handing them to the transport (silverbucket/irc-socket-sasl#24),
+// so this is now a defensive backstop rather than the primary fix: earlier
+// versions built the options via `Object.create(connectOptions)`, which put
+// our `rejectUnauthorized` setting on the prototype rather than as an own
+// property, and Node's `tls.connect` only honors it as an own property.
+// Keeping this here means we don't depend on the installed dependency
+// version (or a future regression/fork) to get this right.
 export function flattenConnectOptions(
     options: Record<string, unknown>,
 ): Record<string, unknown> {

--- a/packages/platform-irc/src/index.ts
+++ b/packages/platform-irc/src/index.ts
@@ -18,6 +18,7 @@
 
 import net from "node:net";
 import tls from "node:tls";
+
 import { IrcToActivityStreams } from "@sockethub/irc2as";
 import type {
     ActivityActor,
@@ -39,6 +40,32 @@ import type { PlatformIrcCredentialsObject } from "./types.js";
 
 export type { IrcSocketInstance } from "irc-socket-sasl";
 export type { PlatformIrcCredentialsObject } from "./types.js";
+
+// irc-socket-sasl builds the options object it passes to the transport via
+// `Object.create(connectOptions)`, which places our `rejectUnauthorized`
+// setting on the prototype rather than as an own property. Node's
+// `tls.connect` only honors `rejectUnauthorized` as an own property, so we
+// flatten the options (own + inherited) into a plain object before handing
+// them to the real TLS transport. Without this the `allowInvalidCert`
+// opt-out (and, defensively, the secure default) would be silently ignored.
+export function flattenConnectOptions(
+    options: Record<string, unknown>,
+): Record<string, unknown> {
+    const flattened: Record<string, unknown> = {};
+    for (const key in options) {
+        flattened[key] = options[key];
+    }
+    return flattened;
+}
+
+const tlsTransport = {
+    connect(options: Record<string, unknown>, ...rest: Array<unknown>) {
+        return (tls.connect as unknown as (...args: Array<unknown>) => unknown)(
+            flattenConnectOptions(options),
+            ...rest,
+        );
+    },
+};
 
 export type GetClientCallback = (
     err: string | null,
@@ -519,7 +546,12 @@ export class IRC implements PersistentPlatformInterface {
             debug: console.log,
         };
         if (is_secure) {
-            module_options.connectOptions = { rejectUnauthorized: false };
+            // Validate the server's TLS certificate by default. Only disable
+            // validation when the caller explicitly opts in via
+            // `allowInvalidCert` (e.g. for self-signed IRC networks). See #1056.
+            module_options.connectOptions = {
+                rejectUnauthorized: !credentials.object.allowInvalidCert,
+            };
         }
         if (is_sasl) {
             module_options.saslMechanism = sasl_mechanism;
@@ -533,7 +565,10 @@ export class IRC implements PersistentPlatformInterface {
             } sasl: ${is_sasl}${is_sasl ? ` (${sasl_mechanism})` : ""}`,
         );
 
-        const client = new IrcSocket(module_options, is_secure ? tls : net);
+        const client = new IrcSocket(
+            module_options,
+            is_secure ? tlsTransport : net,
+        );
 
         const forceDisconnect = (err: string) => {
             this.forceDisconnect = true;

--- a/packages/platform-irc/src/index.ts
+++ b/packages/platform-irc/src/index.ts
@@ -52,8 +52,15 @@ export type { PlatformIrcCredentialsObject } from "./types.js";
 export function flattenConnectOptions(
     options: Record<string, unknown>,
 ): Record<string, unknown> {
-    const flattened: Record<string, unknown> = {};
+    const flattened: Record<string, unknown> = Object.create(null);
     for (const key in options) {
+        if (
+            key === "__proto__" ||
+            key === "constructor" ||
+            key === "prototype"
+        ) {
+            continue;
+        }
         flattened[key] = options[key];
     }
     return flattened;

--- a/packages/platform-irc/src/schema.ts
+++ b/packages/platform-irc/src/schema.ts
@@ -304,6 +304,9 @@ export const PlatformIrcSchema = {
                         type: "string",
                         enum: ["PLAIN", "OAUTHBEARER"],
                     },
+                    allowInvalidCert: {
+                        type: "boolean",
+                    },
                 },
             },
         },

--- a/packages/platform-irc/src/types.ts
+++ b/packages/platform-irc/src/types.ts
@@ -16,5 +16,6 @@ export interface PlatformIrcCredentialsObject extends CredentialsObject {
         secure?: boolean;
         sasl?: boolean;
         saslMechanism?: "PLAIN" | "OAUTHBEARER";
+        allowInvalidCert?: boolean;
     };
 }


### PR DESCRIPTION
## Summary

`ircConnect()` in `packages/platform-irc/src/index.ts` set `rejectUnauthorized: false` unconditionally for every secure (`secure: true`) IRC connection, so TLS sessions were encrypted but never authenticated. This change validates the server's TLS certificate by default and adds an explicit, opt-in escape hatch for self-signed networks:

- `rejectUnauthorized` is now derived from the credentials: `!credentials.object.allowInvalidCert`, defaulting to certificate validation ON.
- New optional `allowInvalidCert?: boolean` credentials field (default `false`), declared in the JSON schema (`schema.ts`), the `PlatformIrcCredentialsObject` interface (`types.ts`), and documented in the README Authentication section.
- A thin TLS transport wrapper flattens the connect options before they reach `tls.connect`. `irc-socket-sasl` builds the options object it hands to the transport with `Object.create(connectOptions)`, which places `rejectUnauthorized` on the prototype rather than as an own property; Node's `tls.connect` ignores it there, so without this wrapper neither the secure default nor the opt-out would actually take effect.

## Why this matters

Without certificate validation, a network-path attacker can present any certificate and transparently MITM a "secure" IRC connection, harvesting the SASL password or OAuth bearer token in transit (#1056, surfaced during security review of the OAUTHBEARER work). Encryption without authentication provides no protection against an active attacker. This restores the security guarantee secure connections are expected to carry, while preserving compatibility with self-signed IRC networks through an explicit, documented opt-out.

This is a behaviour change: deployments that relied on connecting to IRC servers with invalid/self-signed certificates over `secure: true` must now set `allowInvalidCert: true`. Worth a release-notes callout.

## Testing

- `bun test` in `packages/platform-irc`: 90 pass / 0 fail. New tests cover schema validation of `allowInvalidCert` (boolean accepted, non-boolean rejected), the `rejectUnauthorized` computation for secure-default / opt-out / cleartext paths, and the option-flattening regression (an inherited `rejectUnauthorized` becomes an own property).
- `bun run lint` (Biome + markdownlint) and `bun run build` pass.
- Verified end to end against a live self-signed TLS server: a default secure connection is rejected (`DEPTH_ZERO_SELF_SIGNED_CERT`), and `allowInvalidCert: true` connects successfully.

Fixes #1056


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * TLS certificate validation is now enabled by default for secure IRC connections.
  * Added an `allowInvalidCert` credential option to allow trusted self-signed certificates.

* **Documentation**
  * Updated authentication/connection docs to explain TLS certificate validation behavior and the new option.

* **Bug Fixes**
  * Secure connections now correctly apply certificate validation settings, while non-secure connections no longer include TLS options.

* **Tests**
  * Expanded coverage for `allowInvalidCert` (boolean acceptance/rejection) and secure vs non-secure TLS behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->