### PR TITLE
ci: deploy schema artifacts to sockethub.org on release

### DIFF
--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -543,3 +543,69 @@ jobs:
             org.opencontainers.image.version=${{ needs.publish.outputs.version }}
             org.opencontainers.image.revision=${{ github.sha }}
           provenance: false
+
+  # ============================================================
+  # SCHEMA ARTIFACT DEPLOY TRIGGER
+  # Once the packages are on npm, tell the website repo to publish the
+  # @sockethub/schemas artifacts at their canonical sockethub.org $id /
+  # @context URLs (issue #1185). We only *trigger* the cross-repo workflow;
+  # the sync + build + gh-pages deploy all run in website-sockethub.org using
+  # that repo's own GITHUB_TOKEN, so the token here is dispatch-scoped only.
+  #
+  # The schemas artifact version is the @sockethub/schemas package version
+  # (independent of the server release version). The website workflow is
+  # idempotent — a release where @sockethub/schemas did not bump ends up a
+  # no-op there. The website's sync step retries `npm pack` to ride out
+  # registry propagation, so no explicit wait is needed here.
+  #
+  # Requires repo secret WEBSITE_DISPATCH_TOKEN: a fine-grained PAT scoped to
+  # sockethub/website-sockethub.org with Contents: read & write (the minimum
+  # the repository_dispatch API accepts).
+  # ============================================================
+  deploy-schemas:
+    needs: publish
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout release commit
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.sha }}
+
+      - name: Resolve schemas version and channel
+        id: meta
+        env:
+          DIST_TAG: ${{ needs.publish.outputs.dist_tag }}
+        run: |
+          SCHEMAS_VERSION="$(node -p "require('./packages/schemas/package.json').version")"
+
+          # Map the npm dist-tag to a website release channel. Only alpha and
+          # stable exist on the site; other prerelease tags still deploy the
+          # schema artifacts but don't bump an advertised version.
+          case "$DIST_TAG" in
+            latest) CHANNEL="stable" ;;
+            alpha)  CHANNEL="alpha" ;;
+            *)      CHANNEL="" ;;
+          esac
+
+          echo "schemas_version=$SCHEMAS_VERSION" >> "$GITHUB_OUTPUT"
+          echo "channel=$CHANNEL" >> "$GITHUB_OUTPUT"
+          echo "📦 @sockethub/schemas@$SCHEMAS_VERSION (channel: ${CHANNEL:-none})"
+
+      - name: Trigger website schema deploy
+        env:
+          GH_TOKEN: ${{ secrets.WEBSITE_DISPATCH_TOKEN }}
+          SCHEMAS_VERSION: ${{ steps.meta.outputs.schemas_version }}
+          RELEASE_VERSION: ${{ needs.publish.outputs.version }}
+          CHANNEL: ${{ steps.meta.outputs.channel }}
+        run: |
+          if [ -z "${GH_TOKEN:-}" ]; then
+            echo "::error::WEBSITE_DISPATCH_TOKEN secret is not set; cannot trigger schema deploy"
+            exit 1
+          fi
+          PAYLOAD="$(jq -nc \
+            --arg sv "$SCHEMAS_VERSION" \
+            --arg rv "$RELEASE_VERSION" \
+            --arg ch "$CHANNEL" \
+            '{event_type:"deploy-schemas",client_payload:{schemas_version:$sv,release_version:$rv,channel:$ch}}')"
+          echo "$PAYLOAD" | gh api repos/sockethub/website-sockethub.org/dispatches --input -
+          echo "✅ Dispatched deploy-schemas to website-sockethub.org"

--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -570,6 +570,9 @@ jobs:
         uses: actions/checkout@v4
         with:
           ref: ${{ github.sha }}
+          # Read-only: this job only reads packages/schemas/package.json and
+          # never pushes, so don't persist GITHUB_TOKEN into .git/config.
+          persist-credentials: false
 
       - name: Resolve schemas version and channel
         id: meta

--- a/scripts/verify-schema-urls.sh
+++ b/scripts/verify-schema-urls.sh
@@ -41,7 +41,10 @@ check_schema() {
   fi
   case "$ctype" in
     application/json*) echo "✅ $url" ;;
-    *) echo "⚠️  $url — served but content-type is '$ctype' (expected application/json)" ;;
+    *)
+      echo "❌ $url — served but content-type is '$ctype' (expected application/json)"
+      fail=1
+      ;;
   esac
 }
 

--- a/scripts/verify-schema-urls.sh
+++ b/scripts/verify-schema-urls.sh
@@ -1,0 +1,69 @@
+#!/usr/bin/env bash
+# Verify that the published @sockethub/schemas artifacts are actually served at
+# their canonical sockethub.org $id / @context URLs — the acceptance check for
+# issue #1185.
+#
+# Usage:
+#   ./scripts/verify-schema-urls.sh <schemas-version> [base-url]
+#
+# Examples:
+#   ./scripts/verify-schema-urls.sh 3.0.0-alpha.16
+#   ./scripts/verify-schema-urls.sh 3.0.0-alpha.16 https://sockethub.org
+#
+# Exits non-zero if any URL is unreachable, returns the wrong content-type, or
+# serves a schema whose embedded $id disagrees with the URL it was fetched from.
+set -uo pipefail
+
+VERSION="${1:?usage: verify-schema-urls.sh <schemas-version> [base-url]}"
+BASE="${2:-https://sockethub.org}"
+
+fail=0
+
+# Fetch a JSON Schema and assert (a) it is reachable, (b) content-type is
+# application/json, (c) its $id equals the URL we fetched it from.
+check_schema() {
+  local url="$1" body ctype id
+  ctype="$(curl -fsSL -o /dev/null -w '%{content_type}' "$url" 2>/dev/null)" || {
+    echo "❌ $url — unreachable"
+    fail=1
+    return
+  }
+  body="$(curl -fsSL "$url" 2>/dev/null)" || {
+    echo "❌ $url — unreachable"
+    fail=1
+    return
+  }
+  id="$(printf '%s' "$body" | node -e 'let s="";process.stdin.on("data",d=>s+=d).on("end",()=>{try{process.stdout.write(String(JSON.parse(s).$id||""))}catch{}})')"
+  if [ "$id" != "$url" ]; then
+    echo "❌ $url — \$id mismatch (got '${id:-<none>}')"
+    fail=1
+    return
+  fi
+  case "$ctype" in
+    application/json*) echo "✅ $url" ;;
+    *) echo "⚠️  $url — served but content-type is '$ctype' (expected application/json)" ;;
+  esac
+}
+
+# A JSON-LD context has no $id; just assert it is reachable.
+check_reachable() {
+  local url="$1"
+  if curl -fsSL -o /dev/null "$url" 2>/dev/null; then
+    echo "✅ $url"
+  else
+    echo "❌ $url — unreachable"
+    fail=1
+  fi
+}
+
+echo "Verifying schema artifacts for @sockethub/schemas@$VERSION at $BASE"
+check_schema "$BASE/schemas/$VERSION/sockethub-config.json"
+check_schema "$BASE/schemas/$VERSION/activity-stream.json"
+check_schema "$BASE/schemas/$VERSION/platform.json"
+check_reachable "$BASE/ns/context/v1.jsonld"
+
+if [ "$fail" -ne 0 ]; then
+  echo "one or more schema URLs failed verification" >&2
+  exit 1
+fi
+echo "all schema URLs verified"


### PR DESCRIPTION
Closes #1185 (core-repo half — the website serving half is a companion PR on `sockethub/website-sockethub.org`).

## Problem
The `@sockethub/schemas` build bakes absolute `sockethub.org` URLs into its artifacts (`$id` for JSON Schemas, `@context` for JSON-LD), but nothing serves them — the URLs are dangling 404s. This now bites: `sockethub --write-config` stamps `$schema: https://sockethub.org/schemas/<version>/sockethub-config.json` into generated configs, so editors fetch a 404 instead of getting validation/autocomplete.

## What this PR does (trigger side)
- Adds a `deploy-schemas` job to `release-publish.yml` that, after npm publish, fires a `repository_dispatch` at `website-sockethub.org` to publish the just-released schema artifacts. It only *triggers* the cross-repo workflow; the sync + build + `gh-pages` deploy all run in the website repo using that repo's own `GITHUB_TOKEN`, so the token here is dispatch-scoped only.
  - Keys off the **`@sockethub/schemas` package version** (independent of the server release version), and maps the npm dist-tag → website channel.
  - Passes the server release version + channel too, so the site can advertise the new release.
  - The website workflow is idempotent, so a release where `@sockethub/schemas` didn't bump is a no-op there.
- Adds `scripts/verify-schema-urls.sh` — the #1185 acceptance check: reachability + `application/json` content-type + the served schema's `$id` matching the URL it was fetched from.

## Required setup
Create repo secret **`WEBSITE_DISPATCH_TOKEN`**: a fine-grained PAT scoped to `sockethub/website-sockethub.org` with **Contents: read & write** (the minimum the `repository_dispatch` API accepts). The job fails with a clear message if it's missing.

## Sequencing note
The top-level JSON schemas (`sockethub-config.json`, `activity-stream.json`, `platform.json`) are new and first publish to npm when the config-schema work releases. Until then this pipeline still runs and serves the existing contexts + per-platform schemas; the config schema lights up on that release.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Automated deployment of published schema releases to the website immediately after publishing.
  * Sends release metadata (schema version and release channel) to enable the website to publish the correct version.

* **Tests / Validation**
  * Added a script to verify schema and JSON-LD context URLs are reachable, return JSON, and contain the expected identifiers.
  * The verification fails if any checked URLs are unavailable or inconsistent.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->