### PR TITLE
feat(platform-metadata): return the post's own media for X and Reddit URLs

### DIFF
--- a/packages/platform-metadata/README.md
+++ b/packages/platform-metadata/README.md
@@ -77,9 +77,68 @@ The platform returns an ActivityStream object with extracted metadata:
 The platform extracts the following metadata when available:
 
 * **Open Graph data**: Title, description, images, site name, URL, locale
-* **Site information**: Favicon, character encoding
+* **Site information**: Favicon, character encoding — when a page declares no
+  icon, `favicon` falls back to the conventional relative `/favicon.ico` so
+  clients can resolve it against the page URL and decorate previews
 * **Canonical URLs**: Resolved and canonical page URLs
-* **Media**: Images with dimensions and type information
+* **Media**: Images with dimensions and type information; for X/Twitter posts,
+  a `video` object (direct media URL, poster `thumbnail`, dimensions, duration)
+
+## Site-Specific Handling
+
+Some large platforms don't expose a post's own media to Open Graph scrapers,
+so those URLs are resolved through preview services built for this purpose:
+
+* **X / Twitter status URLs** (`x.com`, `twitter.com`, incl. `/i/web/status/…`)
+  are fetched from the [FxTwitter API](https://github.com/FxEmbed/FxEmbed)
+  instead of scraped — X serves only a generic site banner to scrapers. The
+  response carries the post's text, its actual photo (or video + poster
+  thumbnail), and the canonical `x.com` URL. If the API is unavailable or the
+  post can't be resolved, the platform falls back to the regular scrape
+  (which still yields the post text).
+* **Reddit URLs** (`reddit.com` hosts and `redd.it` short links) are scraped
+  directly, but with a *compatibility user agent* — Reddit serves its Open
+  Graph data (including the post's real preview image) only to recognized
+  embed crawlers, and returns a page with no OG tags (or a 403) to anything
+  else. See `compatUserAgent` below.
+* **Facebook** remains best-effort: post text usually comes through, but
+  media requires authentication and no public preview service exists.
+
+### `userAgent`
+
+All outbound requests identify as
+`Mozilla/5.0 (compatible; SockethubBot/<version>; +https://sockethub.org)`.
+Sites gate scraper-facing behavior on the user agent — preview services serve
+their Open Graph payload to bot-like UAs, and many hosts reject undici's
+default UA. Override per deployment via `packageConfig`:
+
+```json
+{
+  "packageConfig": {
+    "@sockethub/platform-metadata": {
+      "userAgent": "MyDeployment/1.0 (+https://my.example)"
+    }
+  }
+}
+```
+
+### `compatUserAgent`
+
+Sites that only serve Open Graph data to *recognized* embed crawlers (Reddit)
+are fetched with a link-preview crawler user agent instead — the established
+practice for self-hosted preview fetchers. Defaults to
+`Mozilla/5.0 (compatible; Discordbot/2.0; +https://discordapp.com)`;
+override via `packageConfig`:
+
+```json
+{
+  "packageConfig": {
+    "@sockethub/platform-metadata": {
+      "compatUserAgent": "Mozilla/5.0 (compatible; TelegramBot/1.0)"
+    }
+  }
+}
+```
 
 ## Dependencies
 

--- a/packages/platform-metadata/src/index.test.ts
+++ b/packages/platform-metadata/src/index.test.ts
@@ -17,6 +17,14 @@ mock.module("open-graph-scraper", () => ({
 
 const { default: Metadata } = await import("./index");
 
+/** The user-agent header the platform handed to open-graph-scraper. */
+function sentUserAgent(): string | undefined {
+    const fetchOptions = ogsOptions?.fetchOptions as
+        | { headers?: Record<string, string> }
+        | undefined;
+    return fetchOptions?.headers?.["user-agent"];
+}
+
 function makePlatform(config?: Record<string, unknown>) {
     // biome-ignore lint/suspicious/noExplicitAny: minimal fake session
     const platform = new Metadata({ log: { debug() {} } } as any);
@@ -92,22 +100,14 @@ describe("scrape user agent", () => {
 
     it("sends an identifiable bot user agent by default", async () => {
         await runFetch(makePlatform());
-        const fetchOptions = ogsOptions?.fetchOptions as
-            | { headers?: Record<string, string> }
-            | undefined;
-        expect(fetchOptions?.headers?.["user-agent"]).toMatch(
+        expect(sentUserAgent()).toMatch(
             /SockethubBot\/.+\+https:\/\/sockethub\.org/,
         );
     });
 
     it("honors a packageConfig userAgent override", async () => {
         await runFetch(makePlatform({ userAgent: "MyDeployment/1.0" }));
-        const fetchOptions = ogsOptions?.fetchOptions as
-            | { headers?: Record<string, string> }
-            | undefined;
-        expect(fetchOptions?.headers?.["user-agent"]).toEqual(
-            "MyDeployment/1.0",
-        );
+        expect(sentUserAgent()).toEqual("MyDeployment/1.0");
     });
 });
 
@@ -137,13 +137,6 @@ describe("reddit compatibility user agent", () => {
         ogsOptions = undefined;
         ogsBehavior = () => Promise.resolve({ result: {} });
     });
-
-    function sentUserAgent(): string | undefined {
-        const fetchOptions = ogsOptions?.fetchOptions as
-            | { headers?: Record<string, string> }
-            | undefined;
-        return fetchOptions?.headers?.["user-agent"];
-    }
 
     it("scrapes reddit posts with an embed-crawler user agent", async () => {
         await runFetch(
@@ -227,6 +220,9 @@ describe("twitter status resolution", () => {
         expect(headers["user-agent"]).toMatch(/SockethubBot/);
         // The guarded dispatcher rides along on the API call too.
         expect(fetchedInit?.dispatcher).toBeInstanceOf(Agent);
+        // And a per-request timeout, so a stalled API cannot stall the
+        // scrape fallback.
+        expect(fetchedInit?.signal).toBeInstanceOf(AbortSignal);
         // The OG scrape pipeline is bypassed entirely.
         expect(ogsOptions).toBeUndefined();
         // biome-ignore lint/suspicious/noExplicitAny: test result shape

--- a/packages/platform-metadata/src/index.test.ts
+++ b/packages/platform-metadata/src/index.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it, mock } from "bun:test";
+import { afterEach, beforeEach, describe, expect, it, mock } from "bun:test";
 import { Agent } from "undici";
 
 // Capture the options passed to open-graph-scraper and control its outcome,
@@ -28,11 +28,12 @@ function makePlatform(config?: Record<string, unknown>) {
 
 function runFetch(
     platform: ReturnType<typeof makePlatform>,
+    url = "https://example.com",
 ): Promise<{ err: unknown; result: unknown }> {
     const job = {
         "@context": ["x"],
         type: "fetch",
-        actor: { id: "https://example.com", type: "website" },
+        actor: { id: url, type: "website" },
     };
     return new Promise((resolve) => {
         // biome-ignore lint/suspicious/noExplicitAny: test job
@@ -80,5 +81,190 @@ describe("metadata fetch SSRF hardening", () => {
         const { err } = await runFetch(makePlatform());
         expect(err).toBeInstanceOf(Error);
         expect((err as Error).message).toMatch(/blocked non-public/);
+    });
+});
+
+describe("scrape user agent", () => {
+    beforeEach(() => {
+        ogsOptions = undefined;
+        ogsBehavior = () => Promise.resolve({ result: {} });
+    });
+
+    it("sends an identifiable bot user agent by default", async () => {
+        await runFetch(makePlatform());
+        const fetchOptions = ogsOptions?.fetchOptions as
+            | { headers?: Record<string, string> }
+            | undefined;
+        expect(fetchOptions?.headers?.["user-agent"]).toMatch(
+            /SockethubBot\/.+\+https:\/\/sockethub\.org/,
+        );
+    });
+
+    it("honors a packageConfig userAgent override", async () => {
+        await runFetch(makePlatform({ userAgent: "MyDeployment/1.0" }));
+        const fetchOptions = ogsOptions?.fetchOptions as
+            | { headers?: Record<string, string> }
+            | undefined;
+        expect(fetchOptions?.headers?.["user-agent"]).toEqual(
+            "MyDeployment/1.0",
+        );
+    });
+});
+
+describe("favicon fallback", () => {
+    beforeEach(() => {
+        ogsOptions = undefined;
+    });
+
+    it("defaults to the conventional /favicon.ico when the page declares none", async () => {
+        ogsBehavior = () => Promise.resolve({ result: { ogTitle: "T" } });
+        const { result } = await runFetch(makePlatform());
+        // biome-ignore lint/suspicious/noExplicitAny: test result shape
+        expect((result as any).object.favicon).toEqual("/favicon.ico");
+    });
+
+    it("keeps the page's declared favicon", async () => {
+        ogsBehavior = () =>
+            Promise.resolve({ result: { favicon: "https://x/i.svg" } });
+        const { result } = await runFetch(makePlatform());
+        // biome-ignore lint/suspicious/noExplicitAny: test result shape
+        expect((result as any).object.favicon).toEqual("https://x/i.svg");
+    });
+});
+
+describe("reddit compatibility user agent", () => {
+    beforeEach(() => {
+        ogsOptions = undefined;
+        ogsBehavior = () => Promise.resolve({ result: {} });
+    });
+
+    function sentUserAgent(): string | undefined {
+        const fetchOptions = ogsOptions?.fetchOptions as
+            | { headers?: Record<string, string> }
+            | undefined;
+        return fetchOptions?.headers?.["user-agent"];
+    }
+
+    it("scrapes reddit posts with an embed-crawler user agent", async () => {
+        await runFetch(
+            makePlatform(),
+            "https://www.reddit.com/r/pics/comments/abc123/some_title/",
+        );
+        expect(ogsOptions?.url).toEqual(
+            "https://www.reddit.com/r/pics/comments/abc123/some_title/",
+        );
+        expect(sentUserAgent()).toMatch(/Discordbot/);
+    });
+
+    it("covers redd.it short links", async () => {
+        await runFetch(makePlatform(), "https://redd.it/abc123");
+        expect(sentUserAgent()).toMatch(/Discordbot/);
+    });
+
+    it("honors a packageConfig compatUserAgent override", async () => {
+        await runFetch(
+            makePlatform({ compatUserAgent: "MyCrawler/2.0" }),
+            "https://old.reddit.com/r/x/comments/id/",
+        );
+        expect(sentUserAgent()).toEqual("MyCrawler/2.0");
+    });
+
+    it("does not affect non-reddit scrapes", async () => {
+        await runFetch(makePlatform(), "https://example.com/article");
+        expect(ogsOptions?.url).toEqual("https://example.com/article");
+        expect(sentUserAgent()).toMatch(/SockethubBot/);
+    });
+});
+
+describe("twitter status resolution", () => {
+    const realFetch = globalThis.fetch;
+    let fetchedUrl: string | undefined;
+    let fetchedInit: Record<string, unknown> | undefined;
+    let tweetResponse: () => Promise<unknown> = () =>
+        Promise.resolve({ code: 404, message: "NOT_FOUND" });
+
+    beforeEach(() => {
+        ogsOptions = undefined;
+        ogsBehavior = () => Promise.resolve({ result: { ogTitle: "scraped" } });
+        fetchedUrl = undefined;
+        fetchedInit = undefined;
+        // biome-ignore lint/suspicious/noExplicitAny: test fetch stub
+        globalThis.fetch = ((url: string, init: Record<string, unknown>) => {
+            fetchedUrl = String(url);
+            fetchedInit = init;
+            return Promise.resolve({
+                json: () => tweetResponse(),
+            });
+        }) as any;
+    });
+
+    afterEach(() => {
+        globalThis.fetch = realFetch;
+    });
+
+    it("resolves a status through the FxTwitter API with the post's own media", async () => {
+        tweetResponse = () =>
+            Promise.resolve({
+                code: 200,
+                tweet: {
+                    url: "https://x.com/someperson/status/11",
+                    text: "post text",
+                    author: { name: "Some Person", screen_name: "someperson" },
+                    media: {
+                        photos: [
+                            { url: "https://pbs.twimg.com/media/a.jpg" },
+                        ],
+                    },
+                },
+            });
+        const { err, result } = await runFetch(
+            makePlatform(),
+            "https://x.com/someperson/status/11",
+        );
+        expect(err).toBeNull();
+        expect(fetchedUrl).toEqual("https://api.fxtwitter.com/status/11");
+        const headers = fetchedInit?.headers as Record<string, string>;
+        expect(headers["user-agent"]).toMatch(/SockethubBot/);
+        // The guarded dispatcher rides along on the API call too.
+        expect(fetchedInit?.dispatcher).toBeInstanceOf(Agent);
+        // The OG scrape pipeline is bypassed entirely.
+        expect(ogsOptions).toBeUndefined();
+        // biome-ignore lint/suspicious/noExplicitAny: test result shape
+        const job = result as any;
+        expect(job.object.description).toEqual("post text");
+        expect(job.object.image).toEqual([
+            { url: "https://pbs.twimg.com/media/a.jpg" },
+        ]);
+    });
+
+    it("falls back to the OG scrape when the FxTwitter API errors", async () => {
+        tweetResponse = () => Promise.reject(new Error("api down"));
+        const { err, result } = await runFetch(
+            makePlatform(),
+            "https://x.com/someperson/status/12",
+        );
+        expect(err).toBeNull();
+        expect(ogsOptions?.url).toEqual("https://x.com/someperson/status/12");
+        // biome-ignore lint/suspicious/noExplicitAny: test result shape
+        expect((result as any).object.title).toEqual("scraped");
+    });
+
+    it("falls back to the OG scrape for deleted/unavailable posts", async () => {
+        tweetResponse = () =>
+            Promise.resolve({ code: 404, message: "NOT_FOUND" });
+        const { err } = await runFetch(
+            makePlatform(),
+            "https://twitter.com/someperson/status/13",
+        );
+        expect(err).toBeNull();
+        expect(ogsOptions?.url).toEqual(
+            "https://twitter.com/someperson/status/13",
+        );
+    });
+
+    it("does not intercept non-status twitter URLs", async () => {
+        await runFetch(makePlatform(), "https://x.com/someperson");
+        expect(fetchedUrl).toBeUndefined();
+        expect(ogsOptions?.url).toEqual("https://x.com/someperson");
     });
 });

--- a/packages/platform-metadata/src/index.ts
+++ b/packages/platform-metadata/src/index.ts
@@ -37,6 +37,13 @@ const DEFAULT_USER_AGENT = `Mozilla/5.0 (compatible; SockethubBot/${packageJson.
 const COMPAT_USER_AGENT =
     "Mozilla/5.0 (compatible; Discordbot/2.0; +https://discordapp.com)";
 
+/**
+ * Cap on the FxTwitter API round-trip. The guarded dispatcher bounds
+ * response size but not time — without this, a stalled API request would
+ * also stall the scrape fallback.
+ */
+const TWEET_API_TIMEOUT_MS = 10_000;
+
 export default class Metadata implements PlatformInterface {
     private readonly log: Logger;
     private dispatcher?: ReturnType<typeof createGuardedDispatcher>;
@@ -112,6 +119,7 @@ export default class Metadata implements PlatformInterface {
                 // biome-ignore lint/suspicious/noExplicitAny: undici fetch accepts a dispatcher
                 dispatcher: this.getDispatcher(),
                 headers: { "user-agent": this.userAgent() },
+                signal: AbortSignal.timeout(TWEET_API_TIMEOUT_MS),
             } as any);
             const status = (await res.json()) as FxTwitterStatus;
             const page = tweetToPageObject(status);

--- a/packages/platform-metadata/src/index.ts
+++ b/packages/platform-metadata/src/index.ts
@@ -9,7 +9,33 @@ import type {
 import { toError } from "@sockethub/util/error";
 import { createGuardedDispatcher } from "@sockethub/util/net";
 import ogs from "open-graph-scraper";
+import packageJson from "../package.json" with { type: "json" };
+import {
+    type FxTwitterStatus,
+    isRedditUrl,
+    resolveTwitterStatus,
+    tweetToPageObject,
+} from "./resolvers";
 import { PlatformMetadataSchema } from "./schema";
+
+/**
+ * Sent with every outbound request. Sites gate their scraper-facing
+ * behavior on the user agent, and many reject undici's default UA
+ * outright. Identify honestly as a bot; override per deployment via
+ * `packageConfig.userAgent`.
+ */
+const DEFAULT_USER_AGENT = `Mozilla/5.0 (compatible; SockethubBot/${packageJson.version}; +https://sockethub.org)`;
+
+/**
+ * Sent to sites that serve their Open Graph payload only to *recognized*
+ * embed crawlers — Reddit returns a page with no OG data (and 403s
+ * datacenter addresses) for anything it doesn't know. Presenting a
+ * link-preview crawler UA is the established practice for self-hosted
+ * preview fetchers; override per deployment via
+ * `packageConfig.compatUserAgent`.
+ */
+const COMPAT_USER_AGENT =
+    "Mozilla/5.0 (compatible; Discordbot/2.0; +https://discordapp.com)";
 
 export default class Metadata implements PlatformInterface {
     private readonly log: Logger;
@@ -47,8 +73,75 @@ export default class Metadata implements PlatformInterface {
         return true;
     }
 
+    private userAgent(): string {
+        return typeof this.config.userAgent === "string" &&
+            this.config.userAgent
+            ? this.config.userAgent
+            : DEFAULT_USER_AGENT;
+    }
+
+    private compatUserAgent(): string {
+        return typeof this.config.compatUserAgent === "string" &&
+            this.config.compatUserAgent
+            ? this.config.compatUserAgent
+            : COMPAT_USER_AGENT;
+    }
+
     fetch(job: ActivityStream, cb: PlatformCallback) {
         this.log.debug(`fetching ${job.actor.id}`);
+        // X/Twitter never exposes a post's own media via Open Graph — it
+        // serves a generic site banner to every scraper — so status URLs
+        // resolve through FxTwitter's JSON API instead, which returns the
+        // tweet text plus direct photo/video URLs. Anything else (including
+        // an FxTwitter failure) goes through the regular OG scrape.
+        const tweetApiUrl = resolveTwitterStatus(job.actor.id);
+        if (tweetApiUrl) {
+            this.fetchTweet(tweetApiUrl, job, cb);
+            return;
+        }
+        this.scrape(job, cb);
+    }
+
+    private async fetchTweet(
+        apiUrl: string,
+        job: ActivityStream,
+        cb: PlatformCallback,
+    ) {
+        try {
+            const res = await globalThis.fetch(apiUrl, {
+                // biome-ignore lint/suspicious/noExplicitAny: undici fetch accepts a dispatcher
+                dispatcher: this.getDispatcher(),
+                headers: { "user-agent": this.userAgent() },
+            } as any);
+            const status = (await res.json()) as FxTwitterStatus;
+            const page = tweetToPageObject(status);
+            if (page) {
+                job.actor.id = page.url || job.actor.id;
+                job.actor.name = page.name || job.actor.name || "";
+                job.object = page;
+                cb(null, job);
+                return;
+            }
+            this.log.debug(
+                `fxtwitter returned no usable data for ${job.actor.id} (code ${status?.code}); falling back to scrape`,
+            );
+        } catch (err) {
+            // The FxTwitter API being down must not break previews entirely —
+            // the plain scrape still yields the post text.
+            this.log.debug(
+                `fxtwitter fetch failed for ${job.actor.id}: ${String(err)}; falling back to scrape`,
+            );
+        }
+        this.scrape(job, cb);
+    }
+
+    private scrape(job: ActivityStream, cb: PlatformCallback) {
+        // Reddit serves its OG data (with the post's real preview image)
+        // only to recognized embed-crawler user agents — everything else
+        // gets a page without OG tags, or a 403.
+        const userAgent = isRedditUrl(job.actor.id)
+            ? this.compatUserAgent()
+            : this.userAgent();
         // The server fetches whatever URL a client puts in actor.id, so guard
         // it against SSRF and oversized responses. open-graph-scraper forwards
         // `fetchOptions` to its undici fetch; the guarded dispatcher refuses to
@@ -78,7 +171,10 @@ export default class Metadata implements PlatformInterface {
                 validate_length: true,
             },
             // biome-ignore lint/suspicious/noExplicitAny: ogs fetchOptions dispatcher
-            fetchOptions: { dispatcher } as any,
+            fetchOptions: {
+                dispatcher,
+                headers: { "user-agent": userAgent },
+            } as any,
         })
             .then((data) => {
                 const { result } = data;
@@ -92,7 +188,11 @@ export default class Metadata implements PlatformInterface {
                     description: result.ogDescription || "",
                     image: result.ogImage,
                     url: result.ogUrl,
-                    favicon: result.favicon,
+                    // Fall back to the conventional location when the page
+                    // declares no icon (vxreddit, many plain sites). It's
+                    // relative on purpose: clients resolve it against the
+                    // page URL, and a 404 just means no decoration.
+                    favicon: result.favicon || "/favicon.ico",
                     charset: result.charset,
                 };
                 cb(null, job);

--- a/packages/platform-metadata/src/resolvers.test.ts
+++ b/packages/platform-metadata/src/resolvers.test.ts
@@ -1,0 +1,169 @@
+import { describe, expect, it } from "bun:test";
+import {
+    isRedditUrl,
+    resolveTwitterStatus,
+    tweetToPageObject,
+} from "./resolvers";
+
+describe("resolveTwitterStatus", () => {
+    it("resolves status URLs on every X/Twitter host", () => {
+        for (const host of [
+            "twitter.com",
+            "www.twitter.com",
+            "mobile.twitter.com",
+            "x.com",
+            "www.x.com",
+            "mobile.x.com",
+        ]) {
+            expect(
+                resolveTwitterStatus(`https://${host}/SomeUser/status/12345`),
+            ).toEqual("https://api.fxtwitter.com/status/12345");
+        }
+    });
+
+    it("resolves the /i/web/status share form", () => {
+        expect(
+            resolveTwitterStatus("https://x.com/i/web/status/98765"),
+        ).toEqual("https://api.fxtwitter.com/status/98765");
+    });
+
+    it("resolves the legacy /statuses/ path and ignores query/fragment", () => {
+        expect(
+            resolveTwitterStatus(
+                "https://twitter.com/user_name/statuses/42?s=20#m",
+            ),
+        ).toEqual("https://api.fxtwitter.com/status/42");
+    });
+
+    it("ignores non-status X URLs", () => {
+        expect(resolveTwitterStatus("https://x.com/SomeUser")).toBeNull();
+        expect(resolveTwitterStatus("https://x.com/search?q=hi")).toBeNull();
+        expect(resolveTwitterStatus("https://x.com/user/status/abc")).toBeNull();
+    });
+
+    it("ignores other hosts and invalid URLs", () => {
+        expect(
+            resolveTwitterStatus("https://example.com/u/status/123"),
+        ).toBeNull();
+        expect(
+            // Lookalike suffix must not match (attacker-controlled host).
+            resolveTwitterStatus("https://notx.com/u/status/123"),
+        ).toBeNull();
+        expect(resolveTwitterStatus("not a url")).toBeNull();
+    });
+});
+
+describe("isRedditUrl", () => {
+    it("matches reddit hosts and redd.it short links", () => {
+        for (const url of [
+            "https://www.reddit.com/r/pics/comments/abc123/some_title/",
+            "https://old.reddit.com/r/x/comments/id/",
+            "https://new.reddit.com/r/x/comments/id/",
+            "https://np.reddit.com/r/x/comments/id/",
+            "https://reddit.com/r/x/comments/id/",
+            "https://redd.it/abc123",
+        ]) {
+            expect(isRedditUrl(url)).toBeTrue();
+        }
+    });
+
+    it("ignores other hosts and invalid URLs", () => {
+        expect(isRedditUrl("https://example.com/r/pics")).toBeFalse();
+        // Lookalike suffix must not match (attacker-controlled host).
+        expect(isRedditUrl("https://ireddit.com/r/pics")).toBeFalse();
+        expect(isRedditUrl("https://notredd.it/abc")).toBeFalse();
+        expect(isRedditUrl("not a url")).toBeFalse();
+    });
+});
+
+describe("tweetToPageObject", () => {
+    const author = { name: "Some Person", screen_name: "someperson" };
+
+    it("maps a photo tweet to a page with the post's own image", () => {
+        const page = tweetToPageObject({
+            code: 200,
+            tweet: {
+                url: "https://x.com/someperson/status/1",
+                text: "hello world",
+                author,
+                media: {
+                    photos: [
+                        {
+                            url: "https://pbs.twimg.com/media/abc.jpg?name=orig",
+                            width: 800,
+                            height: 532,
+                        },
+                    ],
+                },
+            },
+        });
+        expect(page).toEqual({
+            type: "page",
+            title: "Some Person (@someperson) on X",
+            name: "X (formerly Twitter)",
+            description: "hello world",
+            url: "https://x.com/someperson/status/1",
+            favicon: "https://x.com/favicon.ico",
+            image: [
+                {
+                    url: "https://pbs.twimg.com/media/abc.jpg?name=orig",
+                    width: 800,
+                    height: 532,
+                },
+            ],
+        });
+    });
+
+    it("maps a video tweet to a page with thumbnail image and video", () => {
+        const page = tweetToPageObject({
+            code: 200,
+            tweet: {
+                url: "https://x.com/someperson/status/2",
+                text: "watch this",
+                author,
+                media: {
+                    videos: [
+                        {
+                            url: "https://video.twimg.com/vid/1920x1080/x.mp4",
+                            thumbnail_url: "https://pbs.twimg.com/thumb/x.jpg",
+                            width: 1920,
+                            height: 1080,
+                            duration: 9.3,
+                        },
+                    ],
+                },
+            },
+        });
+        expect(page?.image).toEqual([
+            { url: "https://pbs.twimg.com/thumb/x.jpg", width: 1920, height: 1080 },
+        ]);
+        expect(page?.video).toEqual({
+            url: "https://video.twimg.com/vid/1920x1080/x.mp4",
+            thumbnail: "https://pbs.twimg.com/thumb/x.jpg",
+            width: 1920,
+            height: 1080,
+            duration: 9.3,
+        });
+    });
+
+    it("maps a text-only tweet without any image", () => {
+        const page = tweetToPageObject({
+            code: 200,
+            tweet: {
+                url: "https://x.com/someperson/status/3",
+                text: "just words",
+                author,
+            },
+        });
+        expect(page?.description).toEqual("just words");
+        expect(page?.image).toBeUndefined();
+        expect(page?.video).toBeUndefined();
+    });
+
+    it("returns null for API errors so the caller can fall back", () => {
+        expect(tweetToPageObject({ code: 404, message: "NOT_FOUND" })).toBeNull();
+        expect(tweetToPageObject({ code: 200 })).toBeNull();
+        // biome-ignore lint/suspicious/noExplicitAny: malformed API payload
+        expect(tweetToPageObject(undefined as any)).toBeNull();
+    });
+});

--- a/packages/platform-metadata/src/resolvers.ts
+++ b/packages/platform-metadata/src/resolvers.ts
@@ -1,0 +1,182 @@
+/**
+ * Site-specific URL resolution for pages that don't serve useful Open Graph
+ * data to scrapers.
+ *
+ * Some large platforms return a generic banner image (X/Twitter), serve
+ * their Open Graph data only to recognized embed crawlers (Reddit), or
+ * hide post media behind a login (Facebook). Two of those have working
+ * strategies:
+ *
+ * - X/Twitter → FxTwitter's JSON API (api.fxtwitter.com), built for embed
+ *   previews, returns the tweet text plus direct photo/video URLs.
+ * - Reddit → the regular scrape works, but only when presented with an
+ *   embed-crawler user agent (see COMPAT_USER_AGENT in index.ts).
+ *
+ * These are pure URL matchers/mappers — the platform decides what to do
+ * with the resolution (call a JSON API vs. pick a scrape user agent).
+ */
+
+/** Hosts that serve X/Twitter statuses. */
+const TWITTER_HOSTS = new Set([
+    "twitter.com",
+    "www.twitter.com",
+    "mobile.twitter.com",
+    "x.com",
+    "www.x.com",
+    "mobile.x.com",
+]);
+
+/** Hosts that serve Reddit posts. */
+const REDDIT_HOSTS = new Set([
+    "reddit.com",
+    "www.reddit.com",
+    "old.reddit.com",
+    "new.reddit.com",
+    "np.reddit.com",
+]);
+
+/**
+ * Match an X/Twitter status URL and return the FxTwitter API URL for it,
+ * or null when the URL isn't a status page (profiles, search, home feed —
+ * those go through the normal OG scrape).
+ *
+ * Handles `/<user>/status/<id>` and the `/i/web/status/<id>` share form.
+ */
+export function resolveTwitterStatus(url: string): string | null {
+    let parsed: URL;
+    try {
+        parsed = new URL(url);
+    } catch {
+        return null;
+    }
+    if (!TWITTER_HOSTS.has(parsed.hostname.toLowerCase())) {
+        return null;
+    }
+    const match = parsed.pathname.match(
+        /^\/(?:i\/web|[A-Za-z0-9_]{1,15})\/status(?:es)?\/(\d+)/,
+    );
+    if (!match) {
+        return null;
+    }
+    return `https://api.fxtwitter.com/status/${match[1]}`;
+}
+
+/**
+ * True for Reddit URLs (including redd.it short links). Reddit serves its
+ * Open Graph tags — with the post's real preview image — only to
+ * recognized embed-crawler user agents; everything else gets a page with
+ * no OG data (or an outright 403 from datacenter addresses).
+ */
+export function isRedditUrl(url: string): boolean {
+    let parsed: URL;
+    try {
+        parsed = new URL(url);
+    } catch {
+        return false;
+    }
+    const host = parsed.hostname.toLowerCase();
+    return REDDIT_HOSTS.has(host) || host === "redd.it";
+}
+
+/** Subset of the FxTwitter status API response the platform consumes. */
+export interface FxTwitterStatus {
+    code: number;
+    message?: string;
+    tweet?: {
+        url?: string;
+        text?: string;
+        author?: {
+            name?: string;
+            screen_name?: string;
+        };
+        media?: {
+            photos?: Array<{
+                url?: string;
+                width?: number;
+                height?: number;
+            }>;
+            videos?: Array<{
+                url?: string;
+                thumbnail_url?: string;
+                width?: number;
+                height?: number;
+                duration?: number;
+            }>;
+        };
+    };
+}
+
+/** The `object` payload shape the metadata platform responds with. */
+export interface PageObject {
+    type: "page";
+    language?: string;
+    title?: string;
+    name?: string;
+    description?: string;
+    image?: Array<{
+        url: string;
+        type?: string;
+        width?: string | number;
+        height?: string | number;
+    }>;
+    video?: {
+        url: string;
+        thumbnail?: string;
+        width?: number;
+        height?: number;
+        duration?: number;
+    };
+    url?: string;
+    favicon?: string;
+    charset?: string;
+}
+
+/**
+ * Map an FxTwitter API response onto the platform's page object. The
+ * preview image is the post's own media — first photo, else the video
+ * thumbnail — never the generic site banner. Returns null when the API
+ * reports anything but success (the caller falls back to the OG scrape).
+ */
+export function tweetToPageObject(status: FxTwitterStatus): PageObject | null {
+    const tweet = status?.tweet;
+    if (status?.code !== 200 || !tweet) {
+        return null;
+    }
+    const author = tweet.author ?? {};
+    const title =
+        author.name && author.screen_name
+            ? `${author.name} (@${author.screen_name}) on X`
+            : (author.name ?? "Post on X");
+    const photo = tweet.media?.photos?.[0];
+    const video = tweet.media?.videos?.[0];
+    const imageUrl = photo?.url ?? video?.thumbnail_url;
+    const page: PageObject = {
+        type: "page",
+        title,
+        name: "X (formerly Twitter)",
+        description: tweet.text ?? "",
+        url: tweet.url,
+        // The API bypasses the page scrape, so no favicon comes back with
+        // it — supply the canonical one so clients can decorate the card.
+        favicon: "https://x.com/favicon.ico",
+    };
+    if (imageUrl) {
+        page.image = [
+            {
+                url: imageUrl,
+                width: photo?.width ?? video?.width,
+                height: photo?.height ?? video?.height,
+            },
+        ];
+    }
+    if (video?.url) {
+        page.video = {
+            url: video.url,
+            thumbnail: video.thumbnail_url,
+            width: video.width,
+            height: video.height,
+            duration: video.duration,
+        };
+    }
+    return page;
+}

--- a/packages/platform-metadata/src/schema.ts
+++ b/packages/platform-metadata/src/schema.ts
@@ -58,13 +58,28 @@ export const PlatformMetadataSchema = {
                         name: { type: "string" },
                         description: { type: "string" },
                         image: { $ref: "#/definitions/responses/ogImage" },
+                        // Post video (populated for X/Twitter statuses via
+                        // FxTwitter): a direct media URL plus the poster
+                        // thumbnail and dimensions.
+                        video: {
+                            type: "object",
+                            required: ["url"],
+                            additionalProperties: false,
+                            properties: {
+                                url: { type: "string" },
+                                thumbnail: { type: "string" },
+                                width: { type: "number" },
+                                height: { type: "number" },
+                                duration: { type: "number" },
+                            },
+                        },
                         url: { type: "string" },
                         favicon: { type: "string" },
                         charset: { type: "string" },
                     },
                 },
                 // open-graph-scraper returns ogImage as an array of image
-                // objects (url + optional dimensions/type).
+                // objects (url + optional dimensions/type/alt text).
                 ogImage: {
                     type: "array",
                     items: {
@@ -76,6 +91,7 @@ export const PlatformMetadataSchema = {
                             type: { type: "string" },
                             width: { type: ["string", "number"] },
                             height: { type: ["string", "number"] },
+                            alt: { type: "string" },
                         },
                     },
                 },


### PR DESCRIPTION
Fixes #1177.

## What

- **X/Twitter status URLs** (`x.com`, `twitter.com`, `/i/web/status/…`, legacy `/statuses/…`) resolve through [FxTwitter's JSON API](https://github.com/FxEmbed/FxEmbed) instead of the OG scrape — X serves only its generic site banner to scrapers, never the post's media. The mapped response carries the tweet text, the post's own photo (or the video's poster thumbnail plus a new `video` object: direct mp4 URL, thumbnail, dimensions, duration), the canonical `x.com` URL, and a favicon. Any FxTwitter failure (API down, deleted post) falls back to the regular scrape, which still yields the post text.
- **Reddit URLs** (all `reddit.com` hosts + `redd.it` short links) are scraped directly but with a **compatibility user agent** — Reddit serves OG data (including the post's real preview image at `share.redd.it/preview/post/<id>`, verified publicly loadable) only to recognized embed crawlers. Defaults to a Discord crawler UA (established practice for self-hosted preview fetchers), overridable via `packageConfig.compatUserAgent`.
- **All scrapes** send an identifiable default UA (`Mozilla/5.0 (compatible; SockethubBot/<version>; +https://sockethub.org)`, override: `packageConfig.userAgent`) instead of undici's default, which many hosts reject.
- **Favicon fallback**: when a page declares no icon, `favicon` falls back to the conventional relative `/favicon.ico` so clients can resolve it against the page URL and decorate previews.
- Schema: new strict `video` object on the page response; `alt` allowed on image entries (Reddit's OG output includes it and the strict schema would have rejected the whole response).

## Approaches evaluated and rejected

- **vxreddit.com mirror**: serves a "wait for verification" interstitial to unrecognized bot UAs → garbage titles stored on bookmarks.
- **Reddit public `.json` API**: now returns 403 unauthenticated regardless of user agent.
- **Facebook**: no working strategy without auth; documented as best-effort (text only).

## Verification

34 unit tests in the package (671→672 repo-wide, all green; lint + build clean). Also exercised against the live network driving the platform class directly:

| URL | before | after |
|---|---|---|
| X photo post | generic `abs.twimg.com` banner | the post's photo (`pbs.twimg.com/media/…?name=orig`, 800×532) |
| X video post | generic banner, no video | poster thumbnail + `video` {mp4 URL, 1920×1080, 9.3s} |
| Reddit post | `Error: 403 Forbidden` | real title, description, post preview image, reddit favicon |
| `redd.it` short link | 403 | same as above via redirect |
| Wikipedia article | works | unchanged |

One caveat only deployment can confirm: Reddit's treatment of the compat UA from a datacenter IP (local verification ran from a residential IP). If the deployed server still sees 403s, `compatUserAgent` is the knob to tune.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced link preview metadata with better favicon fallback, canonical URL resolution, and richer media support (including video details and `ogImage` alt text).
  * Improved site-specific handling for X/Twitter, Reddit, and Facebook to produce more accurate previews.
  * Added configurable request user-agent behavior via `userAgent` and `compatUserAgent`.
* **Bug Fixes**
  * More reliable Twitter status resolution with automatic fallbacks when the API result isn’t usable; safer request behavior with timeouts.
* **Tests**
  * Expanded coverage for resolver logic and platform request behavior.
* **Documentation**
  * Updated README with the new extraction and user-agent configuration guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->