### PR TITLE
perf(data-layer): parallel job processing for stateless platforms

### DIFF
--- a/packages/data-layer/src/index.ts
+++ b/packages/data-layer/src/index.ts
@@ -14,7 +14,7 @@ import {
     resetSharedRedisConnection,
 } from "./job-base.js";
 import { JobQueue, verifyJobQueue } from "./job-queue.js";
-import { JobWorker } from "./job-worker.js";
+import { JobWorker, type JobWorkerOptions } from "./job-worker.js";
 
 export * from "./types.js";
 
@@ -47,6 +47,7 @@ export {
     redisCheck,
     JobQueue,
     JobWorker,
+    type JobWorkerOptions,
     CredentialsStore,
     CredentialsMismatchError,
     CredentialsNotShareableError,

--- a/packages/data-layer/src/job-worker.ts
+++ b/packages/data-layer/src/job-worker.ts
@@ -25,6 +25,15 @@ import type { JobEncrypted, JobHandler, RedisConfig } from "./types.js";
  * });
  * ```
  */
+export interface JobWorkerOptions {
+    /**
+     * Number of jobs this worker will process in parallel. Defaults to 1
+     * (serial processing). Only safe to raise for stateless platforms whose
+     * job handlers are independent of one another (e.g. feeds, metadata).
+     */
+    concurrency?: number;
+}
+
 export class JobWorker extends JobBase {
     private readonly connectionName: string;
     protected worker: Worker;
@@ -32,6 +41,7 @@ export class JobWorker extends JobBase {
     private readonly log: Logger;
     private readonly redisConfig: RedisConfig;
     protected readonly queueId: string;
+    private readonly concurrency: number;
     private initialized = false;
 
     /**
@@ -47,8 +57,16 @@ export class JobWorker extends JobBase {
         instanceId: string,
         secret: string,
         redisConfig: RedisConfig,
+        options: JobWorkerOptions = {},
     ) {
         super(secret);
+        const concurrency = Math.floor(options.concurrency ?? 1);
+        if (!Number.isFinite(concurrency) || concurrency < 1) {
+            throw new Error(
+                `JobWorker concurrency must be a positive integer, got ${options.concurrency}`,
+            );
+        }
+        this.concurrency = concurrency;
         // Create logger with full namespace (context will be prepended automatically)
         this.log = createLogger(`data-layer:worker:${parentId}:${instanceId}`);
 
@@ -74,6 +92,10 @@ export class JobWorker extends JobBase {
         // Let BullMQ create its own connection (it duplicates them internally anyway)
         this.worker = new Worker(queueName, this.jobHandler.bind(this), {
             connection: this.redisConfig,
+            // Number of jobs processed in parallel; > 1 for stateless platforms
+            // shared by every session (feeds, metadata), so one slow network
+            // fetch doesn't stall the queue for all other clients.
+            concurrency: this.concurrency,
             // Prevent infinite retry loops when platform child process crashes mid-job.
             // If worker disappears (crash/disconnect), job becomes "stalled" and retries
             // up to maxStalledCount times (with default 30s interval) before failing permanently.

--- a/packages/schemas/src/schemas/sockethub-config.ts
+++ b/packages/schemas/src/schemas/sockethub-config.ts
@@ -68,7 +68,7 @@ export const SockethubConfigSchema = {
                     properties: {
                         connectTimeoutMs: { type: "number" },
                         allowPrivateAddresses: { type: "boolean" },
-                        concurrency: { type: "number", minimum: 1 },
+                        concurrency: { type: "integer", minimum: 1 },
                     },
                 },
                 "@sockethub/platform-irc": {
@@ -90,7 +90,7 @@ export const SockethubConfigSchema = {
                     additionalProperties: false,
                     properties: {
                         allowPrivateAddresses: { type: "boolean" },
-                        concurrency: { type: "number", minimum: 1 },
+                        concurrency: { type: "integer", minimum: 1 },
                     },
                 },
             },

--- a/packages/schemas/src/schemas/sockethub-config.ts
+++ b/packages/schemas/src/schemas/sockethub-config.ts
@@ -68,6 +68,7 @@ export const SockethubConfigSchema = {
                     properties: {
                         connectTimeoutMs: { type: "number" },
                         allowPrivateAddresses: { type: "boolean" },
+                        concurrency: { type: "number", minimum: 1 },
                     },
                 },
                 "@sockethub/platform-irc": {
@@ -89,6 +90,7 @@ export const SockethubConfigSchema = {
                     additionalProperties: false,
                     properties: {
                         allowPrivateAddresses: { type: "boolean" },
+                        concurrency: { type: "number", minimum: 1 },
                     },
                 },
             },

--- a/packages/schemas/src/types.ts
+++ b/packages/schemas/src/types.ts
@@ -114,6 +114,14 @@ interface BasePlatformConfig {
 export interface StatelessPlatformConfig extends BasePlatformConfig {
     persist: false;
     requireCredentials?: string[];
+    /**
+     * Number of jobs the platform's worker processes in parallel. Stateless
+     * platforms are shared by every session on the server, so serial
+     * processing lets one slow job (e.g. a hanging feed fetch) stall all
+     * other clients. Defaults to 10; override per-platform via
+     * `packageConfig`.
+     */
+    concurrency?: number;
 }
 
 /**

--- a/packages/server/src/platform.ts
+++ b/packages/server/src/platform.ts
@@ -557,15 +557,16 @@ async function startPlatformProcess() {
                 return;
             }
         }
+        const concurrency = getWorkerConcurrency();
         jobWorker = new JobWorker(
             parentId,
             identifier,
             parentSecret1 + parentSecret2,
             { url: redisUrl },
-            { concurrency: getWorkerConcurrency() },
+            { concurrency },
         );
         logger.info(
-            `listening on the queue for incoming jobs (concurrency: ${getWorkerConcurrency()})`,
+            `listening on the queue for incoming jobs (concurrency: ${concurrency})`,
         );
         jobWorker.onJob(getJobHandler());
         jobWorkerStarted = true;

--- a/packages/server/src/platform.ts
+++ b/packages/server/src/platform.ts
@@ -222,6 +222,26 @@ async function startPlatformProcess() {
     }
 
     /**
+     * Persistent platforms hold per-actor connection state, so their jobs
+     * must be processed serially. Stateless platforms (feeds, metadata) are
+     * shared by every session on the server and their jobs are independent
+     * network fetches, so they process in parallel — otherwise one slow
+     * fetch stalls the queue for all clients. Overridable per-platform via
+     * `packageConfig.concurrency`.
+     */
+    const DEFAULT_STATELESS_CONCURRENCY = 10;
+    function getWorkerConcurrency(): number {
+        if (platform.config.persist) {
+            return 1;
+        }
+        const configured = Number(platform.config.concurrency);
+        if (Number.isFinite(configured) && configured >= 1) {
+            return Math.floor(configured);
+        }
+        return DEFAULT_STATELESS_CONCURRENCY;
+    }
+
+    /**
      * Type guard to check if a platform is persistent and has credentialsHash.
      */
     function isPersistentPlatform(
@@ -542,8 +562,11 @@ async function startPlatformProcess() {
             identifier,
             parentSecret1 + parentSecret2,
             { url: redisUrl },
+            { concurrency: getWorkerConcurrency() },
         );
-        logger.info("listening on the queue for incoming jobs");
+        logger.info(
+            `listening on the queue for incoming jobs (concurrency: ${getWorkerConcurrency()})`,
+        );
         jobWorker.onJob(getJobHandler());
         jobWorkerStarted = true;
     }


### PR DESCRIPTION
Stateless platforms (feeds, metadata) run as a single shared child
process for every session on the server, and their BullMQ worker used
the default concurrency of 1 — every fetch for every client was
processed serially, so one slow or hanging feed stalled all other
clients' jobs server-wide.

JobWorker now accepts a concurrency option, and the platform child
process sets it from the platform config: persistent platforms stay
serial (their handlers share per-actor connection state), stateless
platforms default to 10 and can be tuned per-platform via
packageConfig.concurrency.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added per-platform configurable job-processing concurrency, enabling parallel processing for non-persistent platforms.
  * Persistent platforms continue to process jobs serially.
  * Concurrency can be set through platform configuration (with schema support) and is resolved during worker startup.
* **Bug Fixes**
  * Added validation to ensure concurrency is a finite integer ≥ 1.
  * Updated startup logging to show the resolved concurrency level.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->