### PR TITLE
ci: make verify-npm-publish.sh survive set -e on bash 5

### DIFF
--- a/scripts/verify-npm-publish.sh
+++ b/scripts/verify-npm-publish.sh
@@ -55,12 +55,15 @@ for pkg_json in $PACKAGES; do
   # Check npm registry
   NPM_VERSION=$(npm view "$PKG_NAME@$CHECK_VERSION" version 2>/dev/null || echo "")
 
+  # Plain assignment, not ((VAR++)): under `set -e` an arithmetic command
+  # whose expression evaluates to 0 (the first post-increment from 0) exits
+  # the script on bash >= 4, so ((PUBLISHED++)) dies after the first package.
   if [ -n "$NPM_VERSION" ]; then
     echo "✅ $PKG_NAME@$CHECK_VERSION - published"
-    ((PUBLISHED++))
+    PUBLISHED=$((PUBLISHED + 1))
   else
     echo "❌ $PKG_NAME@$CHECK_VERSION - NOT published"
-    ((NOT_PUBLISHED++))
+    NOT_PUBLISHED=$((NOT_PUBLISHED + 1))
     FAILED=true
   fi
 done


### PR DESCRIPTION
## Problem

`scripts/verify-npm-publish.sh` runs under `set -e` and counts results with `((PUBLISHED++))`. On bash >= 4, an arithmetic command whose expression evaluates to 0 — which is exactly what the first post-increment from 0 returns — is a failing command, so the script exits 1 right after the **first** published package. macOS bash 3.2 doesn't have this behavior, which is why local validation passed while every CI invocation was silently broken.

Repro on the runner's bash:

```
$ docker run --rm bash:5 bash -c 'set -e; P=0; ((P++)); echo survived'   # exits 1, no output
$ /bin/bash -c 'set -e; P=0; ((P++)); echo survived'                    # macOS 3.2: survived
```

## Impact

- **docker-publish (new in #1182)**: the npm-propagation wait loops on this script, so the job fails after 10 minutes even though all packages are resolvable — first seen in [run 28828026734](https://github.com/sockethub/sockethub/actions/runs/28828026734), the v5.0.0-alpha.15 image recovery attempt.
- **publish preflight** (pre-existing, masked): `npm_complete` was always `false` on CI, so the publish path always re-ran; harmless only because `lerna publish from-package` no-ops when everything is published.

## Fix

Replace the arithmetic-command increments with plain assignments (`PUBLISHED=$((PUBLISHED + 1))`), with a comment explaining why.

## Verification

Ran the fixed script in `node:22-slim` (bash 5.2.15, same family as ubuntu-latest):
- all-published path: 14/14 reported, exit 0
- `--version 99.99.99`: 0/14, exit 1

## After merge

Re-dispatch the alpha.15 image recovery:

```bash
gh workflow run release-publish.yml --repo sockethub/sockethub -f version=5.0.0-alpha.15 -f skip_tag_if_exists=true
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of the npm publish verification process so it completes consistently instead of stopping early in some cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->