### PR TITLE
ci: make failure-issue label creation idempotent, clarify NPM_TOKEN docs

### DIFF
--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -374,6 +374,9 @@ jobs:
           # Check if an issue already exists for this version
           EXISTING=$(gh issue list --search "Release v$VERSION failed in:title" --state open --json number --jq '.[0].number')
 
+          # Ensure the label exists so issue creation doesn't fail if it's missing
+          gh label create "release" --color "0e8a16" --description "Release process issues" 2>/dev/null || true
+
           if [ -n "$EXISTING" ]; then
             echo "📝 Updating existing issue #$EXISTING"
             gh issue comment "$EXISTING" --body "$(cat failure_report.md)"

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -344,6 +344,23 @@ A single release might update:
 
 **Prevention**: Set calendar reminder for token renewal (90 days).
 
+### NPM Publish Requires OTP (`EOTP`)
+
+**Error**: `lerna ERR! EOTP You must provide a one-time pass.` — `npm whoami` still succeeds, so the
+token isn't expired; it's just the wrong *type*. A classic **"Publish"** token always requires an
+interactive 2FA one-time-pass, even in CI, so it can never work here. Only these bypass OTP:
+
+- Classic token, type **"Automation"**, or
+- Granular Access Token with **"Bypass two-factor authentication for token-based publishes"**
+  explicitly checked when creating it
+
+**Solution**:
+
+1. Generate a new token at <https://www.npmjs.com/settings/YOUR_USERNAME/tokens> using one of the
+   two types above
+2. Update GitHub secret: Settings → Secrets → `NPM_TOKEN`
+3. Re-run the publish workflow (it's idempotent — already-published packages are skipped)
+
 ### Package Verification Failed
 
 **Error**: `Package not found on npm`
@@ -504,7 +521,9 @@ existing draft release will be automatically deleted and recreated with fresh no
 
 **NPM_TOKEN**:
 
-- Type: "Automation" or "Publish"
+- Type: "Automation" (classic), or a Granular Access Token with "Bypass two-factor
+  authentication for token-based publishes" checked. **Not** classic "Publish" — that type
+  requires an interactive OTP on every publish and will fail in CI with `EOTP`.
 - Permissions: Publish and manage packages
 - Expiration: 90 days (max)
 


### PR DESCRIPTION
## Summary
- The release-publish failure handler crashed with `could not add label: 'release' not found` when reporting a real failure (the alpha.13 npm EOTP failure), masking the actual error in a second unrelated error. Now creates the label idempotently before use.
- Docs said `NPM_TOKEN` could be "Automation" or "Publish" type — that's wrong. Classic "Publish" tokens require an interactive OTP on every publish and always fail in CI with `EOTP`. Clarified requirements and added a troubleshooting entry.

## Test plan
- [x] YAML validated (`js-yaml`)
- [x] No functional npm/lerna logic changed — only the failure-reporting path and docs

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved release publishing so failure reports can be created reliably even when the required issue label is missing.
* **Documentation**
  * Expanded release troubleshooting guidance for npm publish OTP errors.
  * Clarified which token types work for automated publishing in CI.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->