### PR TITLE
fix(server): prevent crashed platform teardown from destroying its replacement

### DIFF
--- a/packages/data-layer/src/job-queue.test.ts
+++ b/packages/data-layer/src/job-queue.test.ts
@@ -296,8 +296,20 @@ describe("JobQueue", () => {
             await jobQueue.disconnect();
             sinon.assert.called(jobQueue.queue.removeAllListeners);
             sinon.assert.called(jobQueue.queue.close);
+            sinon.assert.called(jobQueue.events.close);
             sinon.assert.notCalled(jobQueue.queue.pause);
             sinon.assert.notCalled(jobQueue.queue.obliterate);
+        });
+
+        it("propagates errors from the underlying connection close", async () => {
+            jobQueue.queue.close.rejects(new Error("close failed"));
+            let err: Error | undefined;
+            try {
+                await jobQueue.disconnect();
+            } catch (e) {
+                err = e as Error;
+            }
+            expect(err?.message).to.equal("close failed");
         });
     });
 

--- a/packages/data-layer/src/job-queue.test.ts
+++ b/packages/data-layer/src/job-queue.test.ts
@@ -291,6 +291,16 @@ describe("JobQueue", () => {
         });
     });
 
+    describe("disconnect", () => {
+        it("closes connections without pausing or obliterating the queue", async () => {
+            await jobQueue.disconnect();
+            sinon.assert.called(jobQueue.queue.removeAllListeners);
+            sinon.assert.called(jobQueue.queue.close);
+            sinon.assert.notCalled(jobQueue.queue.pause);
+            sinon.assert.notCalled(jobQueue.queue.obliterate);
+        });
+    });
+
     describe("decryptJobData", () => {
         it("decrypts and returns expected object", () => {
             cryptoMocks.decrypt.returnsArg(0);

--- a/packages/data-layer/src/job-queue.ts
+++ b/packages/data-layer/src/job-queue.ts
@@ -222,6 +222,20 @@ export class JobQueue extends JobBase {
         await this.events.close();
     }
 
+    /**
+     * Closes this queue's connections without pausing or obliterating the
+     * underlying Redis queue. The queue name is derived from the platform
+     * instance identifier, so a replacement instance for the same identifier
+     * shares it; use this instead of shutdown() when a replacement exists
+     * and must keep accepting and processing jobs.
+     */
+    async disconnect() {
+        this.removeAllListeners();
+        this.queue.removeAllListeners();
+        await this.queue.close();
+        await this.events.close();
+    }
+
     private async getJob(jobId: string): Promise<JobDecrypted> {
         const job = await this.queue.getJob(jobId);
         if (job) {

--- a/packages/server/src/platform-instance.test.ts
+++ b/packages/server/src/platform-instance.test.ts
@@ -40,6 +40,7 @@ describe("PlatformInstance", () => {
             createQueue() {
                 this.JobQueue = sandbox.stub().returns({
                     shutdown: sandbox.stub(),
+                    disconnect: sandbox.stub(),
                     on: sandbox.stub(),
                     getJob: sandbox.stub(),
                     initResultEvents: sandbox.stub(),
@@ -163,6 +164,39 @@ describe("PlatformInstance", () => {
             await pi.shutdown();
             expect(pi.queue).toBeUndefined();
             expect(platformInstances.has("platform identifier")).toBeFalse();
+        });
+
+        test("shutdown of a replaced instance disconnects the queue without obliterating it", async () => {
+            pi.initQueue("a secret");
+            const queue = pi.queue;
+            pi.markReplaced();
+            expect(pi.flaggedForTermination).toEqual(true);
+            await pi.shutdown();
+            sandbox.assert.notCalled(queue.shutdown);
+            sandbox.assert.called(queue.disconnect);
+            expect(pi.queue).toBeUndefined();
+        });
+
+        test("shutdown does not evict a replacement instance from the map", async () => {
+            const TestPlatformInstance = getTestPlatformInstanceClass();
+            const replacement = new TestPlatformInstance({
+                identifier: "platform identifier",
+                platform: "a platform name",
+                parentId: "the parentId",
+            });
+            platformInstances.set(replacement.id, replacement);
+            pi.initQueue("a secret");
+            const queue = pi.queue;
+            await pi.shutdown();
+            // the queue name is shared with the replacement, so the stale
+            // instance must not pause/obliterate it
+            sandbox.assert.notCalled(queue.shutdown);
+            sandbox.assert.called(queue.disconnect);
+            expect(platformInstances.get("platform identifier")).toBe(
+                replacement,
+            );
+            platformInstances.set(pi.id, pi); // restore for afterEach shutdown
+            await replacement.shutdown();
         });
 
         test("updates its identifier when changed", () => {
@@ -456,6 +490,7 @@ describe("PlatformInstance", () => {
                 pause: sandbox.stub().resolves(),
                 resume: sandbox.stub().resolves(),
                 shutdown: sandbox.stub().resolves(),
+                disconnect: sandbox.stub().resolves(),
                 on: sandbox.stub(),
                 getJob: sandbox.stub(),
                 initResultEvents: sandbox.stub(),

--- a/packages/server/src/platform-instance.ts
+++ b/packages/server/src/platform-instance.ts
@@ -86,6 +86,7 @@ export default class PlatformInstance {
     private heartbeatMonitor?: NodeJS.Timeout;
     private heartbeatListener?: (message: MessageFromPlatform) => void;
     private heartbeatFailureHandled = false;
+    private replaced = false;
     private readonly actor?: string;
 
     constructor(params: PlatformInstanceParams) {
@@ -166,6 +167,19 @@ export default class PlatformInstance {
     }
 
     /**
+     * Marks this instance as superseded by a replacement that shares its
+     * identifier — and therefore its Redis queue name and platformInstances
+     * slot. shutdown() on a replaced instance must leave those shared
+     * resources alone: pausing/obliterating the queue would destroy the
+     * replacement's pending jobs, and deleting the map entry would evict
+     * the replacement, causing duplicate child processes (#1166).
+     */
+    public markReplaced() {
+        this.replaced = true;
+        this.flaggedForTermination = true;
+    }
+
+    /**
      * Destroys all references to this platform instance, internal listeners and controlled processes
      */
     public async shutdown() {
@@ -200,14 +214,25 @@ export default class PlatformInstance {
         }
 
         try {
-            await this.queue.shutdown();
+            if (this.replaced || platformInstances.get(this.id) !== this) {
+                // A replacement instance shares this queue's Redis name;
+                // pausing or obliterating it would destroy the replacement's
+                // pending jobs. Close our connections only.
+                await this.queue.disconnect();
+            } else {
+                await this.queue.shutdown();
+            }
             this.queue = undefined;
         } catch (_e) {
             // this needs to happen
         }
 
         try {
-            platformInstances.delete(this.id);
+            // Guard against evicting a replacement instance that has taken
+            // over this identifier since our teardown began.
+            if (platformInstances.get(this.id) === this) {
+                platformInstances.delete(this.id);
+            }
         } catch (_e) {
             // this needs to happen
         }

--- a/packages/server/src/process-manager.test.ts
+++ b/packages/server/src/process-manager.test.ts
@@ -40,6 +40,7 @@ describe("ProcessManager", () => {
             .callsFake(function (this: PlatformInstance) {
                 this.JobQueue = sandbox.stub().returns({
                     shutdown: sandbox.stub().resolves(),
+                    disconnect: sandbox.stub().resolves(),
                     on: sandbox.stub(),
                 }) as never;
             });
@@ -120,5 +121,39 @@ describe("ProcessManager", () => {
             manager.get("fakeplatform", "actor-a"),
         ).not.toThrow();
         expect(platformInstances.size).toEqual(1);
+    });
+
+    test("marks a dead instance as replaced before shutting it down", () => {
+        const first = manager.get("fakeplatform", "actor-a");
+        setAlive(first, false);
+        const markReplaced = sandbox.spy(first, "markReplaced");
+        const shutdown = sandbox.stub(first, "shutdown").resolves();
+        const second = manager.get("fakeplatform", "actor-a");
+        expect(second).not.toBe(first);
+        sinon.assert.calledOnce(markReplaced);
+        sinon.assert.calledOnce(shutdown);
+        expect(markReplaced.calledBefore(shutdown)).toEqual(true);
+    });
+
+    test("the dead instance's async teardown does not evict the replacement from the map", async () => {
+        const first = manager.get("fakeplatform", "actor-a");
+        setAlive(first, false);
+        const second = manager.get("fakeplatform", "actor-a");
+        expect(second).not.toBe(first);
+        // ensureProcess fires the old instance's shutdown without awaiting
+        // it; let it finish, then verify the replacement still owns the slot
+        await new Promise((resolve) => setTimeout(resolve, 0));
+        expect(platformInstances.get(second.id)).toBe(second);
+    });
+
+    test("does not shut down a live instance when reusing it", () => {
+        const first = manager.get("fakeplatform", "actor-a");
+        setAlive(first, true);
+        const markReplaced = sandbox.spy(first, "markReplaced");
+        const shutdown = sandbox.stub(first, "shutdown").resolves();
+        const second = manager.get("fakeplatform", "actor-a");
+        expect(second).toBe(first);
+        sinon.assert.notCalled(markReplaced);
+        sinon.assert.notCalled(shutdown);
     });
 });

--- a/packages/server/src/process-manager.ts
+++ b/packages/server/src/process-manager.ts
@@ -82,12 +82,18 @@ class ProcessManager {
         if (!reusable) {
             this.assertInstanceCapacity(platform, identifier);
         }
+        if (existing && !reusable) {
+            // The replacement created below shares `identifier` and the Redis
+            // queue name derived from it. Mark the dead instance as replaced
+            // *before* starting its async teardown so that teardown can't
+            // obliterate the replacement's queue or evict it from
+            // platformInstances (#1166).
+            existing.markReplaced();
+            void existing.shutdown();
+        }
         const platformInstance = reusable
             ? existing
             : this.createPlatformInstance(identifier, platform, actor);
-        if (existing && existing !== platformInstance) {
-            void existing.shutdown();
-        }
         if (sessionId) {
             platformInstance.registerSession(sessionId, sessionIp);
         }


### PR DESCRIPTION
## Summary

Fixes the `Parent Process Sudden Termination` CI flake (#1166), which turned out to be a real crash-recovery race in the server, not a timing issue.

When a platform child crashes, its `close` event fires tens to hundreds of ms after the process dies. If a client message arrives in that window, `ProcessManager.ensureProcess` creates a replacement instance under the **same identifier and Redis queue name**. The stale instance's `shutdown()` then destroyed the replacement's shared resources:

- `queue.shutdown()` paused and `obliterate({force: true})`d the shared-name queue, deleting the replacement's pending jobs — this is what vaporized the flaky test's `sigterm` job (8s of total silence in the failing run's logs)
- `platformInstances.delete(this.id)` unconditionally evicted the replacement from the instance map, so the next message spawned yet another child — the duplicate queue-inits and duplicate platform boots visible in the failing CI logs

The `ensureProcess` replacement path had the same defect ordering: it constructed the replacement first and then fired `void existing.shutdown()`, whose delayed delete/obliterate landed on the new instance.

## Changes

- `PlatformInstance.markReplaced()` — flags an instance as superseded so its teardown leaves shared resources alone
- `PlatformInstance.shutdown()` — closes queue connections without pause/obliterate when replaced or no longer the map-slot owner; only deletes the map entry it still owns
- `ProcessManager.ensureProcess()` — marks a dead instance replaced *before* firing its async shutdown, and does both before constructing the replacement
- `JobQueue.disconnect()` (data-layer) — closes connections without pausing or obliterating the underlying Redis queue

## Verification

- Unit tests added for all three behaviors (609 pass)
- Standalone repro (crash the dummy platform, fire echoes every 5ms into the crash-to-close window, 3 cycles):
  - **before**: 2–3 leaked duplicate dummy children after churn, jobs silently lost
  - **after**: exactly 1 child in every run
- Root-cause analysis with CI log timeline in #1166

Deliberately unchanged: jobs enqueued between a child's death and its close event (while the dead instance still legitimately owns the queue) are still obliterated with it — preserving them would risk replaying the poison job that killed the platform (BullMQ stalled-job retry).

Fixes #1166

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a clean queue disconnection path for teardown scenarios, without pausing or obliterating the underlying queue.

* **Bug Fixes**
  * Improved replacement lifecycle handling to prevent the active replacement instance from being removed or disrupted during shutdown.
  * Enhanced teardown behavior to disconnect queue/event connections safely when instances are superseded.

* **Tests**
  * Expanded coverage for shutdown/replacement and disconnection behavior, including error propagation and lifecycle edge cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->