### PR TITLE
ci: pass supported runtime to release-prepare test job

### DIFF
--- a/.github/workflows/release-prepare.yml
+++ b/.github/workflows/release-prepare.yml
@@ -25,7 +25,7 @@ jobs:
   test-local-packages:
     uses: ./.github/workflows/test-npm-package.yml
     with:
-      runtime: both
+      runtime: node
       suite: all
 
   prepare:


### PR DESCRIPTION
## Summary
Prepare Release runs currently fail immediately at the `test-local-packages` job ([example run](https://github.com/sockethub/sockethub/actions/runs/28758195573)):

```
Error: unsupported runtime 'both' (supported: node)
```

`test-npm-package.yml` was tightened so `node` is the only supported deployment runtime (bun is a dev/build tool, not a deployment target), and its validate step deliberately hard-fails on stale values instead of silently skipping. `release-prepare.yml` was the one remaining caller still passing `runtime: both`.

## Change
Pass `runtime: node`, matching `release-publish.yml`.

## Testing
Once merged to master, re-running the Prepare Release workflow should get past the `test-local-packages` job.