### PR TITLE
ci: restore release package-test gate and packaged-test config

### DIFF
--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -25,7 +25,7 @@ jobs:
       (github.event_name == 'workflow_dispatch')
     uses: ./.github/workflows/test-npm-package.yml
     with:
-      runtime: both
+      runtime: node
       suite: all
 
   publish:

--- a/.github/workflows/test-npm-package.yml
+++ b/.github/workflows/test-npm-package.yml
@@ -53,6 +53,19 @@ jobs:
       fail-fast: false
 
     steps:
+      # node is the only supported deployment runtime. An unrecognized value
+      # must fail the job immediately, not skip steps: a caller passing a
+      # stale value (e.g. 'both') would otherwise produce a green job that
+      # tested nothing.
+      - name: Validate runtime
+        env:
+          INPUT_RUNTIME: ${{ inputs.runtime || github.event.inputs.runtime || 'node' }}
+        run: |
+          if [ "$INPUT_RUNTIME" != "node" ]; then
+            echo "Error: unsupported runtime '$INPUT_RUNTIME' (supported: node)" >&2
+            exit 1
+          fi
+
       - name: Normalize ref
         id: ref
         env:
@@ -82,28 +95,7 @@ jobs:
         with:
           node-version: '20'
 
-      - name: Determine runtime
-        id: runtime
-        env:
-          INPUT_RUNTIME: ${{ inputs.runtime || github.event.inputs.runtime || 'node' }}
-          MATRIX_RUNTIME: ${{ matrix.runtime }}
-        run: |
-          # node is the only supported deployment runtime. An unrecognized
-          # value must fail the job, not skip every step: a caller passing a
-          # stale value (e.g. 'both') would otherwise produce a green job that
-          # tested nothing.
-          if [ "$INPUT_RUNTIME" != "node" ]; then
-            echo "Error: unsupported runtime '$INPUT_RUNTIME' (supported: node)" >&2
-            exit 1
-          fi
-          if [ "$INPUT_RUNTIME" = "$MATRIX_RUNTIME" ]; then
-            echo "run_test=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "run_test=false" >> "$GITHUB_OUTPUT"
-          fi
-
       - name: Validate suite
-        if: steps.runtime.outputs.run_test == 'true'
         env:
           INPUT_SUITE: ${{ inputs.suite || github.event.inputs.suite || 'all' }}
         run: |
@@ -113,15 +105,12 @@ jobs:
           fi
 
       - name: Install dependencies
-        if: steps.runtime.outputs.run_test == 'true'
         run: bun install
 
       - name: Build packages
-        if: steps.runtime.outputs.run_test == 'true'
         run: bun run build
 
       - name: Start local npm registry
-        if: steps.runtime.outputs.run_test == 'true'
         run: |
           REGISTRY_DIR="$RUNNER_TEMP/verdaccio"
           mkdir -p "$REGISTRY_DIR"
@@ -146,7 +135,6 @@ jobs:
           exit 1
 
       - name: Publish packages to local registry
-        if: steps.runtime.outputs.run_test == 'true'
         env:
           NPM_CONFIG_REGISTRY: ${{ env.LOCAL_REGISTRY_URL }}
         run: |
@@ -159,7 +147,6 @@ jobs:
             --ignore-scripts
 
       - name: Resolve package version
-        if: steps.runtime.outputs.run_test == 'true'
         id: package
         run: |
           VERSION=$(node -p "require('./packages/sockethub/package.json').version")
@@ -167,7 +154,6 @@ jobs:
           echo "Testing packaged sockethub@$VERSION"
 
       - name: Run tests against locally published package
-        if: steps.runtime.outputs.run_test == 'true'
         env:
           MATRIX_RUNTIME: ${{ matrix.runtime }}
           SETUP_SUITE: ${{ inputs.suite || github.event.inputs.suite || 'all' }}
@@ -179,7 +165,7 @@ jobs:
             --suite "$SETUP_SUITE"
 
       - name: Upload test results
-        if: always() && steps.runtime.outputs.run_test == 'true'
+        if: always()
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: test-results-local-${{ matrix.runtime }}
@@ -187,7 +173,7 @@ jobs:
           retention-days: 30
 
       - name: Report status
-        if: always() && steps.runtime.outputs.run_test == 'true'
+        if: always()
         run: |
           if [ -f test-results/*/summary.json ]; then
             echo "Test Results Summary:"
@@ -195,7 +181,7 @@ jobs:
           fi
 
       - name: Stop local npm registry
-        if: always() && steps.runtime.outputs.run_test == 'true'
+        if: always()
         run: |
           PID_FILE="$RUNNER_TEMP/verdaccio/pid"
           if [ -f "$PID_FILE" ]; then

--- a/.github/workflows/test-npm-package.yml
+++ b/.github/workflows/test-npm-package.yml
@@ -53,10 +53,23 @@ jobs:
       fail-fast: false
 
     steps:
+      - name: Normalize ref
+        id: ref
+        env:
+          INPUT_REF: ${{ inputs.ref || github.event.inputs.ref || github.ref }}
+        run: |
+          # Accept a bare version (e.g. 5.0.0-alpha.13) by mapping it to its
+          # release tag (v5.0.0-alpha.13).
+          REF="$INPUT_REF"
+          if [[ "$REF" =~ ^[0-9]+\.[0-9]+\.[0-9]+ ]]; then
+            REF="v$REF"
+          fi
+          echo "ref=$REF" >> "$GITHUB_OUTPUT"
+
       - name: Checkout repository
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
-          ref: ${{ inputs.ref || github.event.inputs.ref || github.ref }}
+          ref: ${{ steps.ref.outputs.ref }}
           fetch-depth: 0
 
       - name: Setup Bun
@@ -75,7 +88,14 @@ jobs:
           INPUT_RUNTIME: ${{ inputs.runtime || github.event.inputs.runtime || 'node' }}
           MATRIX_RUNTIME: ${{ matrix.runtime }}
         run: |
-          # node is the only matrix runtime; run when it matches (default 'node').
+          # node is the only supported deployment runtime. An unrecognized
+          # value must fail the job, not skip every step: a caller passing a
+          # stale value (e.g. 'both') would otherwise produce a green job that
+          # tested nothing.
+          if [ "$INPUT_RUNTIME" != "node" ]; then
+            echo "Error: unsupported runtime '$INPUT_RUNTIME' (supported: node)" >&2
+            exit 1
+          fi
           if [ "$INPUT_RUNTIME" = "$MATRIX_RUNTIME" ]; then
             echo "run_test=true" >> "$GITHUB_OUTPUT"
           else

--- a/scripts/test-installed-version/services.js
+++ b/scripts/test-installed-version/services.js
@@ -2,7 +2,15 @@
  * Service management for test-installed-version script
  */
 
+import { fileURLToPath } from "node:url";
+
 import { CONFIG } from "./config.js";
+
+// Same config the docker-compose CI environment mounts: allows the
+// SSRF-guarded feeds/metadata platforms to fetch loopback test fixtures.
+const CI_CONFIG_PATH = fileURLToPath(
+    new URL("../../integration/sockethub.ci.config.json", import.meta.url),
+);
 
 export class ServiceManager {
     constructor(logger) {
@@ -176,6 +184,7 @@ export class ServiceManager {
                     REDIS_URL: "redis://127.0.0.1:6379",
                     PORT: "10550",
                     LOG_LEVEL: "debug",
+                    SOCKETHUB_CONFIG: CI_CONFIG_PATH,
                 },
             },
             "sockethub.log",


### PR DESCRIPTION
## Summary

The `test-local-packages` gate in release-publish has been a silent no-op since #1106: it passes `runtime: both`, but the test matrix was reduced to `[node]`, so the exact-match runtime check set `run_test=false`, every step was skipped, and the job reported success. **v5.0.0-alpha.13 was published with zero packaged-test verification** ([evidence](https://github.com/sockethub/sockethub/actions/runs/28725985062) — all steps after "Determine runtime" skipped).

Re-running Test NPM Package against `v5.0.0-alpha.13` ([run](https://github.com/sockethub/sockethub/actions/runs/28738438509)) then surfaced what the gate would have caught: `browser-basic` and `browser-contract` fail because the packaged-test harness spawns sockethub with no config file, so the SSRF-guarded fetch (#1133/#1138/#1140) blocks the loopback test fixtures (`http://localhost:10550/feed.xml`). The in-repo integration jobs don't hit this because docker-compose mounts `integration/sockethub.ci.config.json` (`allowPrivateAddresses: true`) via `SOCKETHUB_CONFIG`.

## Changes

- **release-publish.yml**: `runtime: both` → `runtime: node`, restoring the release gate
- **test-npm-package.yml**: fail loudly on an unrecognized runtime value instead of skipping every step, so a caller mismatch can never again produce a vacuous green job
- **test-npm-package.yml**: normalize a bare-semver `ref` input (`5.0.0-alpha.13` → `v5.0.0-alpha.13`), so dispatching with a version number checks out its release tag instead of failing at checkout
- **scripts/test-installed-version/services.js**: point `SOCKETHUB_CONFIG` at the same CI config docker-compose mounts, unblocking the feeds/metadata loopback fixtures

## Testing

- YAML validated; `biome check` clean on `services.js`; module loads and the config path resolves
- After merge, dispatching **Test NPM Package** with ref `v5.0.0-alpha.13` will still fail (the tag's harness predates the fix); the fix takes effect for master and future tags — will verify with a dispatch against master

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved release-package testing by using a consistent version tag format and validating unsupported runtime settings earlier, so failures surface clearly instead of silently skipping work.
  * Ensured the installed-version test environment starts with the correct configuration, making local package checks more reliable.

* **Chores**
  * Narrowed one release-publishing workflow to the Node runtime for more predictable test execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->