### PR TITLE
fix(util): use full-length hash for platform instance IDs

### DIFF
--- a/packages/util/src/crypto/index.test.ts
+++ b/packages/util/src/crypto/index.test.ts
@@ -117,7 +117,7 @@ describe("getPlatformId", () => {
             }
         }
         crypto = new TestCrypto();
-        cryptoHashStub = sinon.stub(crypto, "hash");
+        cryptoHashStub = sinon.stub(crypto, "hashFull");
         cryptoHashStub.returnsArg(0);
     });
 

--- a/packages/util/src/crypto/index.ts
+++ b/packages/util/src/crypto/index.ts
@@ -16,9 +16,9 @@ export function getPlatformId(
     _crypto = crypto,
 ): string {
     if (actor) {
-        return _crypto.hash(platform + actor);
+        return _crypto.hashFull(platform + actor);
     }
-    return _crypto.hash(platform);
+    return _crypto.hashFull(platform);
 }
 
 export class Crypto {
@@ -57,6 +57,17 @@ export class Crypto {
         const SHASum = createHash("sha1");
         SHASum.update(text);
         return SHASum.digest("hex").substring(0, 7);
+    }
+
+    /**
+     * Full-length SHA-256 hex digest. Used where hash values act as
+     * identity keys (e.g. platform instance IDs): the truncated 28-bit
+     * `hash()` has a ~1% birthday-collision probability by ~2,400 distinct
+     * inputs, and a collision on a platform instance ID silently routes two
+     * different (platform, actor) pairs to the same instance.
+     */
+    hashFull(text: string): string {
+        return createHash("sha256").update(text).digest("hex");
     }
 
     objectHash(object: object): string {


### PR DESCRIPTION
getPlatformId() truncated a SHA-1 digest to 7 hex characters (28
bits). Platform instance identity for persistent platforms is
hash(platform + actor), so on a long-running public instance the
birthday bound is reached quickly: ~1% collision probability by
~2,400 distinct (platform, actor) pairs, ~17% by 10,000. A collision
silently routes two different users into the same platform instance —
cross-user message delivery and session state.

Instance IDs now use a full SHA-256 hex digest via a new
crypto.hashFull(); the truncated hash() remains for any short-id use.
Queue names, credential store keys, and logger namespaces derive from
the instance ID and handle the longer value unchanged.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved how identity-related values are generated, reducing the chance of collisions and making results more reliable.
  * Corrected test coverage to match the updated identity-hash behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->