### PR TITLE
fix(server): configurable CORS origin, per-IP connection cap

### DIFF
--- a/packages/schemas/src/schemas/sockethub-config.ts
+++ b/packages/schemas/src/schemas/sockethub-config.ts
@@ -148,6 +148,11 @@ export const SockethubConfigSchema = {
                     type: "number",
                     default: 5000,
                 },
+                maxConnectionsPerIp: {
+                    type: "number",
+                    minimum: 0,
+                    default: 0,
+                },
             },
         },
         limits: {
@@ -216,6 +221,16 @@ export const SockethubConfigSchema = {
                 path: {
                     type: "string",
                     default: "/sockethub",
+                },
+                cors: {
+                    type: "object",
+                    additionalProperties: false,
+                    properties: {
+                        origin: {
+                            type: "string",
+                            default: "*",
+                        },
+                    },
                 },
             },
         },

--- a/packages/server/src/config.ts
+++ b/packages/server/src/config.ts
@@ -89,6 +89,15 @@ function buildSchema(): convict.Config<Record<string, unknown>> {
             windowMs: { format: "nat", default: 1000 },
             maxRequests: { format: "nat", default: 100 },
             blockDurationMs: { format: "nat", default: 5000 },
+            maxConnectionsPerIp: {
+                doc:
+                    "Maximum concurrent socket connections per client IP. " +
+                    "The per-event rate limiter is keyed by socket id, so " +
+                    "without a connection cap a client can bypass it by " +
+                    "opening more sockets. 0 disables the cap.",
+                format: "nat",
+                default: 0,
+            },
         },
         limits: {
             maxPlatformInstances: {
@@ -149,6 +158,18 @@ function buildSchema(): convict.Config<Record<string, unknown>> {
                 arg: "host",
             },
             path: { format: String, default: "/sockethub" },
+            cors: {
+                origin: {
+                    doc:
+                        "Allowed CORS origin(s) for socket.io connections. " +
+                        "'*' allows any website to connect visitors' " +
+                        "browsers to this instance; public deployments " +
+                        "should set an explicit origin or comma-separated " +
+                        "list of origins.",
+                    format: String,
+                    default: "*",
+                },
+            },
         },
         platformHeartbeat: {
             intervalMs: {

--- a/packages/server/src/listener.ts
+++ b/packages/server/src/listener.ts
@@ -39,7 +39,7 @@ class Listener {
         this.io = new Server(this.http, {
             path: config.get("sockethub:path") as string,
             cors: {
-                origin: "*",
+                origin: Listener.corsOrigin(),
                 methods: ["GET", "POST"],
             },
         });
@@ -124,6 +124,30 @@ class Listener {
                 "sockethub:port",
             )}`,
         );
+    }
+
+    /**
+     * Resolve the socket.io CORS origin from config. Accepts '*' (default,
+     * historical behavior), a single origin, or a comma-separated list.
+     * Public deployments should set an explicit origin: with '*' any
+     * website can connect visitors' browsers to this instance and use it
+     * as a relay.
+     */
+    private static corsOrigin(): string | Array<string> {
+        const configured = (
+            (config.get("sockethub:cors:origin") as string) || "*"
+        ).trim();
+        if (configured === "*" || configured === "") {
+            return "*";
+        }
+        const origins = configured
+            .split(",")
+            .map((origin) => origin.trim())
+            .filter((origin) => origin.length > 0);
+        if (origins.length === 0) {
+            return "*";
+        }
+        return origins.length === 1 ? origins[0] : origins;
     }
 
     private startHttp() {

--- a/packages/server/src/sockethub.ts
+++ b/packages/server/src/sockethub.ts
@@ -8,6 +8,8 @@ import type {
 } from "@sockethub/schemas";
 import {
     AS2_BASE_CONTEXT_URL,
+    buildCanonicalContext,
+    ERROR_PLATFORM_CONTEXT_URL,
     resolvePlatformId,
     SOCKETHUB_BASE_CONTEXT_URL,
 } from "@sockethub/schemas";
@@ -112,6 +114,9 @@ class Sockethub {
     status: boolean;
     processManager!: ProcessManager;
     private rateLimiter!: ReturnType<typeof createRateLimiter>;
+    // Concurrent socket connections per client IP; used to enforce
+    // rateLimiter.maxConnectionsPerIp.
+    private readonly socketsPerIp = new Map<string, number>();
     private serverVersion?: string;
     private platformRegistryPayloadCache?: {
         payload: ReturnType<Sockethub["buildPlatformRegistryPayload"]> & {
@@ -229,6 +234,55 @@ class Sockethub {
     }
 
     /**
+     * Reserve a connection slot for the client IP. Returns false (after
+     * notifying and disconnecting the socket) when the configured
+     * per-IP connection cap has been reached.
+     */
+    private claimIpSlot(
+        socket: Socket,
+        clientIp: string,
+        sessionLog: ReturnType<typeof createLogger>,
+    ): boolean {
+        const max = Number(
+            config.get("rateLimiter:maxConnectionsPerIp") ?? 0,
+        );
+        if (!Number.isFinite(max) || max <= 0 || !clientIp) {
+            return true;
+        }
+        const current = this.socketsPerIp.get(clientIp) ?? 0;
+        if (current >= max) {
+            sessionLog.warn(
+                `connection limit reached for ${clientIp} (${current}/${max}), rejecting socket`,
+            );
+            socket.emit("error", {
+                type: "Error",
+                "@context": buildCanonicalContext(ERROR_PLATFORM_CONTEXT_URL),
+                actor: {
+                    type: "Application",
+                    name: "sockethub-server",
+                },
+                summary: "too many concurrent connections from this address",
+            });
+            socket.disconnect(true);
+            return false;
+        }
+        this.socketsPerIp.set(clientIp, current + 1);
+        return true;
+    }
+
+    private releaseIpSlot(clientIp: string): void {
+        if (!clientIp) {
+            return;
+        }
+        const current = this.socketsPerIp.get(clientIp) ?? 0;
+        if (current <= 1) {
+            this.socketsPerIp.delete(clientIp);
+        } else {
+            this.socketsPerIp.set(clientIp, current - 1);
+        }
+    }
+
+    /**
      * Configure all socket listeners and middleware for a single client session.
      */
     private handleIncomingConnection(socket: Socket) {
@@ -236,6 +290,13 @@ class Sockethub {
         const sessionLog = createLogger(`server:core:${socket.id}`);
         const sessionSecret = crypto.randToken(16);
         const clientIp = getClientIp(socket);
+
+        // The per-event rate limiter is keyed by socket id, so a client can
+        // bypass it by opening more sockets; cap concurrent connections per
+        // IP when configured (0 = disabled).
+        if (!this.claimIpSlot(socket, clientIp, sessionLog)) {
+            return;
+        }
         const credentialsStore: CredentialsStoreInterface =
             new CredentialsStore(
                 this.parentId,
@@ -278,6 +339,7 @@ class Sockethub {
         socket.on("disconnect", () => {
             sessionLog.debug("disconnect received from client");
             cleanupClient(socket.id);
+            this.releaseIpSlot(clientIp);
         });
 
         socket.on(

--- a/packages/server/src/sockethub.ts
+++ b/packages/server/src/sockethub.ts
@@ -243,9 +243,7 @@ class Sockethub {
         clientIp: string,
         sessionLog: ReturnType<typeof createLogger>,
     ): boolean {
-        const max = Number(
-            config.get("rateLimiter:maxConnectionsPerIp") ?? 0,
-        );
+        const max = Number(config.get("rateLimiter:maxConnectionsPerIp") ?? 0);
         if (!Number.isFinite(max) || max <= 0 || !clientIp) {
             return true;
         }


### PR DESCRIPTION
The socket.io server hardcoded cors.origin '*': any website could
connect its visitors' browsers to a Sockethub instance and use it as a
relay (IRC spam, feed-fetch proxying). The origin is now configurable
via sockethub.cors.origin — '*' (default, preserving behavior), a
single origin, or a comma-separated list. Public deployments should
set an explicit origin.

The per-event rate limiter is keyed by socket id, so a client could
bypass it by opening additional sockets. rateLimiter.maxConnectionsPerIp
(default 0 = disabled) now caps concurrent connections per client IP;
sockets over the cap receive an error message and are disconnected.