### PR TITLE
fix(server): cap concurrent platform instances

### DIFF
--- a/packages/schemas/src/schemas/sockethub-config.ts
+++ b/packages/schemas/src/schemas/sockethub-config.ts
@@ -148,6 +148,17 @@ export const SockethubConfigSchema = {
                 },
             },
         },
+        limits: {
+            type: "object",
+            additionalProperties: false,
+            properties: {
+                maxPlatformInstances: {
+                    type: "number",
+                    minimum: 0,
+                    default: 0,
+                },
+            },
+        },
         redis: {
             type: "object",
             additionalProperties: false,

--- a/packages/server/src/config.ts
+++ b/packages/server/src/config.ts
@@ -90,6 +90,17 @@ function buildSchema(): convict.Config<Record<string, unknown>> {
             maxRequests: { format: "nat", default: 100 },
             blockDurationMs: { format: "nat", default: 5000 },
         },
+        limits: {
+            maxPlatformInstances: {
+                doc:
+                    "Upper bound on concurrently running platform instances " +
+                    "(child processes). Each persistent-platform actor forks " +
+                    "its own process, so an unbounded count is a resource " +
+                    "exhaustion risk on public instances. 0 disables the cap.",
+                format: "nat",
+                default: 0,
+            },
+        },
         credentialCheck: {
             reconnectIpSource: {
                 format: ["socket", "proxy"],

--- a/packages/server/src/process-manager.ts
+++ b/packages/server/src/process-manager.ts
@@ -1,5 +1,7 @@
 import { getPlatformId } from "@sockethub/util/crypto";
 
+import config from "./config.js";
+
 import type { IInitObject } from "./bootstrap/init.js";
 import PlatformInstance, {
     type MessageFromParent,
@@ -78,10 +80,13 @@ class ProcessManager {
     ): PlatformInstance {
         const identifier = getPlatformId(platform, actor);
         const existing = platformInstances.get(identifier);
-        const platformInstance =
-            existing && this.isProcessAlive(existing)
-                ? existing
-                : this.createPlatformInstance(identifier, platform, actor);
+        const reusable = existing && this.isProcessAlive(existing);
+        if (!reusable) {
+            this.assertInstanceCapacity(platform);
+        }
+        const platformInstance = reusable
+            ? existing
+            : this.createPlatformInstance(identifier, platform, actor);
         if (existing && existing !== platformInstance) {
             void existing.shutdown();
         }
@@ -90,6 +95,24 @@ class ProcessManager {
         }
         platformInstances.set(identifier, platformInstance);
         return platformInstance;
+    }
+
+    /**
+     * Each platform instance forks a full child process; without an upper
+     * bound, a public instance can be driven into resource exhaustion.
+     * Throws when the configured cap (`limits.maxPlatformInstances`, 0 =
+     * disabled) has been reached and a new instance would be created.
+     */
+    private assertInstanceCapacity(platform: string): void {
+        const max = Number(config.get("limits:maxPlatformInstances") ?? 0);
+        if (!Number.isFinite(max) || max <= 0) {
+            return;
+        }
+        if (platformInstances.size >= max) {
+            throw new Error(
+                `platform instance limit reached (${max}); cannot start new ${platform} instance`,
+            );
+        }
     }
 
     private isProcessAlive(platformInstance: PlatformInstance): boolean {

--- a/packages/server/src/sockethub.ts
+++ b/packages/server/src/sockethub.ts
@@ -355,12 +355,23 @@ class Sockethub {
                             next(msg);
                             return;
                         }
-                        const platformInstance = this.processManager.get(
-                            platformId,
-                            msg.actor.id,
-                            socket.id,
-                            clientIp,
-                        );
+                        let platformInstance: ReturnType<
+                            ProcessManager["get"]
+                        >;
+                        try {
+                            platformInstance = this.processManager.get(
+                                platformId,
+                                msg.actor.id,
+                                socket.id,
+                                clientIp,
+                            );
+                        } catch (err) {
+                            // e.g. limits.maxPlatformInstances reached
+                            msg.error =
+                                errorMessage(err) || "platform unavailable";
+                            next(msg);
+                            return;
+                        }
                         // job validated and queued, stores socket.io callback for when job is completed
                         try {
                             const job = await platformInstance.queue.add(


### PR DESCRIPTION
Every persistent-platform actor forks its own Node child process, and
there was no upper bound on how many could be created. On a public
instance this is a resource-exhaustion vector: enough distinct actors
(or a misbehaving client cycling credentials) exhausts memory and
Redis connections.

Adds limits.maxPlatformInstances (default 0 = disabled, preserving
current behavior). When the cap is reached, ProcessManager refuses to
fork a new instance and the client receives the request back with an
error instead of the server crashing on an unhandled throw. Reusing an
existing live instance is always allowed.