### PR TITLE
docs: add Cursor Cloud environment setup notes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -163,7 +163,28 @@ The startup update script already runs `bun install`. Bun is installed under
   missing, the server exits with an error. Run `bun run build` first in that case.
 - **Standard commands** (install/build/test/lint) are documented above under
   `## Development`; use those rather than ad-hoc variants.
-- **Docker is not installed in the base environment.** The IRC/XMPP integration tests
-  and `docker:*` scripts (which need `docker compose` plus the `ergo`/`prosody` images)
-  will not run without first installing Docker. The `dummy` and `feeds` platforms work
-  end-to-end with only Redis.
+- **The `dummy` and `feeds` platforms work end-to-end with only Redis.** Testing the
+  `irc` / `xmpp` platforms additionally needs the `ergo` (IRC, `:6667`) and `prosody`
+  (XMPP, `:5222`) containers.
+
+### Docker / IRC / XMPP integration testing
+
+Docker is available but the daemon is not auto-started. Start it with
+`sudo dockerd > /tmp/dockerd.log 2>&1 &` (the daemon is pre-configured for this VM:
+`fuse-overlayfs` storage driver with the `containerd-snapshotter` feature disabled — required
+for Docker 29 — and `iptables-legacy`; use `sudo` for all `docker` commands).
+
+- **Start the test servers.** Redis already runs natively on `:6379`, so start only the
+  chat servers rather than the full `docker:start:deps` (which would collide on Redis):
+  `sudo docker compose up prosody ergo -d`. This also starts `mock-oauth` (an `ergo`
+  dependency used by the IRC SASL/OAuth tests). Containers seed test account
+  `jimmy` / `passw0rd` on both servers; all integration params live in `integration/config.js`.
+- **Run the platform E2E tests** (need the sockethub server + Redis + prosody + ergo all
+  running): `bun run integration:browser` runs every XMPP and IRC browser suite. These
+  use `@web/test-runner` with headless Chrome (already installed) and are the canonical
+  end-to-end tests for IRC/XMPP.
+- **Gotcha: the examples IRC UI (`/irc`) hardcodes `secure: true`**, which forces TLS on
+  `:6697`; the `ergo` container only publishes plaintext `:6667`, so the browser examples
+  page cannot connect to the local IRC server. Use the `integration:browser:irc-*` tests
+  (which pass `secure: false`) to exercise IRC locally. The `/xmpp` examples page works
+  against local prosody.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -143,3 +143,27 @@ patterns including schema definitions, credential handling, client lifecycle, an
 
 See `docs/CONTRIBUTING.md` for the complete contributor guide including version bump rules,
 release process, and workflow details.
+
+## Cursor Cloud specific instructions
+
+The startup update script already runs `bun install`. Bun is installed under
+`~/.bun/bin` (on `PATH` via `~/.bashrc`); non-login shells may need the full path
+`~/.bun/bin/bun`.
+
+- **Redis is required** for anything touching the data layer (the server itself, and
+  the `process`/`rate-limiter`/`integration` tests). It is NOT auto-started. Start it
+  before running the app or those tests: `redis-server --daemonize yes` (verify with
+  `redis-cli ping` → `PONG`). Plain unit tests (`bun test`) do not need Redis.
+- **Run the app (dev):** `bun run dev` from the repo root. This rebuilds all packages
+  first, then starts the server with hot reload and the examples UI at
+  `http://localhost:10550` (WebSocket path `/sockethub`). A quick smoke test: open
+  `http://localhost:10550/dummy` and use the `echo` action.
+- **Examples must be built before serving.** `bun run dev` builds them for you, but if
+  you run the server bin directly with `--examples` and `packages/examples/build` is
+  missing, the server exits with an error. Run `bun run build` first in that case.
+- **Standard commands** (install/build/test/lint) are documented above under
+  `## Development`; use those rather than ad-hoc variants.
+- **Docker is not installed in the base environment.** The IRC/XMPP integration tests
+  and `docker:*` scripts (which need `docker compose` plus the `ergo`/`prosody` images)
+  will not run without first installing Docker. The `dummy` and `feeds` platforms work
+  end-to-end with only Redis.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -172,9 +172,13 @@ The startup update script already runs `bun install`. Bun is installed under
   missing, the server exits with an error. Run `bun run build` first in that case.
 - **Standard commands** (install/build/test/lint) are documented above under
   `## Development`; use those rather than ad-hoc variants.
-- **The `dummy` and `feeds` platforms work end-to-end with only Redis.** Testing the
-  `irc` / `xmpp` platforms additionally needs the `ergo` (IRC, `:6667`) and `prosody`
-  (XMPP, `:5222`) containers.
+- **The `dummy` platform works end-to-end with only Redis.** The `feeds` platform
+  also needs only Redis for public feed URLs, but fetching loopback or private
+  addresses (as in integration tests and the examples smoke test) requires
+  `SOCKETHUB_CONFIG=integration/sockethub.ci.config.json` to bypass the SSRF
+  guard — the same file `docker-compose.yml` mounts for the CI harness. Testing
+  the `irc` / `xmpp` platforms additionally needs the `ergo` (IRC, `:6667`) and
+  `prosody` (XMPP, `:5222`) containers.
 
 ### Docker / IRC / XMPP integration testing
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -31,7 +31,9 @@ Types: `feat`, `fix`, `docs`, `style`, `refactor`, `perf`, `test`, `build`, `ci`
 
 Scopes (optional): package names (`client`, `server`, `data-layer`, `schemas`, `platform-irc`,
 `platform-xmpp`, `examples`, etc.) or components (`job-queue`, `credentials`, `session`,
-`middleware`, `config`). Omit scope for cross-cutting changes.
+`middleware`, `config`). Omit scope for cross-cutting changes. **PR titles with a scope must
+use a name that has a matching `scope:*` label** — see [`.github/LABELS.md`](.github/LABELS.md).
+Commit messages are not validated the same way; only PR titles trigger auto-label CI.
 
 Breaking changes: add `!` after type/scope (e.g. `feat(client)!: remove deprecated method`).
 
@@ -42,6 +44,13 @@ PR titles follow the same conventional format. The PR title becomes the squash c
 ```
 <type>(<scope>): <description>
 ```
+
+If you include a scope, it **must** match an existing GitHub label `scope:<scope>` or the
+**Auto Label PR** CI check fails (even when lint/build/tests pass). See
+[`.github/LABELS.md`](.github/LABELS.md) for the canonical list. Omit the scope for
+cross-cutting changes (including edits to this file or other repo-wide docs).
+
+Examples: `docs: add Cursor Cloud environment setup notes`, `fix(server): handle reconnect`
 
 ### Default Branch
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Sets up the Cloud Agent development environment for Sockethub and documents durable, non-obvious startup caveats for future agents.

- Added a `## Cursor Cloud specific instructions` section to `AGENTS.md` covering: Bun install location, the required-but-not-auto-started Redis dependency, how to run the dev server + examples, the examples-must-be-built gotcha, platform setup requirements (including feeds SSRF config for loopback URLs), and Docker-based IRC/XMPP integration testing.

The startup update script is set to `bun install` (via `~/.bun/bin/bun`). Service startup (Redis, Docker daemon, containers, dev server) is intentionally left out of the update script and documented in `AGENTS.md` instead.

## Code review follow-up

Addresses CodeRabbit feedback: clarified that `feeds` is not Redis-only when fetching loopback/private URLs — it also needs `SOCKETHUB_CONFIG=integration/sockethub.ci.config.json` (the same SSRF bypass config mounted in `docker-compose.yml`).

## Environment verification

- `bun install` — dependencies installed
- `bun run build` — all packages built
- `bun run lint` — Biome + markdownlint clean
- `bun test` — 594 passed, 0 failed (39 files)
- `bun run dev` — server on `ws://localhost:10550`, all platforms loaded, Redis verified, examples served

## Hello-world test (dummy platform)

Browser → `http://localhost:10550/dummy`, entered `Hello Sockethub`, triggered `echo`, got `Sent → Response OK` with the echoed ActivityStreams payload.

## IRC + XMPP end-to-end via Docker

Installed Docker 29 (fuse-overlayfs + iptables-legacy) and started `prosody` (XMPP `:5222`), `ergo` (IRC `:6667`), and `mock-oauth`. Ran the full browser integration suite (headless Chrome via `@web/test-runner`) against the live servers — all suites pass.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-fd25f600-9b8f-4334-afa7-ef71f71c83ea"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-fd25f600-9b8f-4334-afa7-ef71f71c83ea"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated contributor and PR conventions, including required label formats based on PR title scopes and clarified commit scope validation behavior.
  * Added setup and run instructions (including a `/dummy` smoke test) and guidance for Bun installation nuances.
  * Clarified when Redis is required (integration/data-related tests) versus not (unit tests).
  * Expanded Docker-based integration testing instructions for IRC/XMPP and noted an `/irc` secure setting constraint for local coverage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->