### PR TITLE
ci: build release Docker image from published npm packages

### DIFF
--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -478,7 +478,7 @@ jobs:
       # cache", e.g. run 28824982137). Both steps share this job's Buildx
       # builder, so the smoke build's amd64 layers are reused by the push
       # build without an external cache.
-      - name: Build image for smoke test
+      - name: Build candidate image (native arch)
         uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6
         with:
           context: .
@@ -489,7 +489,7 @@ jobs:
           push: false
           tags: sockethub-smoke:candidate
 
-      - name: Smoke test image
+      - name: Smoke test candidate against Redis
         run: |
           docker network create smoke-net
           docker run -d --name smoke-redis --network smoke-net redis
@@ -497,28 +497,38 @@ jobs:
             -e REDIS_URL=redis://smoke-redis:6379 \
             -p 10550:10550 sockethub-smoke:candidate
 
+          # Dump logs and tear down on every exit path, so a failed check
+          # (which aborts the step under bash -e) still leaves the container
+          # logs in the Actions output for debugging.
+          cleanup() {
+            echo "--- sockethub container logs ---"
+            docker logs smoke-sockethub || true
+            docker rm -f smoke-sockethub smoke-redis >/dev/null 2>&1 || true
+            docker network rm smoke-net >/dev/null 2>&1 || true
+          }
+          trap cleanup EXIT
+
           echo "Waiting for sockethub to listen on :10550..."
           for i in $(seq 1 30); do
             if nc -z localhost 10550; then break; fi
             sleep 2
           done
-          nc -zv localhost 10550
+          if ! nc -zv localhost 10550; then
+            echo "❌ sockethub never opened port 10550"
+            exit 1
+          fi
 
           # A crash while bootstrapping platforms happens after the port
           # opens; confirm the process survives startup.
           sleep 5
           if [ "$(docker inspect -f '{{.State.Running}}' smoke-sockethub)" != "true" ]; then
             echo "❌ Container exited after startup"
-            docker logs smoke-sockethub
             exit 1
           fi
 
-          docker logs smoke-sockethub
-          docker rm -f smoke-sockethub smoke-redis
-          docker network rm smoke-net
           echo "✅ Smoke test passed"
 
-      - name: Build and push image
+      - name: Build and push multi-arch image
         uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6
         with:
           context: .

--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -391,13 +391,19 @@ jobs:
   # ============================================================
   # DOCKER IMAGE PUBLISH PHASE
   # Build and push a multi-arch image to ghcr.io once the release
-  # has been published to npm. Image tags mirror the npm dist-tags:
+  # has been published to npm. The image installs the *published npm
+  # packages* (Dockerfile.release) rather than building from source, so
+  # every release functionally verifies the artifacts users install —
+  # tarball contents, declared dependencies, bin wiring. A native-arch
+  # smoke test (boot against Redis, port check) gates the multi-arch
+  # push. Image tags mirror the npm dist-tags:
   #   - ghcr.io/sockethub/sockethub:<version>   (moving, points at latest build)
   #   - ghcr.io/sockethub/sockethub:<dist-tag>  (alpha|beta|next|latest)
   #   - ghcr.io/sockethub/sockethub:sha-<short> (immutable, traceable identity)
   # so :latest only ever points at a stable (non-prerelease) version, while the
-  # sha tag uniquely identifies the exact commit a build came from. To retry a
-  # failed build, re-run this job (tags are overwritten); no new release needed.
+  # sha tag uniquely identifies the exact release commit whose packages the
+  # image installs. To retry a failed build, re-run this job (tags are
+  # overwritten); no new release needed.
   # ============================================================
   docker-publish:
     needs: publish
@@ -411,6 +417,23 @@ jobs:
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           ref: ${{ github.sha }}
+
+      # The publish job just pushed the packages, but the registry can lag
+      # before new versions are resolvable. The image build installs the
+      # released packages, so wait until every workspace package (checked at
+      # the versions recorded in this commit's package.json files) is visible.
+      - name: Wait for npm registry propagation
+        run: |
+          for attempt in $(seq 1 30); do
+            if ./scripts/verify-npm-publish.sh; then
+              echo "✅ All packages resolvable on npm"
+              exit 0
+            fi
+            echo "⏳ Registry not caught up yet (attempt $attempt/30); retrying in 20s..."
+            sleep 20
+          done
+          echo "❌ Packages still not resolvable after 10 minutes"
+          exit 1
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130 # v3
@@ -445,10 +468,63 @@ jobs:
           echo "tags=$TAGS" >> "$GITHUB_OUTPUT"
           echo "🐳 Image tags: $TAGS"
 
+      # Build the native-arch image first and boot it against Redis before
+      # any multi-arch push — a broken published package set (missing tarball
+      # files, undeclared dependencies) fails here instead of shipping.
+      #
+      # No type=gha layer cache on these builds: the npm-install layer changes
+      # every release and GitHub evicts cache entries after 7 days, so it never
+      # hits — while writing it has failed whole releases ("failed to reserve
+      # cache", e.g. run 28824982137). Both steps share this job's Buildx
+      # builder, so the smoke build's amd64 layers are reused by the push
+      # build without an external cache.
+      - name: Build image for smoke test
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6
+        with:
+          context: .
+          file: Dockerfile.release
+          build-args: |
+            SOCKETHUB_VERSION=${{ needs.publish.outputs.version }}
+          load: true
+          push: false
+          tags: sockethub-smoke:candidate
+
+      - name: Smoke test image
+        run: |
+          docker network create smoke-net
+          docker run -d --name smoke-redis --network smoke-net redis
+          docker run -d --name smoke-sockethub --network smoke-net \
+            -e REDIS_URL=redis://smoke-redis:6379 \
+            -p 10550:10550 sockethub-smoke:candidate
+
+          echo "Waiting for sockethub to listen on :10550..."
+          for i in $(seq 1 30); do
+            if nc -z localhost 10550; then break; fi
+            sleep 2
+          done
+          nc -zv localhost 10550
+
+          # A crash while bootstrapping platforms happens after the port
+          # opens; confirm the process survives startup.
+          sleep 5
+          if [ "$(docker inspect -f '{{.State.Running}}' smoke-sockethub)" != "true" ]; then
+            echo "❌ Container exited after startup"
+            docker logs smoke-sockethub
+            exit 1
+          fi
+
+          docker logs smoke-sockethub
+          docker rm -f smoke-sockethub smoke-redis
+          docker network rm smoke-net
+          echo "✅ Smoke test passed"
+
       - name: Build and push image
         uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6
         with:
           context: .
+          file: Dockerfile.release
+          build-args: |
+            SOCKETHUB_VERSION=${{ needs.publish.outputs.version }}
           platforms: linux/amd64,linux/arm64
           push: true
           tags: ${{ steps.tags.outputs.tags }}
@@ -457,5 +533,3 @@ jobs:
             org.opencontainers.image.version=${{ needs.publish.outputs.version }}
             org.opencontainers.image.revision=${{ github.sha }}
           provenance: false
-          cache-from: type=gha
-          cache-to: type=gha,mode=max

--- a/Dockerfile.release
+++ b/Dockerfile.release
@@ -1,0 +1,29 @@
+# syntax=docker.io/docker/dockerfile:1.7-labs
+# Release image: installs sockethub from the published npm packages instead of
+# building from source, so the shipped image exercises the exact artifacts
+# users get from `npm install sockethub` — tarball contents, declared
+# dependencies, and bin wiring. Packaging bugs (files missing from a tarball,
+# dependencies masked by monorepo hoisting) surface here instead of in user
+# installs. Dev/CI builds from source via ./Dockerfile.
+ARG node_version=22
+
+# --- install stage: node + gyp toolchain for native-module compilation ------
+FROM node:${node_version}-slim AS install
+# The exact release version to install from npm, e.g. 5.0.0-alpha.14.
+ARG SOCKETHUB_VERSION
+RUN test -n "${SOCKETHUB_VERSION}" || { echo "SOCKETHUB_VERSION build-arg is required" >&2; exit 1; }
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends python3 make g++ \
+    && rm -rf /var/lib/apt/lists/*
+WORKDIR /app
+RUN npm install "sockethub@${SOCKETHUB_VERSION}"
+
+# --- prod stage: node runtime only ------------------------------------------
+# node:*-slim matches the install stage's glibc so any native modules compiled
+# during install stay ABI-compatible.
+FROM node:${node_version}-slim AS prod
+ARG LOG_LEVEL=info
+ENV LOG_LEVEL=${LOG_LEVEL}
+WORKDIR /app
+COPY --from=install /app/node_modules ./node_modules
+CMD ["node", "/app/node_modules/sockethub/bin/sockethub", "--host", "0.0.0.0"]

--- a/Dockerfile.release
+++ b/Dockerfile.release
@@ -1,4 +1,4 @@
-# syntax=docker.io/docker/dockerfile:1.7-labs
+# syntax=docker.io/docker/dockerfile:1.7
 # Release image: installs sockethub from the published npm packages instead of
 # building from source, so the shipped image exercises the exact artifacts
 # users get from `npm install sockethub` — tarball contents, declared
@@ -25,5 +25,10 @@ FROM node:${node_version}-slim AS prod
 ARG LOG_LEVEL=info
 ENV LOG_LEVEL=${LOG_LEVEL}
 WORKDIR /app
-COPY --from=install /app/node_modules ./node_modules
+# --chown on COPY (rather than a RUN chown -R afterwards) avoids duplicating
+# node_modules into a second image layer. The server writes sockethub.log to
+# the cwd, so /app itself must also be writable by the node user.
+COPY --from=install --chown=node:node /app/node_modules ./node_modules
+RUN chown node:node /app
+USER node
 CMD ["node", "/app/node_modules/sockethub/bin/sockethub", "--host", "0.0.0.0"]

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -135,7 +135,7 @@ All communication uses ActivityStreams 2.0 format:
 ## Production Usage
 
 Deploy on Node.js — install the published package (or use the Docker image,
-which builds and runs the server on Node.js):
+which installs the published npm packages and runs the server on Node.js):
 
 ```bash
 # Install and run on Node.js (examples disabled)


### PR DESCRIPTION
## Problem

The published ghcr.io image was built from the monorepo source at the release commit, so it never exercised the artifacts users actually get from `npm install sockethub`. Whole classes of packaging bugs could ship undetected:

- files missing from a tarball (`files` / `.npmignore` mistakes)
- undeclared dependencies masked by monorepo hoisting
- inter-package semver ranges that don't resolve as published
- broken bin wiring

On top of that, the v5.0.0-alpha.15 `docker-publish` job failed outright (`error writing layer blob: failed to reserve cache`, [run 28824982137](https://github.com/sockethub/sockethub/actions/runs/28824982137/job/85486642503)) and took ~17 min — the full bun install + monorepo build ran twice, with the arm64 half under QEMU, and the `type=gha` cache backend choked writing the resulting layers.

## Changes

- **`Dockerfile.release`** (new): installs `sockethub@<version>` from the npm registry and runs it on `node:22-slim`. The install stage carries the gyp toolchain since `msgpackr-extract` (BullMQ dep) compiles natively. Dev/CI source builds keep using `./Dockerfile` via docker-compose, unchanged.
- **`docker-publish` job**:
  - waits for npm registry propagation after publish (retry loop around the existing `scripts/verify-npm-publish.sh`, up to 10 min)
  - builds a native-arch candidate and smoke tests it before the multi-arch push: boots against Redis, waits for `:10550` to listen, and confirms the process survives platform bootstrapping — so every release now functionally verifies the published packages, and a broken package set fails the job instead of shipping
  - drops the `type=gha` layer cache: the npm-install layer changes every release and cache entries evict after 7 days, so it never hit — while writing it is what failed alpha.15. The smoke and push builds share the job's Buildx builder, so amd64 layers are still reused locally.
- **docs**: one-line update in `getting-started.md` describing the image.

## Verification

Built `Dockerfile.release` locally against the real published packages and ran the exact smoke test the workflow uses: all five platforms load, Redis connects, server listens on 10550 and stays up.

## Notes

- The alpha.15 image was never published due to the cache failure. After this merges, running the **Publish Release** workflow via `workflow_dispatch` with `version: 5.0.0-alpha.15` will recover it (npm publish is skipped as already-complete, then docker-publish runs with the new npm-based build).
- Build time should drop from ~17 min to roughly the apt toolchain + `npm install` per arch. If the QEMU arm64 leg is still felt to be slow, a follow-up could split per-arch onto native `ubuntu-24.04-arm` runners with a manifest merge.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new production-ready Docker image path that installs the published package and runs the server directly.
  * Improved the release process with extra validation before publishing multi-architecture images.

* **Bug Fixes**
  * Added checks to help prevent publishing images before packages are fully available and the app starts correctly.

* **Documentation**
  * Updated the getting started guide to reflect the new production deployment behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->