### PR TITLE
fix(server): single process listener pair per platform instance

### DIFF
--- a/packages/server/src/janitor.test.ts
+++ b/packages/server/src/janitor.test.ts
@@ -21,18 +21,6 @@ function getPlatformInstanceFake() {
             ["session foo", "127.0.0.1"],
             ["session bar", "127.0.0.1"],
         ]),
-        sessionCallbacks: {
-            close: (() =>
-                new Map([
-                    ["session foo", function sessionFooClose() {}],
-                    ["session bar", function sessionBarClose() {}],
-                ]))(),
-            message: (() =>
-                new Map([
-                    ["session foo", function sessionFooMessage() {}],
-                    ["session bar", function sessionBarMessage() {}],
-                ]))(),
-        },
     };
 }
 
@@ -92,62 +80,28 @@ describe("Janitor", () => {
         });
     });
 
-    describe("removeSessionCallbacks", () => {
-        test("removes session listeners and callbacks for a given platform", () => {
-            const pi = getPlatformInstanceFake();
-            const barMessage = pi.sessionCallbacks.message.get("session bar");
-            const barClose = pi.sessionCallbacks.close.get("session bar");
-            pi.flaggedForTermination = true;
-            janitor.removeSessionCallbacks(pi, "session foo");
-            sinon.assert.calledTwice(pi.process.removeListener);
-            expect(
-                pi.sessionCallbacks.message.get("session foo"),
-            ).toBeUndefined();
-            expect(pi.sessionCallbacks.message.get("session bar")).toEqual(
-                barMessage,
-            );
-            expect(
-                pi.sessionCallbacks.close.get("session foo"),
-            ).toBeUndefined();
-            expect(pi.sessionCallbacks.close.get("session bar")).toEqual(
-                barClose,
-            );
-        });
-    });
-
     describe("removeStaleSocketSessions", () => {
         test("doesnt do anything if the socket is active and stop is not flagged", async () => {
             const pi = getPlatformInstanceFake();
-            janitor.removeSessionCallbacks = sinon.stub();
             janitor.socketExists = sinon.stub().returns(true);
             expect(janitor.stopTriggered).toBeFalse();
             await janitor.removeStaleSocketSessions(pi);
-            sinon.assert.notCalled(janitor.removeSessionCallbacks);
+            expect(pi.sessions.has("session foo")).toBeTrue();
+            expect(pi.sessions.has("session bar")).toBeTrue();
         });
 
         test("removes session if the socket is active and stop is flagged", async () => {
             const pi = getPlatformInstanceFake();
-            janitor.removeSessionCallbacks = sinon.stub();
             janitor.socketExists = sinon.stub().returns(true);
             janitor.stop();
             expect(janitor.stopTriggered).toBeTrue();
             await janitor.removeStaleSocketSessions(pi);
-            sinon.assert.calledTwice(janitor.removeSessionCallbacks);
-            sinon.assert.calledWith(
-                janitor.removeSessionCallbacks,
-                pi,
-                "session foo",
-            );
-            sinon.assert.calledWith(
-                janitor.removeSessionCallbacks,
-                pi,
-                "session bar",
-            );
+            expect(pi.sessions.size).toEqual(0);
+            expect(pi.sessionIps.size).toEqual(0);
         });
 
         test("removes session if the socket is inactive", async () => {
             const pi = getPlatformInstanceFake();
-            janitor.removeSessionCallbacks = sinon.stub();
             janitor.socketExists = sinon
                 .stub()
                 .onFirstCall()
@@ -156,12 +110,8 @@ describe("Janitor", () => {
                 .returns(true);
             expect(janitor.stopTriggered).toBeFalse();
             await janitor.removeStaleSocketSessions(pi);
-            sinon.assert.calledOnce(janitor.removeSessionCallbacks);
-            sinon.assert.calledWith(
-                janitor.removeSessionCallbacks,
-                pi,
-                "session foo",
-            );
+            expect(pi.sessions.has("session foo")).toBeFalse();
+            expect(pi.sessions.has("session bar")).toBeTrue();
         });
     });
 

--- a/packages/server/src/janitor.ts
+++ b/packages/server/src/janitor.ts
@@ -39,21 +39,6 @@ export class Janitor {
         }
     }
 
-    private removeSessionCallbacks(
-        platformInstance: PlatformInstance,
-        sessionId: string,
-    ): void {
-        for (const key of Object.keys(
-            platformInstance.sessionCallbacks,
-        ) as Array<"close" | "message">) {
-            platformInstance.process.removeListener(
-                key,
-                platformInstance.sessionCallbacks[key].get(sessionId),
-            );
-            platformInstance.sessionCallbacks[key].delete(sessionId);
-        }
-    }
-
     private removeStaleSocketSessions(
         platformInstance: PlatformInstance,
     ): void {
@@ -76,7 +61,6 @@ export class Janitor {
         );
         platformInstance.sessions.delete(sessionId);
         platformInstance.sessionIps.delete(sessionId);
-        this.removeSessionCallbacks(platformInstance, sessionId);
     }
 
     private async removeStalePlatformInstance(

--- a/packages/server/src/platform-instance.test.ts
+++ b/packages/server/src/platform-instance.test.ts
@@ -128,24 +128,11 @@ describe("PlatformInstance", () => {
         });
 
         describe("registerSession", () => {
-            beforeEach(() => {
-                pi.callbackFunction = sandbox.fake();
-            });
-
-            test("adds a close and message handler when a session is registered", () => {
+            test("tracks the session without adding process listeners", () => {
                 pi.registerSession("my session id");
-                expect(pi.callbackFunction.callCount).toEqual(2);
-                sandbox.assert.calledWith(
-                    pi.callbackFunction,
-                    "close",
-                    "my session id",
-                );
-                sandbox.assert.calledWith(
-                    pi.callbackFunction,
-                    "message",
-                    "my session id",
-                );
                 expect(pi.sessions.has("my session id")).toEqual(true);
+                // sessions no longer register per-session process listeners
+                sandbox.assert.notCalled(pi.process.on);
             });
 
             test("is able to generate failure reports", async () => {
@@ -153,7 +140,12 @@ describe("PlatformInstance", () => {
                 expect(pi.sessions.has("my session id")).toEqual(true);
                 pi.sendToClient = sandbox.stub();
                 pi.shutdown = sandbox.stub();
-                await pi.reportError("my session id", "an error message");
+                await pi.broadcastFatalError("an error message");
+                sandbox.assert.calledWith(
+                    pi.sendToClient,
+                    "my session id",
+                    sinon.match({ error: "an error message" }),
+                );
                 expect(pi.sessions.size).toEqual(0);
             });
         });
@@ -325,9 +317,9 @@ describe("PlatformInstance", () => {
             sandbox.assert.calledOnce(socketMock.emit);
         });
 
-        test("reportError emits a valid service actor for a global platform", async () => {
+        test("broadcastFatalError emits a valid service actor for a global platform", async () => {
             pi.sessions.add("my session id");
-            await pi.reportError("my session id", "boom");
+            await pi.broadcastFatalError("boom");
             sandbox.assert.calledOnce(socketMock.emit);
             const emitted = socketMock.emit.firstCall.args[1];
             expect(emitted.type).toEqual("error");
@@ -388,9 +380,9 @@ describe("PlatformInstance", () => {
             });
         });
 
-        describe("callbackFunction", () => {
+        describe("process event handlers", () => {
             beforeEach(() => {
-                pi.reportError = sandbox.fake();
+                pi.broadcastFatalError = sandbox.fake();
                 pi.sendToClient = sandbox.fake();
                 pi.updateIdentifier = sandbox.fake();
             });
@@ -400,11 +392,9 @@ describe("PlatformInstance", () => {
                 pi.process.connected = true;
                 pi.flaggedForTermination = false;
 
-                const close = pi.callbackFunction("close", "my session id");
-                await close("error msg");
+                await pi.handleProcessClose("error msg");
                 sandbox.assert.calledWith(
-                    pi.reportError,
-                    "my session id",
+                    pi.broadcastFatalError,
                     "Error: session thread closed unexpectedly: error msg",
                 );
             });
@@ -415,11 +405,10 @@ describe("PlatformInstance", () => {
                 pi.flaggedForTermination = false;
                 pi.shutdown = sandbox.stub();
 
-                const close = pi.callbackFunction("close", "my session id");
-                await close("error msg");
+                await pi.handleProcessClose("error msg");
 
                 // Should NOT attempt to report error
-                sandbox.assert.notCalled(pi.reportError);
+                sandbox.assert.notCalled(pi.broadcastFatalError);
                 // Should call shutdown
                 sandbox.assert.called(pi.shutdown);
             });
@@ -430,35 +419,39 @@ describe("PlatformInstance", () => {
                 pi.flaggedForTermination = true;
                 pi.shutdown = sandbox.stub();
 
-                const close = pi.callbackFunction("close", "my session id");
-                await close("error msg");
+                await pi.handleProcessClose("error msg");
 
                 // Should NOT attempt to report error
-                sandbox.assert.notCalled(pi.reportError);
+                sandbox.assert.notCalled(pi.broadcastFatalError);
                 // Should call shutdown
                 sandbox.assert.called(pi.shutdown);
             });
 
-            test("message events from platform thread are route based on command: error", () => {
-                const message = pi.callbackFunction("message", "my session id");
-                message(["error", "error message"]);
+            test("message events from platform thread are routed based on command: error", async () => {
+                await pi.handleProcessMessage(["error", "error message"]);
                 sandbox.assert.calledWith(
-                    pi.reportError,
-                    "my session id",
+                    pi.broadcastFatalError,
                     "error message",
                 );
             });
 
-            test("message events from platform thread are route based on command: updateActor", () => {
-                const message = pi.callbackFunction("message", "my session id");
-                message(["updateActor", undefined, { foo: "bar" }]);
+            test("message events from platform thread are routed based on command: updateActor", async () => {
+                await pi.handleProcessMessage([
+                    "updateActor",
+                    undefined,
+                    { foo: "bar" },
+                ]);
                 sandbox.assert.calledWith(pi.updateIdentifier, { foo: "bar" });
             });
 
-            test("message events from platform thread are route based on command: else", () => {
-                const message = pi.callbackFunction("message", "my session id");
-                message(["blah", { foo: "bar" }]);
-                sandbox.assert.calledWith(pi.sendToClient, "my session id", {
+            test("message events from platform thread are delivered to every registered session", async () => {
+                pi.sessions.add("session one");
+                pi.sessions.add("session two");
+                await pi.handleProcessMessage(["blah", { foo: "bar" }]);
+                sandbox.assert.calledWith(pi.sendToClient, "session one", {
+                    foo: "bar",
+                });
+                sandbox.assert.calledWith(pi.sendToClient, "session two", {
                     foo: "bar",
                 });
             });

--- a/packages/server/src/platform-instance.ts
+++ b/packages/server/src/platform-instance.ts
@@ -74,13 +74,8 @@ export default class PlatformInstance {
     readonly parentId: string;
     readonly sessions: Set<string> = new Set();
     readonly sessionIps: Map<string, string> = new Map();
-    readonly sessionCallbacks: Record<
-        "close" | "message",
-        Map<string, (...args: Array<unknown>) => void | Promise<void>>
-    > = {
-        close: new Map(),
-        message: new Map(),
-    };
+    private processMessageListener?: (message: MessageFromPlatform) => void;
+    private processCloseListener?: (e: unknown) => void;
     private heartbeatLastSeen = Date.now();
     private heartbeatMonitor?: NodeJS.Timeout;
     private heartbeatListener?: (message: MessageFromPlatform) => void;
@@ -133,6 +128,7 @@ export default class PlatformInstance {
 
         this.createQueue();
         this.initProcess(this.parentId, this.name, this.id, env);
+        this.attachProcessListeners();
         this.startHeartbeatMonitor();
         this.createGetSocket();
     }
@@ -178,6 +174,20 @@ export default class PlatformInstance {
             if (this.heartbeatListener) {
                 this.process.removeListener("message", this.heartbeatListener);
                 this.heartbeatListener = undefined;
+            }
+            if (this.processMessageListener) {
+                this.process.removeListener(
+                    "message",
+                    this.processMessageListener,
+                );
+                this.processMessageListener = undefined;
+            }
+            if (this.processCloseListener) {
+                this.process.removeListener(
+                    "close",
+                    this.processCloseListener,
+                );
+                this.processCloseListener = undefined;
             }
             this.process.removeAllListeners("close");
             this.process.unref();
@@ -240,16 +250,7 @@ export default class PlatformInstance {
         if (clientIp) {
             this.sessionIps.set(sessionId, clientIp);
         }
-        if (!this.sessions.has(sessionId)) {
-            this.sessions.add(sessionId);
-            for (const type of Object.keys(this.sessionCallbacks) as Array<
-                "close" | "message"
-            >) {
-                const cb = this.callbackFunction(type, sessionId);
-                this.process.on(type, cb);
-                this.sessionCallbacks[type].set(sessionId, cb);
-            }
-        }
+        this.sessions.add(sessionId);
     }
 
     /**
@@ -396,11 +397,12 @@ export default class PlatformInstance {
     }
 
     /**
-     * Sends error message to client and clears all references to this class.
-     * @param sessionId
-     * @param message
+     * Sends a fatal error message to every connected session, then clears
+     * all references to this class. Previously only the session whose
+     * listener happened to run first received the error; every other
+     * session sharing the instance lost the platform silently.
      */
-    private async reportError(sessionId: string, message: string) {
+    private async broadcastFatalError(message: string) {
         const errorObject: ActivityStream = {
             "@context": buildCanonicalContext(
                 this.contextUrl ?? INTERNAL_PLATFORM_CONTEXT_URL,
@@ -412,15 +414,14 @@ export default class PlatformInstance {
             error: message,
         };
 
-        // Only attempt to send to client if we have a valid session
-        try {
-            if (sessionId && this.sessions.has(sessionId)) {
+        for (const sessionId of this.sessions.values()) {
+            try {
                 this.sendToClient(sessionId, errorObject);
+            } catch (err) {
+                this.log.error(
+                    `Failed to send error to client: ${errorMessage(err)}`,
+                );
             }
-        } catch (err) {
-            this.log.error(
-                `Failed to send error to client: ${errorMessage(err)}`,
-            );
         }
 
         this.sessions.clear();
@@ -438,67 +439,83 @@ export default class PlatformInstance {
     }
 
     /**
-     * Generates a function tied to a given client session (socket connection), the generated
-     * function will be called for each session ID registered, for every platform emit.
-     * @param listener
-     * @param sessionId
+     * Attach one message and one close listener to the child process,
+     * serving every session registered with this instance. Sessions no
+     * longer add their own listener pair, so listener count stays constant
+     * regardless of how many sockets share the instance. Previously each
+     * session registered two listeners: O(sessions) callback invocations
+     * per platform emit, plus MaxListenersExceeded warnings past ten
+     * sessions on shared (e.g. global) platforms.
      */
-    private callbackFunction(listener: "close" | "message", sessionId: string) {
-        const funcs: Record<
-            "close" | "message",
-            (...args: Array<unknown>) => Promise<void>
-        > = {
-            close: async (e: object) => {
-                this.log.error(`close event triggered ${this.id}: ${e}`);
-                // Check if process is still connected before attempting error reporting
-                if (this.process?.connected && !this.flaggedForTermination) {
-                    await this.reportError(
-                        sessionId,
-                        `Error: session thread closed unexpectedly: ${e}`,
-                    );
-                } else {
-                    this.log.debug(
-                        "Process already disconnected or flagged for termination, skipping error report",
-                    );
-                    await this.shutdown();
-                }
-            },
-            message: async ([first, second, third]: MessageFromPlatform) => {
-                if (first === "updateActor") {
-                    // Internal control message: platform process is reporting a new actor id.
-                    // We need to update the key to the store in order to find it in the future.
-                    this.updateIdentifier(third);
-                } else if (first === "error") {
-                    // Error messages travel over IPC as plain objects; normalize to a string.
-                    let normalizedError: string;
-                    if (typeof second === "string") {
-                        normalizedError = second;
-                    } else if (
-                        second &&
-                        typeof second === "object" &&
-                        "message" in (second as Record<string, unknown>)
-                    ) {
-                        normalizedError = String(
-                            (second as Record<string, unknown>).message,
-                        );
-                    } else {
-                        try {
-                            normalizedError = JSON.stringify(second);
-                        } catch {
-                            normalizedError = String(second);
-                        }
-                    }
-                    await this.reportError(sessionId, normalizedError);
-                } else if (first === "heartbeat") {
-                    // Internal heartbeat signals are handled by the monitor listener only.
-                    return;
-                } else {
-                    // treat like a message to clients
-                    this.sendToClient(sessionId, second);
-                }
-            },
+    private attachProcessListeners() {
+        if (!this.process?.on) {
+            return;
+        }
+        this.processMessageListener = (message: MessageFromPlatform) => {
+            void this.handleProcessMessage(message);
         };
-        return funcs[listener];
+        this.processCloseListener = (e: unknown) => {
+            void this.handleProcessClose(e);
+        };
+        this.process.on("message", this.processMessageListener);
+        this.process.on("close", this.processCloseListener);
+    }
+
+    private async handleProcessClose(e: unknown) {
+        this.log.error(`close event triggered ${this.id}: ${e}`);
+        // Check if process is still connected before attempting error reporting
+        if (this.process?.connected && !this.flaggedForTermination) {
+            await this.broadcastFatalError(
+                `Error: session thread closed unexpectedly: ${e}`,
+            );
+        } else {
+            this.log.debug(
+                "Process already disconnected or flagged for termination, skipping error report",
+            );
+            await this.shutdown();
+        }
+    }
+
+    private async handleProcessMessage([
+        first,
+        second,
+        third,
+    ]: MessageFromPlatform) {
+        if (first === "updateActor") {
+            // Internal control message: platform process is reporting a new actor id.
+            // We need to update the key to the store in order to find it in the future.
+            this.updateIdentifier(third);
+        } else if (first === "error") {
+            // Error messages travel over IPC as plain objects; normalize to a string.
+            let normalizedError: string;
+            if (typeof second === "string") {
+                normalizedError = second;
+            } else if (
+                second &&
+                typeof second === "object" &&
+                "message" in (second as Record<string, unknown>)
+            ) {
+                normalizedError = String(
+                    (second as Record<string, unknown>).message,
+                );
+            } else {
+                try {
+                    normalizedError = JSON.stringify(second);
+                } catch {
+                    normalizedError = String(second);
+                }
+            }
+            await this.broadcastFatalError(normalizedError);
+        } else if (first === "heartbeat") {
+            // Internal heartbeat signals are handled by the monitor listener only.
+            return;
+        } else {
+            // treat like a message to clients: deliver to every session
+            // registered with this platform instance
+            for (const sessionId of this.sessions.values()) {
+                this.sendToClient(sessionId, second as InternalActivityStream);
+            }
+        }
     }
 
     private markHeartbeat() {


### PR DESCRIPTION
Each registered session attached its own message and close listener to
the platform child process. On shared instances — including the global
feeds/metadata platforms every session touches — this meant O(sessions)
listener invocations per platform emit, MaxListenersExceededWarning
spam past ten sessions (nothing raised the limit), and listeners that
lingered until a janitor cycle noticed the socket was gone.

The instance now attaches exactly one message and one close listener at
construction and routes to registered sessions itself. Fatal errors
(error IPC messages, unexpected process close) are now broadcast to
every connected session before shutdown; previously only the session
whose listener ran first received the error and everyone else sharing
the instance lost the platform silently.

registerSession() just records the session; the janitor no longer
removes per-session listeners.