### PR TITLE
fix(server,data-layer): collision-free job titles, expire orphaned handlers

### DIFF
--- a/packages/data-layer/src/job-queue.test.ts
+++ b/packages/data-layer/src/job-queue.test.ts
@@ -123,16 +123,17 @@ describe("JobQueue", () => {
                 id: "an identifier",
             });
             expect(job).to.eql({
-                title: `${TEST_PLATFORM_ID}-an identifier`,
+                title: `${TEST_PLATFORM_ID}-0`,
                 msg: "an encrypted message",
                 sessionId: "a socket id",
             });
         });
 
-        it("uses counter when no id provided", () => {
+        it("uses counter even when an id is provided (ids may repeat)", () => {
             cryptoMocks.encrypt.returns("an encrypted message");
             let job = jobQueue.createJob("a socket id", {
                 "@context": TEST_CONTEXT,
+                id: "a reused identifier",
             });
             expect(job).to.eql({
                 title: `${TEST_PLATFORM_ID}-0`,
@@ -141,6 +142,7 @@ describe("JobQueue", () => {
             });
             job = jobQueue.createJob("a socket id", {
                 "@context": TEST_CONTEXT,
+                id: "a reused identifier",
             });
             expect(job).to.eql({
                 title: `${TEST_PLATFORM_ID}-1`,
@@ -155,7 +157,7 @@ describe("JobQueue", () => {
                 id: "an identifier",
             });
             expect(job).to.eql({
-                title: "unknown-an identifier",
+                title: "unknown-0",
                 msg: "an encrypted message",
                 sessionId: "a socket id",
             });
@@ -218,7 +220,7 @@ describe("JobQueue", () => {
         it("stores encrypted job", async () => {
             cryptoMocks.encrypt.returns("encrypted foo");
             jobQueue.queue.isPaused.returns(false);
-            const title = `${TEST_PLATFORM_ID}-an identifier`;
+            const title = `${TEST_PLATFORM_ID}-0`;
             const resultJob = {
                 title,
                 sessionId: "a socket id",

--- a/packages/data-layer/src/job-queue.ts
+++ b/packages/data-layer/src/job-queue.ts
@@ -237,7 +237,12 @@ export class JobQueue extends JobBase {
 
     private createJob(socketId: string, msg: ActivityStream): JobDataEncrypted {
         const platformId = resolvePlatformId(msg) || "unknown";
-        const title = `${platformId}-${msg.id ? msg.id : this.counter++}`;
+        // The title keys the per-instance completed-job handler registry, so
+        // it must be unique per job. Client-supplied msg.id values are not
+        // guaranteed unique (or honest); two in-flight jobs sharing a title
+        // silently overwrite each other's completion handlers, dropping or
+        // misrouting responses. Always use the internal counter.
+        const title = `${platformId}-${this.counter++}`;
         return {
             title: title,
             sessionId: socketId,

--- a/packages/server/src/platform-instance.ts
+++ b/packages/server/src/platform-instance.ts
@@ -50,6 +50,10 @@ export interface MessageFromParent extends Array<string | unknown> {
     1: unknown;
 }
 
+// Handlers for jobs that never complete are pruned after this long. Matches
+// the queue's removeOnComplete/removeOnFail age (300s) plus slack.
+const JOB_HANDLER_TTL_MS = 6 * 60 * 1000;
+
 const HEARTBEAT_INTERVAL_MS = Number(
     config.get("platformHeartbeat:intervalMs") ?? 5000,
 );
@@ -65,6 +69,8 @@ export default class PlatformInstance {
     getSocket: typeof getSocket;
     readonly global: boolean = false;
     readonly completedJobHandlers: Map<string, CompletedJobHandler> = new Map();
+    private readonly completedJobHandlerTimestamps: Map<string, number> =
+        new Map();
     config: PlatformConfig;
     contextUrl?: string;
     private initialized = false;
@@ -233,6 +239,48 @@ export default class PlatformInstance {
     }
 
     /**
+     * Register a handler to be invoked when the job with the given title
+     * completes or fails. Entries are pruned after JOB_HANDLER_TTL_MS so
+     * jobs that never produce a result (e.g. the platform process dies
+     * mid-job) don't leak handlers for the lifetime of the instance.
+     */
+    public registerCompletedJobHandler(
+        title: string,
+        handler: CompletedJobHandler,
+    ) {
+        this.pruneExpiredJobHandlers();
+        this.completedJobHandlers.set(title, handler);
+        this.completedJobHandlerTimestamps.set(title, Date.now());
+    }
+
+    private takeCompletedJobHandler(
+        title: string,
+    ): CompletedJobHandler | undefined {
+        const handler = this.completedJobHandlers.get(title);
+        if (handler) {
+            this.completedJobHandlers.delete(title);
+            this.completedJobHandlerTimestamps.delete(title);
+        }
+        return handler;
+    }
+
+    private pruneExpiredJobHandlers() {
+        const cutoff = Date.now() - JOB_HANDLER_TTL_MS;
+        for (const [
+            title,
+            registeredAt,
+        ] of this.completedJobHandlerTimestamps) {
+            if (registeredAt < cutoff) {
+                this.log.debug(
+                    `pruning expired completed-job handler ${title}`,
+                );
+                this.completedJobHandlers.delete(title);
+                this.completedJobHandlerTimestamps.delete(title);
+            }
+        }
+    }
+
+    /**
      * Register listener to be called when the process emits a message.
      * @param sessionId ID of socket connection that will receive messages from platform emits
      */
@@ -351,10 +399,9 @@ export default class PlatformInstance {
         payload = this.toExternalPayload(payload);
 
         // send result to client
-        const callback = this.completedJobHandlers.get(job.title);
+        const callback = this.takeCompletedJobHandler(job.title);
         if (callback) {
             callback(payload);
-            this.completedJobHandlers.delete(job.title);
         } else {
             this.sendToClient(job.sessionId, payload);
         }

--- a/packages/server/src/sockethub.ts
+++ b/packages/server/src/sockethub.ts
@@ -368,7 +368,7 @@ class Sockethub {
                                 msg,
                             );
                             if (job) {
-                                platformInstance.completedJobHandlers.set(
+                                platformInstance.registerCompletedJobHandler(
                                     job.title,
                                     next,
                                 );


### PR DESCRIPTION
Job titles keyed the per-instance completed-job handler registry but
were built from client-supplied msg.id when present. Reused or
colliding ids meant two in-flight jobs shared a title: the second
registration silently overwrote the first, dropping or misrouting the
first client's response. Titles now always use the queue's internal
counter.

Separately, handlers for jobs that never produce a result (platform
process dies mid-job, queue paused during teardown) were never removed
from completedJobHandlers, growing the map for the lifetime of the
instance. Registration now goes through registerCompletedJobHandler(),
which timestamps entries and prunes anything older than 6 minutes
(the queue's own removeOnComplete/removeOnFail age plus slack).