### PR TITLE
fix(server): serialize platform replacement behind crashed instance teardown

### DIFF
--- a/packages/server/src/message-handlers.ts
+++ b/packages/server/src/message-handlers.ts
@@ -147,9 +147,11 @@ export function createMessageHandlers(
                     );
                     return;
                 }
-                let platformInstance: ReturnType<ProcessManager["get"]>;
+                let platformInstance: Awaited<
+                    ReturnType<ProcessManager["get"]>
+                >;
                 try {
-                    platformInstance = processManager.get(
+                    platformInstance = await processManager.get(
                         platformId,
                         msg.actor.id,
                         platformSessionId,

--- a/packages/server/src/platform-instance.test.ts
+++ b/packages/server/src/platform-instance.test.ts
@@ -166,6 +166,21 @@ describe("PlatformInstance", () => {
             expect(platformInstances.has("platform identifier")).toBeFalse();
         });
 
+        test("shutdown is single-flight: repeated calls share one teardown", async () => {
+            pi.initQueue("a secret");
+            const queue = pi.queue;
+            const first = pi.shutdown();
+            const second = pi.shutdown();
+            // both callers must observe the same teardown run; a second,
+            // independent run would resolve while the first is still
+            // obliterating the shared Redis queue
+            expect(second).toBe(first);
+            await first;
+            sandbox.assert.calledOnce(queue.shutdown);
+            await pi.shutdown();
+            sandbox.assert.calledOnce(queue.shutdown);
+        });
+
         test("shutdown of a replaced instance disconnects the queue without obliterating it", async () => {
             pi.initQueue("a secret");
             const queue = pi.queue;

--- a/packages/server/src/platform-instance.ts
+++ b/packages/server/src/platform-instance.ts
@@ -88,6 +88,7 @@ export default class PlatformInstance {
     private heartbeatListener?: (message: MessageFromPlatform) => void;
     private heartbeatFailureHandled = false;
     private replaced = false;
+    private shutdownResult?: Promise<void>;
     private readonly actor?: string;
 
     constructor(params: PlatformInstanceParams) {
@@ -187,9 +188,23 @@ export default class PlatformInstance {
     }
 
     /**
-     * Destroys all references to this platform instance, internal listeners and controlled processes
+     * Destroys all references to this platform instance, internal listeners and controlled processes.
+     *
+     * Single-flight: every caller shares one teardown run. A crash-close
+     * teardown pauses and obliterates the Redis queue asynchronously, so a
+     * caller about to create a replacement (ProcessManager.ensureProcess)
+     * must be able to await the teardown *already in flight* — a second,
+     * independent run would resolve while the first is still obliterating
+     * the queue name the replacement is about to reuse.
      */
-    public async shutdown() {
+    public shutdown(): Promise<void> {
+        if (!this.shutdownResult) {
+            this.shutdownResult = this.teardown();
+        }
+        return this.shutdownResult;
+    }
+
+    private async teardown() {
         this.log.debug("platform process shutdown");
         this.flaggedForTermination = true;
 

--- a/packages/server/src/process-manager.test.ts
+++ b/packages/server/src/process-manager.test.ts
@@ -85,75 +85,104 @@ describe("ProcessManager", () => {
         platformInstances.clear();
     });
 
-    test("disabled cap (0) allows unbounded instance creation", () => {
+    test("disabled cap (0) allows unbounded instance creation", async () => {
         maxPlatformInstances = 0;
         for (let i = 0; i < 5; i++) {
-            expect(() =>
-                manager.get("fakeplatform", `actor-${i}`),
-            ).not.toThrow();
+            await manager.get("fakeplatform", `actor-${i}`);
         }
         expect(platformInstances.size).toEqual(5);
     });
 
-    test("blocks a new actor once the cap is reached", () => {
+    test("blocks a new actor once the cap is reached", async () => {
         maxPlatformInstances = 1;
-        manager.get("fakeplatform", "actor-a");
-        expect(() => manager.get("fakeplatform", "actor-b")).toThrow(
+        await manager.get("fakeplatform", "actor-a");
+        await expect(manager.get("fakeplatform", "actor-b")).rejects.toThrow(
             /platform instance limit reached/,
         );
         expect(platformInstances.size).toEqual(1);
     });
 
-    test("always allows reusing a live instance regardless of the cap", () => {
+    test("always allows reusing a live instance regardless of the cap", async () => {
         maxPlatformInstances = 1;
-        const first = manager.get("fakeplatform", "actor-a");
+        const first = await manager.get("fakeplatform", "actor-a");
         setAlive(first, true);
-        const second = manager.get("fakeplatform", "actor-a");
+        const second = await manager.get("fakeplatform", "actor-a");
         expect(second).toBe(first);
         expect(platformInstances.size).toEqual(1);
     });
 
-    test("allows the same actor to replace its own dead instance at the cap", () => {
+    test("allows the same actor to replace its own dead instance at the cap", async () => {
         maxPlatformInstances = 1;
-        const first = manager.get("fakeplatform", "actor-a");
+        const first = await manager.get("fakeplatform", "actor-a");
         setAlive(first, false);
-        expect(() =>
-            manager.get("fakeplatform", "actor-a"),
-        ).not.toThrow();
+        await manager.get("fakeplatform", "actor-a");
         expect(platformInstances.size).toEqual(1);
     });
 
-    test("marks a dead instance as replaced before shutting it down", () => {
-        const first = manager.get("fakeplatform", "actor-a");
+    test("marks a dead instance as replaced before shutting it down", async () => {
+        const first = await manager.get("fakeplatform", "actor-a");
         setAlive(first, false);
         const markReplaced = sandbox.spy(first, "markReplaced");
         const shutdown = sandbox.stub(first, "shutdown").resolves();
-        const second = manager.get("fakeplatform", "actor-a");
+        const second = await manager.get("fakeplatform", "actor-a");
         expect(second).not.toBe(first);
         sinon.assert.calledOnce(markReplaced);
         sinon.assert.calledOnce(shutdown);
         expect(markReplaced.calledBefore(shutdown)).toEqual(true);
     });
 
-    test("the dead instance's async teardown does not evict the replacement from the map", async () => {
-        const first = manager.get("fakeplatform", "actor-a");
+    test("the dead instance's teardown does not evict the replacement from the map", async () => {
+        const first = await manager.get("fakeplatform", "actor-a");
         setAlive(first, false);
-        const second = manager.get("fakeplatform", "actor-a");
+        const second = await manager.get("fakeplatform", "actor-a");
         expect(second).not.toBe(first);
-        // ensureProcess fires the old instance's shutdown without awaiting
-        // it; let it finish, then verify the replacement still owns the slot
-        await new Promise((resolve) => setTimeout(resolve, 0));
         expect(platformInstances.get(second.id)).toBe(second);
     });
 
-    test("does not shut down a live instance when reusing it", () => {
-        const first = manager.get("fakeplatform", "actor-a");
+    test("does not shut down a live instance when reusing it", async () => {
+        const first = await manager.get("fakeplatform", "actor-a");
         setAlive(first, true);
         const markReplaced = sandbox.spy(first, "markReplaced");
         const shutdown = sandbox.stub(first, "shutdown").resolves();
-        const second = manager.get("fakeplatform", "actor-a");
+        const second = await manager.get("fakeplatform", "actor-a");
         expect(second).toBe(first);
         sinon.assert.notCalled(markReplaced);
         sinon.assert.notCalled(shutdown);
+    });
+
+    test("waits for the dead instance's in-flight teardown before creating the replacement", async () => {
+        const first = await manager.get("fakeplatform", "actor-a");
+        setAlive(first, false);
+        let releaseTeardown: () => void;
+        const teardown = new Promise<void>((resolve) => {
+            releaseTeardown = resolve;
+        });
+        sandbox.stub(first, "shutdown").returns(teardown);
+        let second: PlatformInstance | undefined;
+        const pending = manager.get("fakeplatform", "actor-a").then((pi) => {
+            second = pi;
+            return pi;
+        });
+        await new Promise((resolve) => setTimeout(resolve, 0));
+        // The replacement (and its queue, which shares the dead instance's
+        // Redis queue name) must not exist while the old teardown — which
+        // may be obliterating that queue — is still running; jobs added to
+        // the replacement's queue in that window would be destroyed.
+        expect(second).toBeUndefined();
+        releaseTeardown();
+        const replacement = await pending;
+        expect(replacement).not.toBe(first);
+        expect(platformInstances.get(replacement.id)).toBe(replacement);
+    });
+
+    test("concurrent requests for the same dead instance produce a single replacement", async () => {
+        const first = await manager.get("fakeplatform", "actor-a");
+        setAlive(first, false);
+        const [a, b] = await Promise.all([
+            manager.get("fakeplatform", "actor-a"),
+            manager.get("fakeplatform", "actor-a"),
+        ]);
+        expect(a).toBe(b);
+        expect(platformInstances.size).toEqual(1);
     });
 });

--- a/packages/server/src/process-manager.ts
+++ b/packages/server/src/process-manager.ts
@@ -12,6 +12,8 @@ class ProcessManager {
     private readonly parentSecret1: string;
     private readonly parentSecret2: string;
     private init: IInitObject;
+    // per-identifier serialization of ensureProcess runs; see ensureProcess()
+    private readonly ensureChains = new Map<string, Promise<void>>();
 
     constructor(
         parentId: string,
@@ -25,22 +27,18 @@ class ProcessManager {
         this.init = init;
     }
 
-    get(
+    async get(
         platform: string,
         actorId: string,
         sessionId?: string,
         sessionIp?: string,
-    ): PlatformInstance {
+    ): Promise<PlatformInstance> {
         const platformDetails = this.init.platforms.get(platform);
-        let pi: PlatformInstance;
-
-        if (platformDetails.config.persist) {
-            // ensure process is started - one for each actor
-            pi = this.ensureProcess(platform, sessionId, actorId, sessionIp);
-        } else {
-            // ensure process is started - one for all jobs
-            pi = this.ensureProcess(platform);
-        }
+        const pi = platformDetails.config.persist
+            ? // ensure process is started - one for each actor
+              await this.ensureProcess(platform, sessionId, actorId, sessionIp)
+            : // ensure process is started - one for all jobs
+              await this.ensureProcess(platform);
         pi.config = platformDetails.config;
         pi.contextUrl = platformDetails.contextUrl;
         return pi;
@@ -70,13 +68,52 @@ class ProcessManager {
         return platformInstance;
     }
 
+    /**
+     * ensureProcessNow() yields the event loop while awaiting a dead
+     * predecessor's teardown, so two concurrent messages for the same
+     * identifier could otherwise both find no live instance and each fork
+     * a replacement child. Chain runs per identifier so only one is
+     * inspecting or creating that identifier's instance at a time.
+     */
     private ensureProcess(
         platform: string,
         sessionId?: string,
         actor?: string,
         sessionIp?: string,
-    ): PlatformInstance {
+    ): Promise<PlatformInstance> {
         const identifier = getPlatformId(platform, actor);
+        const prior = this.ensureChains.get(identifier) ?? Promise.resolve();
+        const run = prior.then(() =>
+            this.ensureProcessNow(
+                identifier,
+                platform,
+                sessionId,
+                actor,
+                sessionIp,
+            ),
+        );
+        // Park a settled (never-rejecting) copy for the next caller, and
+        // drop it once the chain drains so the map doesn't grow unboundedly.
+        const settled = run.then(
+            (): undefined => undefined,
+            (): undefined => undefined,
+        );
+        this.ensureChains.set(identifier, settled);
+        settled.then(() => {
+            if (this.ensureChains.get(identifier) === settled) {
+                this.ensureChains.delete(identifier);
+            }
+        });
+        return run;
+    }
+
+    private async ensureProcessNow(
+        identifier: string,
+        platform: string,
+        sessionId?: string,
+        actor?: string,
+        sessionIp?: string,
+    ): Promise<PlatformInstance> {
         const existing = platformInstances.get(identifier);
         const reusable = existing && this.isProcessAlive(existing);
         if (!reusable) {
@@ -85,11 +122,13 @@ class ProcessManager {
         if (existing && !reusable) {
             // The replacement created below shares `identifier` and the Redis
             // queue name derived from it. Mark the dead instance as replaced
-            // *before* starting its async teardown so that teardown can't
-            // obliterate the replacement's queue or evict it from
-            // platformInstances (#1166).
+            // *before* teardown so a teardown started here leaves the shared
+            // queue's jobs intact (#1166), and *await* the teardown so one
+            // already in flight — a crash-close teardown pauses and
+            // obliterates the queue — finishes before the replacement's
+            // queue exists to be damaged by it.
             existing.markReplaced();
-            void existing.shutdown();
+            await existing.shutdown();
         }
         const platformInstance = reusable
             ? existing


### PR DESCRIPTION
## Problem

The `process` integration job flaked on the release PR (#1173, [run 28787974839](https://github.com/sockethub/sockethub/actions/runs/28787974839/job/85360038426)): `should recover from uncaught TypeError` timed out waiting for the platform child to exit, and the three tests after it cascade-failed.

Root cause is a race in crash teardown that #1166/#1167 narrowed but didn't close:

1. A platform child crashes; its `close` handler starts `shutdown()`, which checks for a replacement **once, at teardown start**, finds none, and proceeds to `queue.shutdown()` — BullMQ `pause()` + `obliterate({force: true})` on a Redis queue keyed by identifier and therefore shared with any future replacement.
2. While that pause/obliterate is still in flight, a message for the same identifier arrives. `ensureProcess` creates the replacement and its queue under the same Redis name. `markReplaced()` fires too late — the in-flight teardown already passed its guard.
3. Jobs enqueued for the replacement are destroyed by the old teardown. In the flaky run, the exit1 test's restart poll created the replacement 9ms after the close event, and the next test's `throwTypeError` job silently vanished — the child never crashed, so `waitForProcessExit` timed out.

## Fix

- **`PlatformInstance.shutdown()` is single-flight**: every caller shares one teardown run. Awaiting `shutdown()` now means the pause/obliterate has actually finished, rather than a second, independent no-op run having resolved alongside the first. (This also collapses the previously duplicated teardown from `handleProcessClose` → `broadcastFatalError` → `shutdown()` → `shutdown()`.)
- **`ensureProcess` awaits the dead predecessor's teardown** before creating the replacement, so an in-flight obliterate can never land on the replacement's queue.
- Because the path now yields the event loop, **runs are chained per identifier** — two concurrent messages for the same dead instance can no longer each fork a replacement child.
- `ProcessManager.get()` becomes async; its only call site (the shared socket/HTTP message middleware) is already an async function.

## Testing

- New unit test pins the ordering: replacement creation blocks until an in-flight teardown resolves.
- New unit test covers concurrent requests for a dead instance yielding a single replacement.
- New unit test covers single-flight `shutdown()`.
- All 175 server unit tests pass; biome clean.
- Runtime-verified against a locally launched server + Redis: echo → `exit1` crash → recovery → `throwTypeError` crash → recovery, all behave correctly.
- The `process` integration suite doesn't run on macOS (pre-existing `ps` discovery incompatibility, fails identically on master), so CI is the gate for the integration path.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved handling of platform process reuse and replacement, making concurrent requests more reliable.
  * Shutdown operations are now single-flight, so repeated shutdown calls share the same in-progress teardown.

* **Bug Fixes**
  * Fixed race conditions that could start multiple platform processes at once.
  * Improved replacement timing to avoid issues when a dead process is being torn down.
  * Updated message handling to properly wait for platform lookup before continuing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->