### PR TITLE
ci: export SOCKETHUB_CONFIG so packaged tests work against older tags

### DIFF
--- a/.github/workflows/test-npm-package.yml
+++ b/.github/workflows/test-npm-package.yml
@@ -153,15 +153,23 @@ jobs:
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"
           echo "Testing packaged sockethub@$VERSION"
 
+      # The harness spawns sockethub with `...process.env`, so this reaches the
+      # server even when an older checked-out ref's harness predates the
+      # explicit SOCKETHUB_CONFIG override (needed for tags v5.0.0-alpha.13 and
+      # earlier, whose SSRF guard otherwise blocks loopback fixtures). Only set
+      # when the ref ships the config: the server hard-fails on an explicit
+      # SOCKETHUB_CONFIG path that does not exist.
+      - name: Point sockethub at the CI config when the ref ships it
+        run: |
+          CONFIG="$GITHUB_WORKSPACE/integration/sockethub.ci.config.json"
+          if [ -f "$CONFIG" ]; then
+            echo "SOCKETHUB_CONFIG=$CONFIG" >> "$GITHUB_ENV"
+          fi
+
       - name: Run tests against locally published package
         env:
           MATRIX_RUNTIME: ${{ matrix.runtime }}
           SETUP_SUITE: ${{ inputs.suite || github.event.inputs.suite || 'all' }}
-          # The harness spawns sockethub with `...process.env`, so this reaches
-          # the server even when an older checked-out ref's harness predates the
-          # explicit SOCKETHUB_CONFIG override (needed for tags v5.0.0-alpha.13
-          # and earlier, whose SSRF guard otherwise blocks loopback fixtures).
-          SOCKETHUB_CONFIG: ${{ github.workspace }}/integration/sockethub.ci.config.json
         run: |
           bun run scripts/test-installed-version.js \
             "${{ steps.package.outputs.version }}" \

--- a/.github/workflows/test-npm-package.yml
+++ b/.github/workflows/test-npm-package.yml
@@ -157,6 +157,11 @@ jobs:
         env:
           MATRIX_RUNTIME: ${{ matrix.runtime }}
           SETUP_SUITE: ${{ inputs.suite || github.event.inputs.suite || 'all' }}
+          # The harness spawns sockethub with `...process.env`, so this reaches
+          # the server even when an older checked-out ref's harness predates the
+          # explicit SOCKETHUB_CONFIG override (needed for tags v5.0.0-alpha.13
+          # and earlier, whose SSRF guard otherwise blocks loopback fixtures).
+          SOCKETHUB_CONFIG: ${{ github.workspace }}/integration/sockethub.ci.config.json
         run: |
           bun run scripts/test-installed-version.js \
             "${{ steps.package.outputs.version }}" \


### PR DESCRIPTION
## Summary

Follow-up to #1164. Dispatching Test NPM Package against `v5.0.0-alpha.13` ([run](https://github.com/sockethub/sockethub/actions/runs/28739820316)) still failed `browser-basic`/`browser-contract`: the checkout at the tag uses the **tag's frozen harness**, which predates the `SOCKETHUB_CONFIG` fix, so the SSRF guard blocks the loopback fixtures.

The harness (both old and new) spawns sockethub with `...process.env`, so exporting `SOCKETHUB_CONFIG` at the workflow step level reaches the server regardless of which ref's harness runs. `integration/sockethub.ci.config.json` exists at every ref that ships the SSRF guard (added in #1133), so the path always resolves on affected tags.

## Changes

- `.github/workflows/test-npm-package.yml`: export `SOCKETHUB_CONFIG: ${{ github.workspace }}/integration/sockethub.ci.config.json` on the test step (5 lines, mostly comment)

## Testing

- Dispatched this branch's workflow against ref `v5.0.0-alpha.13` — the exact scenario that failed: https://github.com/sockethub/sockethub/actions/runs/28740492686 (result to be posted below)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved test reliability by ensuring the correct CI harness configuration is used when running tests against locally published packages.
  * Reduced test failures on older or tagged builds by automatically applying a provided CI configuration when it’s available.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->