### PR TITLE
chore(server): replace stale packageConfig comment with accurate doc

### DIFF
--- a/packages/server/src/config.ts
+++ b/packages/server/src/config.ts
@@ -73,9 +73,10 @@ function buildSchema(): convict.Config<Record<string, unknown>> {
                 "@sockethub/platform-xmpp",
             ],
         },
-        // Per-platform config keyed by package name. Free-form for now: no
-        // server code consumes it yet (see README/follow-up).
         packageConfig: {
+            doc:
+                "Per-platform config keyed by package name, validated against " +
+                "each platform's config schema and forwarded to its child process",
             format: Object,
             default: {},
         },


### PR DESCRIPTION
The comment above `packageConfig` in the convict schema claimed "no server code consumes it yet", which has been untrue since the convict migration (#1137): the entry is deep-validated against each platform's config schema (`config.ts`) and forwarded to the platform child process via `SOCKETHUB_PLATFORM_CONFIG` (`platform-instance.ts`).

This replaces the stale comment with a convict `doc` property describing the actual behavior, matching the style of the other schema entries.

Surfaced during the issue-triage pass (see #1097, closed as done).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Improved the configuration description for the platforms package settings, making the available options clearer in the generated schema documentation.
  * No changes were made to configuration behavior, defaults, or validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->