### PR TITLE
fix(server): share and harden multi-origin CORS resolution

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -76,10 +76,21 @@ Sockethub uses a JSON configuration file:
   "sockethub": {
     "port": 10550,          // Port Sockethub listens on
     "host": "localhost",    // Bind address
-    "path": "/sockethub"    // WebSocket endpoint path
+    "path": "/sockethub",   // WebSocket endpoint path
+    "cors": {
+      "origin": "https://app.example.com, https://admin.example.com"
+    }
   }
 }
 ```
+
+`sockethub:cors:origin` (default `"*"`) controls which web origins may connect
+— it governs both socket.io connections and the HTTP actions endpoint. It
+accepts `"*"`, a single origin, or a comma-separated list of origins; when a
+list is configured, the matching request origin is echoed back in
+`Access-Control-Allow-Origin`. See [CORS](#cors) for details. It can also be
+set with the `SOCKETHUB_CORS_ORIGIN` environment variable or the
+`--cors.origin` command-line flag.
 
 ### Public Settings
 
@@ -257,6 +268,14 @@ its origin is allowed:
 - A single origin or comma-separated list — only those origins are allowed;
   the matching origin is echoed in `Access-Control-Allow-Origin` (with
   `Vary: Origin`), and requests from other origins are blocked by the browser.
+
+Configured origins are normalized to the serialization browsers send in the
+`Origin` header (lowercase scheme/host, no trailing slash, default ports
+stripped), so `https://App.example.com/` matches requests from
+`https://app.example.com`. Entries that are not valid origins (missing scheme,
+containing only a path, etc.) are dropped with a logged warning. If a
+restrictive config yields no valid origins, all cross-origin requests are
+blocked (it does not fall back to `"*"`).
 
 Preflight `OPTIONS` requests are answered automatically, and the allowed request
 headers include `Content-Type`, `X-Request-Id`, and `X-Sockethub-Request-Id`.
@@ -492,6 +511,9 @@ Override configuration with environment variables:
 # Server settings
 export HOST=0.0.0.0
 export PORT=10550
+
+# Allowed CORS origin(s): '*', one origin, or a comma-separated list
+export SOCKETHUB_CORS_ORIGIN="https://app.example.com,https://admin.example.com"
 
 # Redis connection
 export REDIS_URL=redis://localhost:6379

--- a/packages/server/src/config.ts
+++ b/packages/server/src/config.ts
@@ -185,13 +185,16 @@ function buildSchema(): convict.Config<Record<string, unknown>> {
             cors: {
                 origin: {
                     doc:
-                        "Allowed CORS origin(s) for socket.io connections. " +
-                        "'*' allows any website to connect visitors' " +
-                        "browsers to this instance; public deployments " +
-                        "should set an explicit origin or comma-separated " +
-                        "list of origins.",
+                        "Allowed CORS origin(s) for socket.io connections " +
+                        "and the HTTP actions endpoint. '*' allows any " +
+                        "website to connect visitors' browsers to this " +
+                        "instance; public deployments should set an " +
+                        "explicit origin or comma-separated list of " +
+                        "origins.",
                     format: String,
                     default: "*",
+                    env: "SOCKETHUB_CORS_ORIGIN",
+                    arg: "cors.origin",
                 },
             },
         },

--- a/packages/server/src/cors.test.ts
+++ b/packages/server/src/cors.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "bun:test";
-import { parseCorsOrigins } from "./cors.js";
+import { parseCorsOrigins, resolveAllowedOrigin } from "./cors.js";
 
 describe("parseCorsOrigins", () => {
     it("returns * when unset, empty, or configured as *", () => {
@@ -58,5 +58,69 @@ describe("parseCorsOrigins", () => {
     it("fails closed when a restrictive config has no valid origins", () => {
         expect(parseCorsOrigins(",,,")).toEqual([]);
         expect(parseCorsOrigins("not a url")).toEqual([]);
+    });
+});
+
+describe("resolveAllowedOrigin", () => {
+    it("returns * when any origin is allowed", () => {
+        expect(resolveAllowedOrigin("*", "https://app.example")).toBe("*");
+        expect(resolveAllowedOrigin("*", undefined)).toBe("*");
+    });
+
+    it("echoes a request origin that is in the allow-list", () => {
+        expect(
+            resolveAllowedOrigin(
+                ["https://a.example", "https://b.example"],
+                "https://b.example",
+            ),
+        ).toBe("https://b.example");
+    });
+
+    it("returns undefined for an origin not in the allow-list", () => {
+        expect(
+            resolveAllowedOrigin(["https://a.example"], "https://evil.example"),
+        ).toBeUndefined();
+    });
+
+    it("returns undefined for a restricted list when no origin is sent", () => {
+        expect(
+            resolveAllowedOrigin(["https://a.example"], undefined),
+        ).toBeUndefined();
+    });
+
+    it("normalizes the request origin before matching", () => {
+        expect(
+            resolveAllowedOrigin(
+                ["https://a.example"],
+                "https://A.example:443",
+            ),
+        ).toBe("https://A.example:443");
+    });
+
+    it("returns undefined for a malformed or opaque request origin", () => {
+        expect(
+            resolveAllowedOrigin(["https://a.example"], "not a url"),
+        ).toBeUndefined();
+        expect(
+            resolveAllowedOrigin(["https://a.example"], "null"),
+        ).toBeUndefined();
+    });
+
+    it("fails closed against an empty allow-list", () => {
+        expect(
+            resolveAllowedOrigin(
+                parseCorsOrigins(",,,"),
+                "https://app.example.com",
+            ),
+        ).toBeUndefined();
+    });
+
+    it("matches configured origins that needed normalizing", () => {
+        expect(
+            resolveAllowedOrigin(
+                parseCorsOrigins("https://App.Example.com/, https://b.example"),
+                "https://app.example.com",
+            ),
+        ).toBe("https://app.example.com");
     });
 });

--- a/packages/server/src/cors.test.ts
+++ b/packages/server/src/cors.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it } from "bun:test";
+import { parseCorsOrigins } from "./cors.js";
+
+describe("parseCorsOrigins", () => {
+    it("returns * when unset, empty, or configured as *", () => {
+        expect(parseCorsOrigins(undefined)).toBe("*");
+        expect(parseCorsOrigins("")).toBe("*");
+        expect(parseCorsOrigins("   ")).toBe("*");
+        expect(parseCorsOrigins("*")).toBe("*");
+    });
+
+    it("parses a single origin into a one-entry list", () => {
+        expect(parseCorsOrigins("https://app.example.com")).toEqual([
+            "https://app.example.com",
+        ]);
+    });
+
+    it("parses a comma-separated list, trimming whitespace", () => {
+        expect(
+            parseCorsOrigins(" https://a.example , https://b.example:8080 "),
+        ).toEqual(["https://a.example", "https://b.example:8080"]);
+    });
+
+    it("normalizes to the browser Origin serialization", () => {
+        expect(
+            parseCorsOrigins(
+                "https://App.Example.com/, http://a.example:80, https://b.example/path",
+            ),
+        ).toEqual([
+            "https://app.example.com",
+            "http://a.example",
+            "https://b.example",
+        ]);
+    });
+
+    it("deduplicates entries that normalize to the same origin", () => {
+        expect(
+            parseCorsOrigins("https://a.example, https://A.example/"),
+        ).toEqual(["https://a.example"]);
+    });
+
+    it("drops entries that are not valid URLs", () => {
+        expect(
+            parseCorsOrigins("app.example.com, https://b.example"),
+        ).toEqual(["https://b.example"]);
+    });
+
+    it("drops entries with an opaque origin", () => {
+        expect(
+            parseCorsOrigins("file:///etc/passwd, https://b.example"),
+        ).toEqual(["https://b.example"]);
+    });
+
+    it("treats a list containing * as allow-any", () => {
+        expect(parseCorsOrigins("https://a.example, *")).toBe("*");
+    });
+
+    it("fails closed when a restrictive config has no valid origins", () => {
+        expect(parseCorsOrigins(",,,")).toEqual([]);
+        expect(parseCorsOrigins("not a url")).toEqual([]);
+    });
+});

--- a/packages/server/src/cors.ts
+++ b/packages/server/src/cors.ts
@@ -1,0 +1,74 @@
+import { createLogger } from "@sockethub/logger";
+
+const log = createLogger("server:cors");
+
+/**
+ * Parse the `sockethub:cors:origin` config value into either `"*"` (any
+ * origin) or a normalized origin allow-list. Both the socket.io listener and
+ * the HTTP actions routes resolve their CORS policy through this single
+ * parser so the two transports can never drift apart.
+ *
+ * Browsers serialize the `Origin` request header as a lowercase
+ * `scheme://host[:port]` with default ports omitted and no trailing slash or
+ * path. Configured entries are normalized to that same serialization before
+ * matching, so values like `https://App.example.com/` still match what the
+ * browser actually sends. Entries that cannot yield a usable origin are
+ * dropped with a warning rather than left in the list where they would
+ * silently never match.
+ *
+ * A restrictive config that yields no valid origins returns an empty list
+ * (blocking all cross-origin requests) instead of falling back to `"*"`:
+ * when an operator attempted to restrict origins, failing closed is the only
+ * safe interpretation.
+ */
+export function parseCorsOrigins(configured: unknown): "*" | Array<string> {
+    const raw = typeof configured === "string" ? configured.trim() : "";
+    if (raw === "" || raw === "*") {
+        return "*";
+    }
+    const origins: Array<string> = [];
+    for (const entry of raw.split(",")) {
+        const trimmed = entry.trim();
+        if (trimmed.length === 0) {
+            continue;
+        }
+        if (trimmed === "*") {
+            log.warn(
+                "cors origin list contains '*'; allowing any origin and " +
+                    "ignoring the other entries",
+            );
+            return "*";
+        }
+        let origin: string;
+        try {
+            origin = new URL(trimmed).origin;
+        } catch {
+            log.warn(
+                `ignoring cors origin entry that is not a valid URL: "${trimmed}"` +
+                    " (origins must include a scheme, e.g. https://app.example.com)",
+            );
+            continue;
+        }
+        // Non-special schemes (file:, data:, ...) serialize to the opaque
+        // origin "null", which no browser request can legitimately match.
+        if (origin === "null") {
+            log.warn(
+                `ignoring cors origin entry with no usable origin: "${trimmed}"`,
+            );
+            continue;
+        }
+        if (origin !== trimmed) {
+            log.warn(`normalized cors origin "${trimmed}" to "${origin}"`);
+        }
+        if (!origins.includes(origin)) {
+            origins.push(origin);
+        }
+    }
+    if (origins.length === 0) {
+        log.error(
+            "cors origin config contained no valid origins; all " +
+                "cross-origin requests will be blocked",
+        );
+    }
+    return origins;
+}

--- a/packages/server/src/cors.ts
+++ b/packages/server/src/cors.ts
@@ -72,3 +72,31 @@ export function parseCorsOrigins(configured: unknown): "*" | Array<string> {
     }
     return origins;
 }
+
+/**
+ * Resolve the `Access-Control-Allow-Origin` value for a request against an
+ * allow-list already parsed by `parseCorsOrigins`. Returns `"*"` when any
+ * origin is allowed, the request's own origin when it is in the allow-list,
+ * or `undefined` when it is not allowed (the browser then blocks the
+ * response). The request origin is run through the same URL normalization as
+ * the configured entries, so matching never depends on the client sending
+ * the canonical serialization.
+ */
+export function resolveAllowedOrigin(
+    allowedOrigins: "*" | Array<string>,
+    requestOrigin: string | undefined,
+): string | undefined {
+    if (allowedOrigins === "*") {
+        return "*";
+    }
+    if (!requestOrigin) {
+        return undefined;
+    }
+    let normalized: string;
+    try {
+        normalized = new URL(requestOrigin).origin;
+    } catch {
+        return undefined;
+    }
+    return allowedOrigins.includes(normalized) ? requestOrigin : undefined;
+}

--- a/packages/server/src/http/actions.test.ts
+++ b/packages/server/src/http/actions.test.ts
@@ -669,4 +669,19 @@ describe("resolveAllowedOrigin", () => {
             resolveAllowedOrigin("https://a.example", undefined),
         ).toBeUndefined();
     });
+
+    it("matches configured origins that need normalizing", () => {
+        expect(
+            resolveAllowedOrigin(
+                "https://App.Example.com/, https://b.example",
+                "https://app.example.com",
+            ),
+        ).toBe("https://app.example.com");
+    });
+
+    it("fails closed when a restrictive config has no valid origins", () => {
+        expect(
+            resolveAllowedOrigin(",,,", "https://app.example.com"),
+        ).toBeUndefined();
+    });
 });

--- a/packages/server/src/http/actions.test.ts
+++ b/packages/server/src/http/actions.test.ts
@@ -3,7 +3,7 @@
  */
 import { describe, expect, it } from "bun:test";
 
-import { registerHttpActionsRoutes, resolveAllowedOrigin } from "./actions.js";
+import { registerHttpActionsRoutes } from "./actions.js";
 import {
     hasHttpSessions,
     unregisterHttpSession,
@@ -640,48 +640,5 @@ describe("http actions", () => {
     });
 });
 
-describe("resolveAllowedOrigin", () => {
-    it("allows any origin when configured as * or unset", () => {
-        expect(resolveAllowedOrigin("*", "https://app.example")).toBe("*");
-        expect(resolveAllowedOrigin(undefined, "https://app.example")).toBe(
-            "*",
-        );
-        expect(resolveAllowedOrigin("", "https://app.example")).toBe("*");
-    });
-
-    it("echoes a request origin that is in the configured allow-list", () => {
-        expect(
-            resolveAllowedOrigin(
-                "https://a.example, https://b.example",
-                "https://b.example",
-            ),
-        ).toBe("https://b.example");
-    });
-
-    it("returns undefined for an origin not in the allow-list", () => {
-        expect(
-            resolveAllowedOrigin("https://a.example", "https://evil.example"),
-        ).toBeUndefined();
-    });
-
-    it("returns undefined for a restricted list when no origin is sent", () => {
-        expect(
-            resolveAllowedOrigin("https://a.example", undefined),
-        ).toBeUndefined();
-    });
-
-    it("matches configured origins that need normalizing", () => {
-        expect(
-            resolveAllowedOrigin(
-                "https://App.Example.com/, https://b.example",
-                "https://app.example.com",
-            ),
-        ).toBe("https://app.example.com");
-    });
-
-    it("fails closed when a restrictive config has no valid origins", () => {
-        expect(
-            resolveAllowedOrigin(",,,", "https://app.example.com"),
-        ).toBeUndefined();
-    });
-});
+// CORS origin resolution is covered in ../cors.test.ts alongside
+// parseCorsOrigins.

--- a/packages/server/src/http/actions.ts
+++ b/packages/server/src/http/actions.ts
@@ -30,6 +30,7 @@ import express, {
 import rateLimit from "express-rate-limit";
 import RedisStore from "rate-limit-redis";
 import config from "../config.js";
+import { parseCorsOrigins } from "../cors.js";
 import { createMessageHandlers } from "../message-handlers.js";
 import type ProcessManager from "../process-manager.js";
 import {
@@ -245,24 +246,19 @@ function resolveConfigNumber(
  * `sockethub:cors:origin` config that governs socket.io. Returns `"*"` when any
  * origin is allowed, the request's own origin when it is in a configured
  * allow-list, or `undefined` when the origin is not allowed (the browser then
- * blocks the response).
+ * blocks the response). Matching is case-insensitive: the allow-list is
+ * normalized to the lowercase browser Origin serialization by
+ * `parseCorsOrigins`.
  */
 export function resolveAllowedOrigin(
     configuredOrigin: string | undefined,
     requestOrigin: string | undefined,
 ): string | undefined {
-    const configured = (configuredOrigin ?? "*").trim();
-    if (configured === "*" || configured === "") {
+    const allowed = parseCorsOrigins(configuredOrigin);
+    if (allowed === "*") {
         return "*";
     }
-    const allowed = configured
-        .split(",")
-        .map((origin) => origin.trim())
-        .filter((origin) => origin.length > 0);
-    if (allowed.length === 0) {
-        return "*";
-    }
-    if (requestOrigin && allowed.includes(requestOrigin)) {
+    if (requestOrigin && allowed.includes(requestOrigin.toLowerCase())) {
         return requestOrigin;
     }
     return undefined;

--- a/packages/server/src/http/actions.ts
+++ b/packages/server/src/http/actions.ts
@@ -30,7 +30,7 @@ import express, {
 import rateLimit from "express-rate-limit";
 import RedisStore from "rate-limit-redis";
 import config from "../config.js";
-import { parseCorsOrigins } from "../cors.js";
+import { parseCorsOrigins, resolveAllowedOrigin } from "../cors.js";
 import { createMessageHandlers } from "../message-handlers.js";
 import type ProcessManager from "../process-manager.js";
 import {
@@ -242,39 +242,22 @@ function resolveConfigNumber(
 }
 
 /**
- * Resolve the `Access-Control-Allow-Origin` value for a request, using the same
- * `sockethub:cors:origin` config that governs socket.io. Returns `"*"` when any
- * origin is allowed, the request's own origin when it is in a configured
- * allow-list, or `undefined` when the origin is not allowed (the browser then
- * blocks the response). Matching is case-insensitive: the allow-list is
- * normalized to the lowercase browser Origin serialization by
- * `parseCorsOrigins`.
- */
-export function resolveAllowedOrigin(
-    configuredOrigin: string | undefined,
-    requestOrigin: string | undefined,
-): string | undefined {
-    const allowed = parseCorsOrigins(configuredOrigin);
-    if (allowed === "*") {
-        return "*";
-    }
-    if (requestOrigin && allowed.includes(requestOrigin.toLowerCase())) {
-        return requestOrigin;
-    }
-    return undefined;
-}
-
-/**
- * CORS middleware for the HTTP actions routes. Emits the allow headers and
- * answers preflight `OPTIONS` requests so browser clients on a configured
- * origin can call the endpoint.
+ * CORS middleware for the HTTP actions routes, honoring the same
+ * `sockethub:cors:origin` config that governs socket.io. Emits the allow
+ * headers and answers preflight `OPTIONS` requests so browser clients on a
+ * configured origin can call the endpoint.
  */
 function createCorsMiddleware(
     getConfig: (key: string) => unknown,
 ): RequestHandler {
+    // Parse the allow-list (and log any config warnings) once at route
+    // registration rather than on every request.
+    const allowedOrigins = parseCorsOrigins(
+        getConfig("sockethub:cors:origin") as string | undefined,
+    );
     return (req, res, next) => {
         const allowOrigin = resolveAllowedOrigin(
-            getConfig("sockethub:cors:origin") as string | undefined,
+            allowedOrigins,
             req.headers.origin,
         );
         if (allowOrigin) {

--- a/packages/server/src/listener.ts
+++ b/packages/server/src/listener.ts
@@ -12,6 +12,7 @@ import express, {
 import rateLimit from "express-rate-limit";
 import { Server, type Socket } from "socket.io";
 import config from "./config.js";
+import { parseCorsOrigins } from "./cors.js";
 import routes from "./routes.js";
 
 const require = createRequire(import.meta.url);
@@ -162,20 +163,7 @@ class Listener {
      * as a relay.
      */
     private static corsOrigin(): string | Array<string> {
-        const configured = (
-            (config.get("sockethub:cors:origin") as string) || "*"
-        ).trim();
-        if (configured === "*" || configured === "") {
-            return "*";
-        }
-        const origins = configured
-            .split(",")
-            .map((origin) => origin.trim())
-            .filter((origin) => origin.length > 0);
-        if (origins.length === 0) {
-            return "*";
-        }
-        return origins.length === 1 ? origins[0] : origins;
+        return parseCorsOrigins(config.get("sockethub:cors:origin"));
     }
 
     private startHttp() {


### PR DESCRIPTION
## Summary

Multi-origin CORS support (the ask in #1176) already landed for socket.io in #1158 and for the HTTP actions endpoint in #1036 — `sockethub:cors:origin` accepts a comma-separated list and the matching request origin is echoed back dynamically. This PR closes the remaining gaps:

- **One shared parser.** `listener.ts` and `http/actions.ts` each parsed the origin list independently; both now resolve through a single `parseCorsOrigins()` (`packages/server/src/cors.ts`) so the two transports can never drift apart.
- **Origin normalization.** Matching was exact string comparison, but browsers send the `Origin` header lowercase with no trailing slash and default ports stripped — so a configured `https://App.example.com/` silently never matched. Configured entries are now normalized to the browser serialization, invalid entries (no scheme, opaque origin) are dropped with a logged warning, and a `*` inside a list is treated as allow-any with a warning.
- **Fail closed.** A restrictive config that yields no valid origins now blocks all cross-origin requests instead of silently falling back to `*`.
- **Env/CLI bindings.** `sockethub:cors:origin` was config-file-only; it can now be set via `SOCKETHUB_CORS_ORIGIN` or `--cors.origin` — the natural fit for the multi-tenant service deployment described in #1176.
- **Docs.** `docs/configuration.md` now covers the setting under Server Settings, the CORS section, and Environment Variables.

Deliberately **not** included: wildcard-subdomain/regex patterns (exact-match lists are the safest primitive and the issue doesn't ask for them), and the `Access-Control-Allow-Origin: *` on the static client-JS routes (`routes.ts`), which is correct for public credential-free assets.

## Runtime verification

Started the built server with `SOCKETHUB_CORS_ORIGIN="https://App.Example.com/, http://localhost:3000"`:

- polling handshake with `Origin: http://localhost:3000` → echoed in `Access-Control-Allow-Origin` + `Vary: Origin`; full socket.io client connect succeeded
- `Origin: https://app.example.com` → allowed despite the uppercase/trailing-slash config entry (normalization warning logged at boot)
- `Origin: https://evil.example` → no `Access-Control-Allow-Origin` header emitted (browser blocks)

## Tests

`bun run lint`, `bun run build`, `bun test` (660 pass) — new unit coverage in `cors.test.ts` plus normalization/fail-closed cases in `actions.test.ts`.

Closes #1176