### PR TITLE
fix(server): cap concurrent platform instances

### DIFF
--- a/packages/schemas/src/schemas/sockethub-config.ts
+++ b/packages/schemas/src/schemas/sockethub-config.ts
@@ -150,6 +150,17 @@ export const SockethubConfigSchema = {
                 },
             },
         },
+        limits: {
+            type: "object",
+            additionalProperties: false,
+            properties: {
+                maxPlatformInstances: {
+                    type: "number",
+                    minimum: 0,
+                    default: 0,
+                },
+            },
+        },
         redis: {
             type: "object",
             additionalProperties: false,

--- a/packages/server/src/config.ts
+++ b/packages/server/src/config.ts
@@ -90,6 +90,17 @@ function buildSchema(): convict.Config<Record<string, unknown>> {
             maxRequests: { format: "nat", default: 100 },
             blockDurationMs: { format: "nat", default: 5000 },
         },
+        limits: {
+            maxPlatformInstances: {
+                doc:
+                    "Upper bound on concurrently running platform instances " +
+                    "(child processes). Each persistent-platform actor forks " +
+                    "its own process, so an unbounded count is a resource " +
+                    "exhaustion risk on public instances. 0 disables the cap.",
+                format: "nat",
+                default: 0,
+            },
+        },
         credentialCheck: {
             reconnectIpSource: {
                 format: ["socket", "proxy"],

--- a/packages/server/src/process-manager.test.ts
+++ b/packages/server/src/process-manager.test.ts
@@ -1,0 +1,124 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import * as sinon from "sinon";
+
+import config from "./config.js";
+import PlatformInstance, { platformInstances } from "./platform-instance.js";
+import ProcessManager from "./process-manager.js";
+
+describe("ProcessManager", () => {
+    let sandbox: sinon.SinonSandbox;
+    let maxPlatformInstances: number;
+    let manager: ProcessManager;
+
+    function fakePlatforms(persist: boolean) {
+        const platforms = new Map();
+        platforms.set("fakeplatform", {
+            config: { persist },
+            contextUrl: "https://sockethub.org/ns/context/platform/fakeplatform/v1.jsonld",
+        });
+        return platforms;
+    }
+
+    // Marks the instance's forked child process as alive (isProcessAlive
+    // sends signal 0 to this pid; the test runner's own pid always exists)
+    // or dead (falsy pid short-circuits isProcessAlive to false).
+    function setAlive(pi: PlatformInstance, alive: boolean) {
+        pi.process = {
+            ...pi.process,
+            pid: alive ? process.pid : undefined,
+            exitCode: null,
+        } as never;
+    }
+
+    beforeEach(() => {
+        sandbox = sinon.createSandbox();
+        platformInstances.clear();
+        maxPlatformInstances = 0;
+
+        sandbox
+            .stub(PlatformInstance.prototype, "createQueue")
+            .callsFake(function (this: PlatformInstance) {
+                this.JobQueue = sandbox.stub().returns({
+                    shutdown: sandbox.stub().resolves(),
+                    on: sandbox.stub(),
+                }) as never;
+            });
+        sandbox
+            .stub(PlatformInstance.prototype, "initProcess")
+            .callsFake(function (this: PlatformInstance) {
+                this.process = {
+                    pid: process.pid,
+                    exitCode: null,
+                    on: sandbox.spy(),
+                    removeListener: sandbox.spy(),
+                    removeAllListeners: sandbox.spy(),
+                    unref: sandbox.spy(),
+                    kill: sandbox.spy(),
+                    send: sandbox.spy(),
+                } as never;
+            });
+        sandbox
+            .stub(PlatformInstance.prototype, "createGetSocket")
+            .callsFake(function (this: PlatformInstance) {
+                this.getSocket = sandbox.stub() as never;
+            });
+
+        const realGet = config.get;
+        sandbox.stub(config, "get").callsFake((key: string) => {
+            if (key === "limits:maxPlatformInstances") {
+                return maxPlatformInstances;
+            }
+            return realGet(key);
+        });
+
+        manager = new ProcessManager(
+            "parent id",
+            "parent secret 1",
+            "parent secret 2",
+            { version: "0.0.0", platforms: fakePlatforms(true) },
+        );
+    });
+
+    afterEach(() => {
+        sandbox.restore();
+        platformInstances.clear();
+    });
+
+    test("disabled cap (0) allows unbounded instance creation", () => {
+        maxPlatformInstances = 0;
+        for (let i = 0; i < 5; i++) {
+            expect(() =>
+                manager.get("fakeplatform", `actor-${i}`),
+            ).not.toThrow();
+        }
+        expect(platformInstances.size).toEqual(5);
+    });
+
+    test("blocks a new actor once the cap is reached", () => {
+        maxPlatformInstances = 1;
+        manager.get("fakeplatform", "actor-a");
+        expect(() => manager.get("fakeplatform", "actor-b")).toThrow(
+            /platform instance limit reached/,
+        );
+        expect(platformInstances.size).toEqual(1);
+    });
+
+    test("always allows reusing a live instance regardless of the cap", () => {
+        maxPlatformInstances = 1;
+        const first = manager.get("fakeplatform", "actor-a");
+        setAlive(first, true);
+        const second = manager.get("fakeplatform", "actor-a");
+        expect(second).toBe(first);
+        expect(platformInstances.size).toEqual(1);
+    });
+
+    test("allows the same actor to replace its own dead instance at the cap", () => {
+        maxPlatformInstances = 1;
+        const first = manager.get("fakeplatform", "actor-a");
+        setAlive(first, false);
+        expect(() =>
+            manager.get("fakeplatform", "actor-a"),
+        ).not.toThrow();
+        expect(platformInstances.size).toEqual(1);
+    });
+});

--- a/packages/server/src/process-manager.ts
+++ b/packages/server/src/process-manager.ts
@@ -1,8 +1,6 @@
 import { getPlatformId } from "@sockethub/util/crypto";
-
-import config from "./config.js";
-
 import type { IInitObject } from "./bootstrap/init.js";
+import config from "./config.js";
 import PlatformInstance, {
     type MessageFromParent,
     type PlatformInstanceParams,

--- a/packages/server/src/process-manager.ts
+++ b/packages/server/src/process-manager.ts
@@ -80,7 +80,7 @@ class ProcessManager {
         const existing = platformInstances.get(identifier);
         const reusable = existing && this.isProcessAlive(existing);
         if (!reusable) {
-            this.assertInstanceCapacity(platform);
+            this.assertInstanceCapacity(platform, identifier);
         }
         const platformInstance = reusable
             ? existing
@@ -100,13 +100,21 @@ class ProcessManager {
      * bound, a public instance can be driven into resource exhaustion.
      * Throws when the configured cap (`limits.maxPlatformInstances`, 0 =
      * disabled) has been reached and a new instance would be created.
+     *
+     * `identifier`'s existing (dead) slot, if any, is excluded from the
+     * count: replacing a crashed instance for the same actor doesn't
+     * increase the total instance count, so it shouldn't be blocked by
+     * the cap.
      */
-    private assertInstanceCapacity(platform: string): void {
+    private assertInstanceCapacity(platform: string, identifier: string): void {
         const max = Number(config.get("limits:maxPlatformInstances") ?? 0);
         if (!Number.isFinite(max) || max <= 0) {
             return;
         }
-        if (platformInstances.size >= max) {
+        const occupied = platformInstances.has(identifier)
+            ? platformInstances.size - 1
+            : platformInstances.size;
+        if (occupied >= max) {
             throw new Error(
                 `platform instance limit reached (${max}); cannot start new ${platform} instance`,
             );

--- a/packages/server/src/process-manager.ts
+++ b/packages/server/src/process-manager.ts
@@ -1,5 +1,7 @@
 import { getPlatformId } from "@sockethub/util/crypto";
 
+import config from "./config.js";
+
 import type { IInitObject } from "./bootstrap/init.js";
 import PlatformInstance, {
     type MessageFromParent,
@@ -78,10 +80,13 @@ class ProcessManager {
     ): PlatformInstance {
         const identifier = getPlatformId(platform, actor);
         const existing = platformInstances.get(identifier);
-        const platformInstance =
-            existing && this.isProcessAlive(existing)
-                ? existing
-                : this.createPlatformInstance(identifier, platform, actor);
+        const reusable = existing && this.isProcessAlive(existing);
+        if (!reusable) {
+            this.assertInstanceCapacity(platform);
+        }
+        const platformInstance = reusable
+            ? existing
+            : this.createPlatformInstance(identifier, platform, actor);
         if (existing && existing !== platformInstance) {
             void existing.shutdown();
         }
@@ -90,6 +95,24 @@ class ProcessManager {
         }
         platformInstances.set(identifier, platformInstance);
         return platformInstance;
+    }
+
+    /**
+     * Each platform instance forks a full child process; without an upper
+     * bound, a public instance can be driven into resource exhaustion.
+     * Throws when the configured cap (`limits.maxPlatformInstances`, 0 =
+     * disabled) has been reached and a new instance would be created.
+     */
+    private assertInstanceCapacity(platform: string): void {
+        const max = Number(config.get("limits:maxPlatformInstances") ?? 0);
+        if (!Number.isFinite(max) || max <= 0) {
+            return;
+        }
+        if (platformInstances.size >= max) {
+            throw new Error(
+                `platform instance limit reached (${max}); cannot start new ${platform} instance`,
+            );
+        }
     }
 
     private isProcessAlive(platformInstance: PlatformInstance): boolean {

--- a/packages/server/src/sockethub.ts
+++ b/packages/server/src/sockethub.ts
@@ -355,12 +355,23 @@ class Sockethub {
                             next(msg);
                             return;
                         }
-                        const platformInstance = this.processManager.get(
-                            platformId,
-                            msg.actor.id,
-                            socket.id,
-                            clientIp,
-                        );
+                        let platformInstance: ReturnType<
+                            ProcessManager["get"]
+                        >;
+                        try {
+                            platformInstance = this.processManager.get(
+                                platformId,
+                                msg.actor.id,
+                                socket.id,
+                                clientIp,
+                            );
+                        } catch (err) {
+                            // e.g. limits.maxPlatformInstances reached
+                            msg.error =
+                                errorMessage(err) || "platform unavailable";
+                            next(msg);
+                            return;
+                        }
                         // job validated and queued, stores socket.io callback for when job is completed
                         try {
                             const job = await platformInstance.queue.add(

--- a/packages/server/src/sockethub.ts
+++ b/packages/server/src/sockethub.ts
@@ -355,9 +355,7 @@ class Sockethub {
                             next(msg);
                             return;
                         }
-                        let platformInstance: ReturnType<
-                            ProcessManager["get"]
-                        >;
+                        let platformInstance: ReturnType<ProcessManager["get"]>;
                         try {
                             platformInstance = this.processManager.get(
                                 platformId,


### PR DESCRIPTION
Every persistent-platform actor forks its own Node child process, and
there was no upper bound on how many could be created. On a public
instance this is a resource-exhaustion vector: enough distinct actors
(or a misbehaving client cycling credentials) exhausts memory and
Redis connections.

Adds limits.maxPlatformInstances (default 0 = disabled, preserving
current behavior). When the cap is reached, ProcessManager refuses to
fork a new instance and the client receives the request back with an
error instead of the server crashing on an unhandled throw. Reusing an
existing live instance is always allowed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new configuration to cap concurrently running platform instances, with the default set to `0` (limit disabled).
  * The server enforces capacity by blocking creation of new instances once the cap is reached.

* **Bug Fixes**
  * When the instance limit is hit, requests now fail gracefully with a clear error message instead of throwing.
  * Live/reusable instances are reused when possible, including replacing an actor’s own dead instance even at the cap.

* **Tests**
  * Added automated coverage for the platform instance limit behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->