### PR TITLE
docs: align IRC room addressing with channel@server convention

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -317,8 +317,8 @@ Redis and BullMQ provide reliable, encrypted communication between server and pl
     "https://sockethub.org/ns/context/v1.jsonld",
     "https://sockethub.org/ns/context/platform/irc/v1.jsonld"
   ],
-  "actor": { "id": "mynick", "type": "person" },
-  "target": { "id": "#javascript", "type": "room" },
+  "actor": { "id": "mynick@irc.libera.chat", "type": "person", "name": "mynick" },
+  "target": { "id": "javascript@irc.libera.chat", "type": "room" },
   "object": { "type": "message", "content": "Hello!" }
 }
 
@@ -406,8 +406,8 @@ IRC: ":alice!user@host PRIVMSG #room :hello world"
 ActivityStreams: {
   "type": "send",
   "@context": ["...as2", "...sockethub", "...irc"],
-  "actor": { "id": "alice", "type": "person" },
-  "target": { "id": "#room", "type": "room" },
+  "actor": { "id": "alice@irc.libera.chat", "type": "person", "name": "alice" },
+  "target": { "id": "room@irc.libera.chat", "type": "room" },
   "object": { "type": "message", "content": "hello world" }
 }
 ```
@@ -418,8 +418,8 @@ ActivityStreams: {
 ActivityStreams: {
   "type": "join",
   "@context": ["...as2", "...sockethub", "...irc"],
-  "actor": { "id": "mynick", "type": "person" },
-  "target": { "id": "#room", "type": "room" }
+  "actor": { "id": "mynick@irc.libera.chat", "type": "person", "name": "mynick" },
+  "target": { "id": "room@irc.libera.chat", "type": "room" }
 }
   ↓
 IRC: "JOIN #room"
@@ -439,8 +439,8 @@ Web applications send the same ActivityStreams format regardless of target proto
     "https://sockethub.org/ns/context/v1.jsonld",
     "https://sockethub.org/ns/context/platform/irc/v1.jsonld"
   ],
-  "actor": { "id": "user", "type": "person" },
-  "target": { "id": "#room", "type": "room" },
+  "actor": { "id": "user@irc.libera.chat", "type": "person", "name": "user" },
+  "target": { "id": "room@irc.libera.chat", "type": "room" },
   "object": { "type": "message", "content": "Hello!" }
 }
 ```

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -318,7 +318,7 @@ Redis and BullMQ provide reliable, encrypted communication between server and pl
     "https://sockethub.org/ns/context/platform/irc/v1.jsonld"
   ],
   "actor": { "id": "mynick@irc.libera.chat", "type": "person", "name": "mynick" },
-  "target": { "id": "javascript@irc.libera.chat", "type": "room" },
+  "target": { "id": "javascript@irc.libera.chat", "type": "room", "name": "#javascript" },
   "object": { "type": "message", "content": "Hello!" }
 }
 
@@ -407,7 +407,7 @@ ActivityStreams: {
   "type": "send",
   "@context": ["...as2", "...sockethub", "...irc"],
   "actor": { "id": "alice@irc.libera.chat", "type": "person", "name": "alice" },
-  "target": { "id": "room@irc.libera.chat", "type": "room" },
+  "target": { "id": "room@irc.libera.chat", "type": "room", "name": "#room" },
   "object": { "type": "message", "content": "hello world" }
 }
 ```
@@ -419,7 +419,7 @@ ActivityStreams: {
   "type": "join",
   "@context": ["...as2", "...sockethub", "...irc"],
   "actor": { "id": "mynick@irc.libera.chat", "type": "person", "name": "mynick" },
-  "target": { "id": "room@irc.libera.chat", "type": "room" }
+  "target": { "id": "room@irc.libera.chat", "type": "room", "name": "#room" }
 }
   ↓
 IRC: "JOIN #room"
@@ -440,7 +440,7 @@ Web applications send the same ActivityStreams format regardless of target proto
     "https://sockethub.org/ns/context/platform/irc/v1.jsonld"
   ],
   "actor": { "id": "user@irc.libera.chat", "type": "person", "name": "user" },
-  "target": { "id": "room@irc.libera.chat", "type": "room" },
+  "target": { "id": "room@irc.libera.chat", "type": "room", "name": "#room" },
   "object": { "type": "message", "content": "Hello!" }
 }
 ```

--- a/docs/client-guide.md
+++ b/docs/client-guide.md
@@ -99,7 +99,7 @@ sc.socket.emit('message', {
     type: 'send',
     '@context': sc.contextFor('irc'),
     actor: { id: 'mynick@irc.libera.chat', type: 'person', name: 'mynick' },
-    target: { id: 'sockethub@irc.libera.chat', type: 'room' },
+    target: { id: 'sockethub@irc.libera.chat', type: 'room', name: '#sockethub' },
     object: { type: 'message', content: 'Hello channel' }
 }, (result) => {
     if (result?.error) {
@@ -149,7 +149,7 @@ success/failure.
   "type": "send",            // Action: send, connect, join, fetch
   "@context": sc.contextFor("irc"),  // Canonical contexts for this platform
   "actor": { "id": "user@irc.libera.chat", "type": "person", "name": "user" },  // Who
-  "target": { "id": "room@irc.libera.chat", "type": "room" },  // Where (optional)
+  "target": { "id": "room@irc.libera.chat", "type": "room", "name": "#room" },  // Where (optional)
   "object": { "type": "message", "content": "Hi!" }   // What
 }
 ```
@@ -158,9 +158,10 @@ The `actor` object must have an `id` and `type` field, and if `name` does not ex
 the `id` will be used for display purposes.
 
 For IRC, room targets use `channel@server` in `target.id` (for example
-`sockethub@irc.libera.chat`). The leading `#` belongs in `target.name` when you
-want to preserve the IRC channel sigil for display; `type: "room"` disambiguates
-room ids from person ids (`nick@server`).
+`sockethub@irc.libera.chat`). Put the channel name as it appears on IRC in
+`target.name` (for example `#sockethub`). The `#` does not belong in
+`target.id`; `type: "room"` disambiguates room ids from person ids
+(`nick@server`).
 
 ### Platform-Specific Object Properties
 
@@ -179,7 +180,7 @@ sc.socket.emit('message', {
     type: 'send',
     '@context': sc.contextFor('irc'),
     actor: { id: 'me@irc.libera.chat', type: 'person', name: 'me' },
-    target: { id: 'general@irc.libera.chat', type: 'room' },
+    target: { id: 'general@irc.libera.chat', type: 'room', name: '#general' },
     object: {
         type: 'message',
         content: 'Hello!',
@@ -214,7 +215,7 @@ sc.socket.emit('credentials', {
 sc.socket.emit('message', {
     type: 'connect',
     '@context': sc.contextFor('irc'),
-    actor: { id: 'mynick', type: 'person' }
+    actor: { id: 'mynick@irc.libera.chat', type: 'person', name: 'mynick' }
 });
 ```
 
@@ -296,7 +297,7 @@ sc.socket.emit('message', {
     type: 'join',
     '@context': sc.contextFor('irc'),
     actor: { id: 'mynick@irc.libera.chat', type: 'person', name: 'mynick' },
-    target: { id: 'channel@irc.libera.chat', type: 'room' }
+    target: { id: 'channel@irc.libera.chat', type: 'room', name: '#channel' }
 });
 ```
 

--- a/docs/client-guide.md
+++ b/docs/client-guide.md
@@ -98,8 +98,8 @@ with `error` as failure.
 sc.socket.emit('message', {
     type: 'send',
     '@context': sc.contextFor('irc'),
-    actor: { id: 'mynick', type: 'person' },
-    target: { id: '#sockethub', type: 'room' },
+    actor: { id: 'mynick@irc.libera.chat', type: 'person', name: 'mynick' },
+    target: { id: 'sockethub@irc.libera.chat', type: 'room' },
     object: { type: 'message', content: 'Hello channel' }
 }, (result) => {
     if (result?.error) {
@@ -148,14 +148,19 @@ success/failure.
 {
   "type": "send",            // Action: send, connect, join, fetch
   "@context": sc.contextFor("irc"),  // Canonical contexts for this platform
-  "actor": { "id": "user", "type": "person" },     // Who
-  "target": { "id": "#room", "type": "room" },     // Where (optional)
+  "actor": { "id": "user@irc.libera.chat", "type": "person", "name": "user" },  // Who
+  "target": { "id": "room@irc.libera.chat", "type": "room" },  // Where (optional)
   "object": { "type": "message", "content": "Hi!" }   // What
 }
 ```
 
 The `actor` object must have an `id` and `type` field, and if `name` does not exist,
 the `id` will be used for display purposes.
+
+For IRC, room targets use `channel@server` in `target.id` (for example
+`sockethub@irc.libera.chat`). The leading `#` belongs in `target.name` when you
+want to preserve the IRC channel sigil for display; `type: "room"` disambiguates
+room ids from person ids (`nick@server`).
 
 ### Platform-Specific Object Properties
 
@@ -173,8 +178,8 @@ await sc.ready();
 sc.socket.emit('message', {
     type: 'send',
     '@context': sc.contextFor('irc'),
-    actor: { id: 'me@example.com', type: 'person' },
-    target: { id: '#general', type: 'room' },
+    actor: { id: 'me@irc.libera.chat', type: 'person', name: 'me' },
+    target: { id: 'general@irc.libera.chat', type: 'room' },
     object: {
         type: 'message',
         content: 'Hello!',
@@ -192,7 +197,7 @@ await sc.ready();
 sc.socket.emit('credentials', {
     '@context': sc.contextFor('irc'),
     type: 'credentials',
-    actor: { id: 'mynick', type: 'person' },
+    actor: { id: 'mynick@irc.libera.chat', type: 'person', name: 'mynick' },
     object: {
         type: 'credentials',
         nick: 'mynick',
@@ -246,7 +251,7 @@ The rejected request returns an ActivityStream response with an `error`:
 {
   "context": "irc",
   "type": "connect",
-  "actor": { "id": "mynick", "type": "person" },
+  "actor": { "id": "mynick@irc.libera.chat", "type": "person", "name": "mynick" },
   "id": "1",
   "error": "username already in use"
 }
@@ -290,8 +295,8 @@ sc.socket.emit('message', {
 sc.socket.emit('message', {
     type: 'join',
     '@context': sc.contextFor('irc'),
-    actor: { id: 'mynick', type: 'person' },
-    target: { id: '#channel', type: 'room' }
+    actor: { id: 'mynick@irc.libera.chat', type: 'person', name: 'mynick' },
+    target: { id: 'channel@irc.libera.chat', type: 'room' }
 });
 ```
 

--- a/docs/img/activitystreams-send-receive.dark.svg
+++ b/docs/img/activitystreams-send-receive.dark.svg
@@ -25,11 +25,11 @@
   <text x="72" y="175" class="code"><tspan class="s">"https://sockethub.org/ns/context/platform/irc/v1.jsonld"</tspan></text>
   <text x="56" y="193" class="code"><tspan class="p">],</tspan></text>
   <text x="56" y="211" class="code"><tspan class="k">"actor"</tspan><tspan class="p">: {</tspan></text>
-  <text x="72" y="229" class="code"><tspan class="k">"id"</tspan><tspan class="p">: </tspan><tspan class="s">"alice"</tspan><tspan class="p">,</tspan></text>
+  <text x="72" y="229" class="code"><tspan class="k">"id"</tspan><tspan class="p">: </tspan><tspan class="s">"alice@irc.libera.chat"</tspan><tspan class="p">,</tspan></text>
   <text x="72" y="247" class="code"><tspan class="k">"type"</tspan><tspan class="p">: </tspan><tspan class="s">"person"</tspan></text>
   <text x="56" y="265" class="code"><tspan class="p">},</tspan></text>
   <text x="56" y="283" class="code"><tspan class="k">"target"</tspan><tspan class="p">: {</tspan></text>
-  <text x="72" y="301" class="code"><tspan class="k">"id"</tspan><tspan class="p">: </tspan><tspan class="s">"#sockethub"</tspan><tspan class="p">,</tspan></text>
+  <text x="72" y="301" class="code"><tspan class="k">"id"</tspan><tspan class="p">: </tspan><tspan class="s">"sockethub@irc.libera.chat"</tspan><tspan class="p">,</tspan></text>
   <text x="72" y="319" class="code"><tspan class="k">"type"</tspan><tspan class="p">: </tspan><tspan class="s">"room"</tspan></text>
   <text x="56" y="337" class="code"><tspan class="p">},</tspan></text>
   <text x="56" y="355" class="code"><tspan class="k">"object"</tspan><tspan class="p">: {</tspan></text>
@@ -47,11 +47,11 @@
   <text x="672" y="175" class="code"><tspan class="s">"https://sockethub.org/ns/context/platform/irc/v1.jsonld"</tspan></text>
   <text x="656" y="193" class="code"><tspan class="p">],</tspan></text>
   <text x="656" y="211" class="code"><tspan class="k">"actor"</tspan><tspan class="p">: {</tspan></text>
-  <text x="672" y="229" class="code"><tspan class="k">"id"</tspan><tspan class="p">: </tspan><tspan class="s">"bob"</tspan><tspan class="p">,</tspan></text>
+  <text x="672" y="229" class="code"><tspan class="k">"id"</tspan><tspan class="p">: </tspan><tspan class="s">"bob@irc.libera.chat"</tspan><tspan class="p">,</tspan></text>
   <text x="672" y="247" class="code"><tspan class="k">"type"</tspan><tspan class="p">: </tspan><tspan class="s">"person"</tspan></text>
   <text x="656" y="265" class="code"><tspan class="p">},</tspan></text>
   <text x="656" y="283" class="code"><tspan class="k">"target"</tspan><tspan class="p">: {</tspan></text>
-  <text x="672" y="301" class="code"><tspan class="k">"id"</tspan><tspan class="p">: </tspan><tspan class="s">"#sockethub"</tspan><tspan class="p">,</tspan></text>
+  <text x="672" y="301" class="code"><tspan class="k">"id"</tspan><tspan class="p">: </tspan><tspan class="s">"sockethub@irc.libera.chat"</tspan><tspan class="p">,</tspan></text>
   <text x="672" y="319" class="code"><tspan class="k">"type"</tspan><tspan class="p">: </tspan><tspan class="s">"room"</tspan></text>
   <text x="656" y="337" class="code"><tspan class="p">},</tspan></text>
   <text x="656" y="355" class="code"><tspan class="k">"object"</tspan><tspan class="p">: {</tspan></text>

--- a/docs/img/activitystreams-send-receive.svg
+++ b/docs/img/activitystreams-send-receive.svg
@@ -25,11 +25,11 @@
   <text x="72" y="175" class="code"><tspan class="s">"https://sockethub.org/ns/context/platform/irc/v1.jsonld"</tspan></text>
   <text x="56" y="193" class="code"><tspan class="p">],</tspan></text>
   <text x="56" y="211" class="code"><tspan class="k">"actor"</tspan><tspan class="p">: {</tspan></text>
-  <text x="72" y="229" class="code"><tspan class="k">"id"</tspan><tspan class="p">: </tspan><tspan class="s">"alice"</tspan><tspan class="p">,</tspan></text>
+  <text x="72" y="229" class="code"><tspan class="k">"id"</tspan><tspan class="p">: </tspan><tspan class="s">"alice@irc.libera.chat"</tspan><tspan class="p">,</tspan></text>
   <text x="72" y="247" class="code"><tspan class="k">"type"</tspan><tspan class="p">: </tspan><tspan class="s">"person"</tspan></text>
   <text x="56" y="265" class="code"><tspan class="p">},</tspan></text>
   <text x="56" y="283" class="code"><tspan class="k">"target"</tspan><tspan class="p">: {</tspan></text>
-  <text x="72" y="301" class="code"><tspan class="k">"id"</tspan><tspan class="p">: </tspan><tspan class="s">"#sockethub"</tspan><tspan class="p">,</tspan></text>
+  <text x="72" y="301" class="code"><tspan class="k">"id"</tspan><tspan class="p">: </tspan><tspan class="s">"sockethub@irc.libera.chat"</tspan><tspan class="p">,</tspan></text>
   <text x="72" y="319" class="code"><tspan class="k">"type"</tspan><tspan class="p">: </tspan><tspan class="s">"room"</tspan></text>
   <text x="56" y="337" class="code"><tspan class="p">},</tspan></text>
   <text x="56" y="355" class="code"><tspan class="k">"object"</tspan><tspan class="p">: {</tspan></text>
@@ -47,11 +47,11 @@
   <text x="672" y="175" class="code"><tspan class="s">"https://sockethub.org/ns/context/platform/irc/v1.jsonld"</tspan></text>
   <text x="656" y="193" class="code"><tspan class="p">],</tspan></text>
   <text x="656" y="211" class="code"><tspan class="k">"actor"</tspan><tspan class="p">: {</tspan></text>
-  <text x="672" y="229" class="code"><tspan class="k">"id"</tspan><tspan class="p">: </tspan><tspan class="s">"bob"</tspan><tspan class="p">,</tspan></text>
+  <text x="672" y="229" class="code"><tspan class="k">"id"</tspan><tspan class="p">: </tspan><tspan class="s">"bob@irc.libera.chat"</tspan><tspan class="p">,</tspan></text>
   <text x="672" y="247" class="code"><tspan class="k">"type"</tspan><tspan class="p">: </tspan><tspan class="s">"person"</tspan></text>
   <text x="656" y="265" class="code"><tspan class="p">},</tspan></text>
   <text x="656" y="283" class="code"><tspan class="k">"target"</tspan><tspan class="p">: {</tspan></text>
-  <text x="672" y="301" class="code"><tspan class="k">"id"</tspan><tspan class="p">: </tspan><tspan class="s">"#sockethub"</tspan><tspan class="p">,</tspan></text>
+  <text x="672" y="301" class="code"><tspan class="k">"id"</tspan><tspan class="p">: </tspan><tspan class="s">"sockethub@irc.libera.chat"</tspan><tspan class="p">,</tspan></text>
   <text x="672" y="319" class="code"><tspan class="k">"type"</tspan><tspan class="p">: </tspan><tspan class="s">"room"</tspan></text>
   <text x="656" y="337" class="code"><tspan class="p">},</tspan></text>
   <text x="656" y="355" class="code"><tspan class="k">"object"</tspan><tspan class="p">: {</tspan></text>

--- a/packages/client/README.md
+++ b/packages/client/README.md
@@ -187,7 +187,11 @@ sc.socket.emit("message", {
     type: "join",
     "@context": sc.contextFor("irc"),
     actor: { id: "mynick@irc.libera.chat", type: "person", name: "mynick" },
-    target: { id: "sockethub@irc.libera.chat", type: "room" },
+    target: {
+        id: "sockethub@irc.libera.chat",
+        type: "room",
+        name: "#sockethub",
+    },
 }, (result) => {
     if (result?.error) console.error(result.error);
 });

--- a/packages/client/README.md
+++ b/packages/client/README.md
@@ -186,8 +186,8 @@ client-side error instead of dispatching a malformed message.
 sc.socket.emit("message", {
     type: "join",
     "@context": sc.contextFor("irc"),
-    actor: { id: "mynick", type: "person", name: "My IRC Nick" },
-    target: { id: "#sockethub", type: "room" },
+    actor: { id: "mynick@irc.libera.chat", type: "person", name: "mynick" },
+    target: { id: "sockethub@irc.libera.chat", type: "room" },
 }, (result) => {
     if (result?.error) console.error(result.error);
 });

--- a/packages/examples/src/components/chat/Room.svelte
+++ b/packages/examples/src/components/chat/Room.svelte
@@ -63,10 +63,10 @@ async function joinRoom(): Promise<void> {
                 id="room" 
                 bind:value={room} 
                 class="w-full px-4 py-3 border border-gray-300 rounded-lg shadow-sm focus:ring-2 focus:ring-indigo-500 focus:border-indigo-500 transition-colors duration-200 text-gray-900 placeholder-gray-500" 
-                placeholder="#general, kosmos-random@kosmos.chat"
+                placeholder="general, kosmos-random@kosmos.chat"
             />
             <p class="text-gray-500 text-xs">
-                💡 IRC: Use #channel-name | XMPP: Use room@server.com
+                💡 IRC: channel@server (e.g. sockethub@irc.libera.chat) | XMPP: room@server.com
             </p>
         </div>
         

--- a/packages/examples/src/components/chat/Room.svelte
+++ b/packages/examples/src/components/chat/Room.svelte
@@ -63,10 +63,10 @@ async function joinRoom(): Promise<void> {
                 id="room" 
                 bind:value={room} 
                 class="w-full px-4 py-3 border border-gray-300 rounded-lg shadow-sm focus:ring-2 focus:ring-indigo-500 focus:border-indigo-500 transition-colors duration-200 text-gray-900 placeholder-gray-500" 
-                placeholder="general, kosmos-random@kosmos.chat"
+                placeholder="sockethub@irc.libera.chat, kosmos-random@kosmos.chat"
             />
             <p class="text-gray-500 text-xs">
-                💡 IRC: channel@server (e.g. sockethub@irc.libera.chat) | XMPP: room@server.com
+                💡 IRC: channel@server (e.g. sockethub@irc.libera.chat); include # in name when sending (e.g. #sockethub) | XMPP: room@server.com
             </p>
         </div>
         

--- a/packages/platform-irc/README.md
+++ b/packages/platform-irc/README.md
@@ -33,7 +33,7 @@ messages.
     "type": "person"
   },
   "target": {
-    "id": "#general@irc.libera.chat",
+    "id": "general@irc.libera.chat",
     "type": "room"
   },
   "object": {
@@ -58,7 +58,7 @@ messages.
     "type": "person"
   },
   "target": {
-    "id": "#general@irc.libera.chat",
+    "id": "general@irc.libera.chat",
     "type": "room"
   }
 }
@@ -104,7 +104,7 @@ messages.
     "type": "person"
   },
   "target": {
-    "id": "#general@irc.libera.chat",
+    "id": "general@irc.libera.chat",
     "type": "room"
   },
   "object": {
@@ -153,7 +153,7 @@ messages.
     "type": "person"
   },
   "target": {
-    "id": "#general@irc.libera.chat",
+    "id": "general@irc.libera.chat",
     "type": "room"
   },
   "object": {
@@ -173,7 +173,7 @@ messages.
     "https://sockethub.org/ns/context/platform/irc/v1.jsonld"
   ],
   "actor": {
-    "id": "#general@irc.libera.chat",
+    "id": "general@irc.libera.chat",
     "type": "room"
   },
   "target": {},

--- a/packages/platform-irc/README.md
+++ b/packages/platform-irc/README.md
@@ -18,6 +18,10 @@ messages.
 
 ## Usage
 
+IRC room targets use `channel@server` in `target.id` (for example
+`general@irc.libera.chat`). When you include `target.name`, use the channel
+name as it appears on IRC (for example `#general`).
+
 ### Send Message Example
 
 ```json
@@ -34,7 +38,8 @@ messages.
   },
   "target": {
     "id": "general@irc.libera.chat",
-    "type": "room"
+    "type": "room",
+    "name": "#general"
   },
   "object": {
     "type": "message",
@@ -59,7 +64,8 @@ messages.
   },
   "target": {
     "id": "general@irc.libera.chat",
-    "type": "room"
+    "type": "room",
+    "name": "#general"
   }
 }
 ```
@@ -105,7 +111,8 @@ messages.
   },
   "target": {
     "id": "general@irc.libera.chat",
-    "type": "room"
+    "type": "room",
+    "name": "#general"
   },
   "object": {
     "type": "topic",
@@ -154,7 +161,8 @@ messages.
   },
   "target": {
     "id": "general@irc.libera.chat",
-    "type": "room"
+    "type": "room",
+    "name": "#general"
   },
   "object": {
     "type": "attendance"
@@ -174,7 +182,8 @@ messages.
   ],
   "actor": {
     "id": "general@irc.libera.chat",
-    "type": "room"
+    "type": "room",
+    "name": "#general"
   },
   "target": {},
   "object": {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Updates documentation and examples to match the normalized IRC room addressing convention:

- **`target.id`**: `channel@server` (no leading `#`, e.g. `sockethub@irc.libera.chat`)
- **`target.name`**: channel as it appears on IRC (with `#`, e.g. `#sockethub`)
- **`actor.id`**: `nick@server` (e.g. `mynick@irc.libera.chat`)

## Changes

- **README diagrams** (`docs/img/activitystreams-send-receive*.svg`): update actor and room target ids
- **`docs/client-guide.md`**: fix IRC examples; clarify `target.id` vs `target.name`
- **`docs/architecture.md`**: fix ActivityStreams examples in the IRC flow section
- **`packages/client/README.md`**: fix join example with `target.name`
- **`packages/platform-irc/README.md`**: add addressing note; `#general@…` → `general@…` with `name: "#general"`
- **`packages/examples/.../Room.svelte`**: refresh placeholder and hint text

Wire-protocol references (`PRIVMSG #channel`, `JOIN #room`) are intentionally unchanged — those describe IRC on the wire, not ActivityStreams ids.

## Related

Companion website update on branch `fix/irc-room-naming-docs-2be9` in `sockethub/website-sockethub.org` (needs push from a machine with write access).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-966d847b-8d6c-4c53-91b5-cc9681f72be9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-966d847b-8d6c-4c53-91b5-cc9681f72be9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated IRC ActivityStreams examples across the architecture docs, client guide, and package READMEs to use fully-qualified `nick@irc.libera.chat` / `channel@irc.libera.chat` identifiers.
  * Added/adjusted `name` fields in example payloads and clarified how IRC `target.id` vs `target.name` map (including `#channel` display).
  * Refreshed the chat UI guidance and examples to reflect the correct IRC vs XMPP room targeting formats.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->