### PR TITLE
fix(ci): use pull_request_target for auto-label so fork PRs get labeled

### DIFF
--- a/.github/workflows/auto-label-pr.yml
+++ b/.github/workflows/auto-label-pr.yml
@@ -1,7 +1,11 @@
 name: Auto Label PR
 
 on:
-  pull_request:
+  # pull_request_target (not pull_request) so this gets a write-scoped token
+  # even for PRs from forks. Safe here because the job only reads
+  # `pull_request.title` and calls the labels API — it never checks out or
+  # executes any code from the PR head.
+  pull_request_target:
     types: [opened, reopened, edited, synchronize]
 
 jobs:


### PR DESCRIPTION
## Summary

`.github/workflows/auto-label-pr.yml` labels PRs based on their conventional-commit title, but it's triggered on `pull_request`, which GitHub always issues a **read-only** token for when the PR comes from a fork — regardless of the `permissions:` block declared in the workflow. That caused every fork PR's label step to fail with `403: Resource not accessible by integration` (e.g. observed on #1143).

## Fix

Switch the trigger to `pull_request_target`, which runs with the base repository's context and grants the declared `pull-requests: write` permission even for PRs from forks.

This is safe in this specific case because the job never checks out or executes any code from the PR head — it only reads `pull_request.title` (a string) and calls the GitHub labels API. `pull_request_target` is unsafe when a workflow checks out and runs PR-controlled code with elevated permissions; that doesn't apply here.

## Testing

- Reviewed the workflow file: no `actions/checkout` step, no execution of anything from the PR diff/head — only `pull_request.title` is read.
- YAML change is minimal (trigger key swap + comment); job body untouched.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the automatic PR labeling workflow to run with safer permissions and avoid executing code from incoming changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->