### PR TITLE
fix(server): run janitor cycle in a loop instead of recursing

### DIFF
--- a/packages/server/src/janitor.ts
+++ b/packages/server/src/janitor.ts
@@ -24,9 +24,8 @@ export class Janitor {
      */
     start(): void {
         rmLog.debug("initializing");
-        this.clean().then(() => {
-            rmLog.info("cleaning cycle started");
-        });
+        void this.runCleanCycle();
+        rmLog.info("cleaning cycle started");
     }
 
     async stop(): Promise<void> {
@@ -122,6 +121,20 @@ export class Janitor {
         }
     }
 
+    /**
+     * Run clean() every cycleInterval in a plain loop. The previous
+     * implementation recursed (`return this.clean()`) after the delay, so
+     * the promise chain from start() grew by one pending promise per cycle
+     * for the lifetime of the process — a slow, unbounded leak.
+     */
+    private async runCleanCycle(): Promise<void> {
+        while (!this.stopTriggered) {
+            await this.clean();
+            await this.delay(this.cycleInterval);
+        }
+        this.cycleRunning = false;
+    }
+
     private async clean(): Promise<void> {
         if (this.stopTriggered) {
             this.cycleRunning = false;
@@ -147,8 +160,6 @@ export class Janitor {
             await this.performStaleCheck(platformInstance);
         }
         this.cycleRunning = false;
-        await this.delay(this.cycleInterval);
-        return this.clean();
     }
 }
 


### PR DESCRIPTION
clean() re-invoked itself (return this.clean()) after each delay, so
the promise returned by the initial start() call could never settle
and the chain grew by one pending promise per cycle — an unbounded
(if slow, at one frame per 15s) leak over the lifetime of a
long-running server. A while loop with the same stop semantics
replaces the recursion; per-cycle behavior is unchanged.