### PR TITLE
feat(examples): add CalDAV example page

### DIFF
--- a/integration/sockethub.ci.config.json
+++ b/integration/sockethub.ci.config.json
@@ -6,6 +6,10 @@
     },
     "@sockethub/platform-metadata": {
       "allowPrivateAddresses": true
+    },
+    "@sockethub/platform-caldav": {
+      "allowPrivateAddresses": true,
+      "allowInsecureHttp": true
     }
   }
 }

--- a/packages/examples/src/components/Nav.svelte
+++ b/packages/examples/src/components/Nav.svelte
@@ -7,6 +7,7 @@ const navItems = [
     ["🔧", "Dummy", "/dummy", "Basic examples • Start here"],
     ["📰", "Feeds", "/feeds", "RSS/ATOM feed parsing"],
     ["🔍", "Metadata", "/metadata", "Web page metadata extraction"],
+    ["📅", "CalDAV", "/caldav", "Calendars and tasks"],
     ["💬", "IRC", "/irc", "Internet Relay Chat • Advanced"],
     ["📨", "XMPP", "/xmpp", "Extensible messaging • Advanced"],
 ];

--- a/packages/examples/src/routes/caldav/+page.svelte
+++ b/packages/examples/src/routes/caldav/+page.svelte
@@ -67,19 +67,21 @@ async function setCredentials(): Promise<void> {
                 password,
             },
         };
+        await new Promise<void>((resolve, reject) => {
+            sc.socket.emit(
+                "credentials",
+                credentials,
+                (response: SockethubResponse) => {
+                    if (response?.error) {
+                        reject(new Error(response.error));
+                        return;
+                    }
+                    resolve();
+                },
+            );
+        });
         credentialsSet = true;
         credentialSuccess = "Credentials set for this Sockethub session.";
-        sc.socket.emit(
-            "credentials",
-            credentials,
-            (response: SockethubResponse) => {
-                if (response?.error) {
-                    credentialsSet = false;
-                    credentialSuccess = null;
-                    credentialError = response.error;
-                }
-            },
-        );
     } catch (err) {
         credentialError = err instanceof Error ? err.message : String(err);
     } finally {
@@ -101,6 +103,7 @@ async function fetchCalendars(): Promise<void> {
             (item): item is AnyActivityStream & Calendar =>
                 item.type === "calendar" &&
                 typeof item.id === "string" &&
+                typeof item.name === "string" &&
                 Array.isArray((item as unknown as Calendar).components),
         ) as Calendar[];
         selectedCalendarId = calendars[0]?.id ?? "";
@@ -190,7 +193,7 @@ async function createItem(): Promise<void> {
                 buttonAction={setCredentials}
                 disabled={credentialsSet || busy || !actorId || !serviceUrl || !username || !password}
             >
-                {credentialsSet ? "Credentials Set" : "Set Credentials"}
+                {credentialsSet ? "Credentials Set" : busy ? "Setting Credentials…" : "Set Credentials"}
             </SockethubButton>
         </div>
         {#if credentialError}

--- a/packages/examples/src/routes/caldav/+page.svelte
+++ b/packages/examples/src/routes/caldav/+page.svelte
@@ -103,7 +103,7 @@ async function fetchCalendars(): Promise<void> {
             (item): item is AnyActivityStream & Calendar =>
                 item.type === "calendar" &&
                 typeof item.id === "string" &&
-                typeof item.name === "string" &&
+                typeof (item as unknown as Calendar).name === "string" &&
                 Array.isArray((item as unknown as Calendar).components),
         ) as Calendar[];
         selectedCalendarId = calendars[0]?.id ?? "";

--- a/packages/examples/src/routes/caldav/+page.svelte
+++ b/packages/examples/src/routes/caldav/+page.svelte
@@ -1,0 +1,274 @@
+<script lang="ts">
+import BaseExample from "$components/BaseExample.svelte";
+import FormField from "$components/FormField.svelte";
+import SockethubButton from "$components/SockethubButton.svelte";
+import { contextFor, ensureClientReady, sc, send } from "$lib/sockethub";
+import type { AnyActivityStream, SockethubResponse } from "$lib/sockethub";
+
+type Calendar = {
+    id: string;
+    type: "calendar";
+    name: string;
+    components: ("event" | "task")[];
+};
+
+let actorId = $state("caldav:alice");
+let serviceUrl = $state("");
+let username = $state("");
+let password = $state("");
+let credentialsSet = $state(false);
+let calendars = $state<Calendar[]>([]);
+let selectedCalendarId = $state("");
+let itemType = $state<"event" | "task">("event");
+let name = $state("");
+let startTime = $state("");
+let endTime = $state("");
+let due = $state("");
+let busy = $state(false);
+let error = $state<string | null>(null);
+let success = $state<string | null>(null);
+let credentialError = $state<string | null>(null);
+let credentialSuccess = $state<string | null>(null);
+
+const selectedCalendar = $derived(
+    calendars.find((calendar) => calendar.id === selectedCalendarId),
+);
+const itemTypeSupported = $derived(
+    selectedCalendar?.components.includes(itemType) ?? false,
+);
+
+function actor() {
+    return { id: actorId, type: "person" };
+}
+
+function invalidateCredentials(): void {
+    if (!credentialsSet) return;
+    credentialsSet = false;
+    calendars = [];
+    selectedCalendarId = "";
+    credentialError = null;
+    credentialSuccess = null;
+}
+
+async function setCredentials(): Promise<void> {
+    credentialError = null;
+    credentialSuccess = null;
+    busy = true;
+    try {
+        await ensureClientReady();
+        const credentials = {
+            "@context": await contextFor("caldav"),
+            type: "credentials",
+            actor: actor(),
+            object: {
+                type: "credentials",
+                url: serviceUrl,
+                username,
+                password,
+            },
+        };
+        credentialsSet = true;
+        credentialSuccess = "Credentials set for this Sockethub session.";
+        sc.socket.emit(
+            "credentials",
+            credentials,
+            (response: SockethubResponse) => {
+                if (response?.error) {
+                    credentialsSet = false;
+                    credentialSuccess = null;
+                    credentialError = response.error;
+                }
+            },
+        );
+    } catch (err) {
+        credentialError = err instanceof Error ? err.message : String(err);
+    } finally {
+        busy = false;
+    }
+}
+
+async function fetchCalendars(): Promise<void> {
+    error = null;
+    success = null;
+    busy = true;
+    try {
+        const response = await send({
+            "@context": await contextFor("caldav"),
+            type: "fetch",
+            actor: actor(),
+        } as AnyActivityStream);
+        calendars = (response.items ?? []).filter(
+            (item): item is AnyActivityStream & Calendar =>
+                item.type === "calendar" &&
+                typeof item.id === "string" &&
+                Array.isArray((item as unknown as Calendar).components),
+        ) as Calendar[];
+        selectedCalendarId = calendars[0]?.id ?? "";
+        success = `Found ${calendars.length} calendar${calendars.length === 1 ? "" : "s"}.`;
+    } catch (err) {
+        error = err instanceof Error ? err.message : String(err);
+    } finally {
+        busy = false;
+    }
+}
+
+async function createItem(): Promise<void> {
+    if (!selectedCalendar) return;
+    error = null;
+    success = null;
+    busy = true;
+    try {
+        const object =
+            itemType === "event"
+                ? {
+                      type: "event",
+                      name,
+                      startTime: new Date(startTime).toISOString(),
+                      ...(endTime
+                          ? { endTime: new Date(endTime).toISOString() }
+                          : {}),
+                  }
+                : {
+                      type: "task",
+                      name,
+                      ...(due ? { due: new Date(due).toISOString() } : {}),
+                  };
+        await send({
+            "@context": await contextFor("caldav"),
+            type: "create",
+            actor: actor(),
+            target: { id: selectedCalendar.id, type: "calendar" },
+            object,
+        } as unknown as AnyActivityStream);
+        success = `${itemType === "event" ? "Event" : "To-do"} created.`;
+        name = "";
+        startTime = "";
+        endTime = "";
+        due = "";
+    } catch (err) {
+        error = err instanceof Error ? err.message : String(err);
+    } finally {
+        busy = false;
+    }
+}
+</script>
+
+<BaseExample
+    title="CalDAV Platform Example"
+    description="Discover the calendars in a CalDAV account, then add an event or to-do."
+>
+    <section class="space-y-4">
+        <h2 class="text-xl font-semibold text-gray-900">1. Set credentials</h2>
+        <p class="text-sm text-gray-600">
+            Use an app password when your calendar provider supports one. Credentials stay in this Sockethub session.
+        </p>
+        <FormField
+            label="Actor ID"
+            id="caldav-actor"
+            bind:value={actorId}
+            placeholder="caldav:alice"
+            onInput={invalidateCredentials}
+        />
+        <FormField
+            label="CalDAV URL"
+            id="caldav-url"
+            type="url"
+            bind:value={serviceUrl}
+            placeholder="https://calendar.example/dav/"
+            onInput={invalidateCredentials}
+        />
+        <FormField label="Username" id="caldav-username" bind:value={username} onInput={invalidateCredentials} />
+        <FormField
+            label="Password"
+            id="caldav-password"
+            type="password"
+            bind:value={password}
+            onInput={invalidateCredentials}
+        />
+        <div class="flex justify-end">
+            <SockethubButton
+                buttonAction={setCredentials}
+                disabled={credentialsSet || busy || !actorId || !serviceUrl || !username || !password}
+            >
+                {credentialsSet ? "Credentials Set" : "Set Credentials"}
+            </SockethubButton>
+        </div>
+        {#if credentialError}
+            <div class="rounded-lg border border-red-200 bg-red-50 p-4 text-sm text-red-800" role="alert">
+                {credentialError}
+            </div>
+        {/if}
+        {#if credentialSuccess}
+            <div class="rounded-lg border border-green-200 bg-green-50 p-4 text-sm text-green-800" role="status">
+                {credentialSuccess}
+            </div>
+        {/if}
+    </section>
+
+    <section class="space-y-4 border-t border-gray-200 pt-6">
+        <h2 class="text-xl font-semibold text-gray-900">2. Choose a calendar</h2>
+        <div class="flex justify-end">
+            <SockethubButton buttonAction={fetchCalendars} disabled={busy || !credentialsSet}>
+                Fetch Calendars
+            </SockethubButton>
+        </div>
+        {#if calendars.length > 0}
+            <label for="caldav-calendar" class="block text-sm font-semibold text-gray-700">Calendar</label>
+            <select
+                id="caldav-calendar"
+                bind:value={selectedCalendarId}
+                class="w-full rounded-lg border border-gray-300 bg-white px-4 py-3"
+            >
+                {#each calendars as calendar (calendar.id)}
+                    <option value={calendar.id}>
+                        {calendar.name} ({calendar.components.join(", ")})
+                    </option>
+                {/each}
+            </select>
+        {/if}
+    </section>
+
+    <section class="space-y-4 border-t border-gray-200 pt-6">
+        <h2 class="text-xl font-semibold text-gray-900">3. Add an item</h2>
+        <div class="flex gap-6">
+            <label class="flex items-center gap-2">
+                <input
+                    type="radio"
+                    bind:group={itemType}
+                    value="event"
+                    disabled={Boolean(selectedCalendar && !selectedCalendar.components.includes("event"))}
+                /> Event
+            </label>
+            <label class="flex items-center gap-2">
+                <input
+                    type="radio"
+                    bind:group={itemType}
+                    value="task"
+                    disabled={Boolean(selectedCalendar && !selectedCalendar.components.includes("task"))}
+                /> To-do
+            </label>
+        </div>
+        <FormField label="Name" id="caldav-item-name" bind:value={name} />
+        {#if itemType === "event"}
+            <FormField label="Starts" id="caldav-start" type="datetime-local" bind:value={startTime} />
+            <FormField label="Ends (optional)" id="caldav-end" type="datetime-local" bind:value={endTime} />
+        {:else}
+            <FormField label="Due (optional)" id="caldav-due" type="datetime-local" bind:value={due} />
+        {/if}
+        <div class="flex justify-end">
+            <SockethubButton
+                buttonAction={createItem}
+                disabled={busy || !itemTypeSupported || !name || (itemType === "event" && !startTime)}
+            >
+                Add {itemType === "event" ? "Event" : "To-do"}
+            </SockethubButton>
+        </div>
+    </section>
+
+    {#if error}
+        <div class="rounded-lg border border-red-200 bg-red-50 p-4 text-sm text-red-800" role="alert">{error}</div>
+    {/if}
+    {#if success}
+        <div class="rounded-lg border border-green-200 bg-green-50 p-4 text-sm text-green-800" role="status">{success}</div>
+    {/if}
+</BaseExample>

--- a/packages/examples/tests/smoke.spec.ts
+++ b/packages/examples/tests/smoke.spec.ts
@@ -50,4 +50,32 @@ test.describe("examples smoke against sockethub --examples", () => {
         );
         expect(relevantErrors).toEqual([]);
     });
+
+    test("caldav page exposes the simple create flow", async ({ page }) => {
+        await page.goto("/caldav");
+        await expect(
+            page.getByRole("heading", { name: "CalDAV Platform Example" }),
+        ).toBeVisible();
+        await expect(
+            page.getByRole("button", { name: "Fetch Calendars" }),
+        ).toBeDisabled();
+        await expect(
+            page.getByRole("button", { name: "Add Event" }),
+        ).toBeDisabled();
+
+        await page
+            .getByLabel("CalDAV URL")
+            .fill("https://calendar.example/dav/");
+        await page.getByLabel("Username").fill("alice");
+        await page.getByLabel("Password").fill("app-password");
+        await page.getByRole("button", { name: "Set Credentials" }).click();
+        await expect(
+            page.getByRole("button", { name: "Credentials Set" }),
+        ).toBeDisabled();
+
+        await page.getByLabel("Username").fill("alice-changed");
+        await expect(
+            page.getByRole("button", { name: "Set Credentials" }),
+        ).toBeEnabled();
+    });
 });

--- a/packages/schemas/src/helpers/objects.ts
+++ b/packages/schemas/src/helpers/objects.ts
@@ -42,12 +42,6 @@ export const ObjectTypesSchema = {
             name: {
                 type: "string",
             },
-            components: {
-                type: "array",
-                items: {
-                    enum: ["event", "task"],
-                },
-            },
         },
     },
 
@@ -139,6 +133,12 @@ export const ObjectTypesSchema = {
             },
             name: {
                 type: "string",
+            },
+            components: {
+                type: "array",
+                items: {
+                    enum: ["event", "task"],
+                },
             },
         },
     },

--- a/packages/schemas/src/helpers/objects.ts
+++ b/packages/schemas/src/helpers/objects.ts
@@ -119,6 +119,23 @@ export const ObjectTypesSchema = {
             },
         },
     },
+
+    calendar: {
+        required: ["id", "type"],
+        additionalProperties: true,
+        properties: {
+            id: {
+                type: "string",
+                format: "iri",
+            },
+            type: {
+                enum: ["calendar"],
+            },
+            name: {
+                type: "string",
+            },
+        },
+    },
 };
 
 // Internal AS object types reserved for Sockethub IPC/housekeeping.
@@ -140,6 +157,7 @@ export const TargetTypesList = [
     "website",
     "platform",
     "address",
+    "calendar",
 ];
 export const validActorRefs = ActorTypesList.map((type) => ({
     $ref: `#/definitions/type/${type}`,

--- a/packages/schemas/src/helpers/objects.ts
+++ b/packages/schemas/src/helpers/objects.ts
@@ -42,6 +42,12 @@ export const ObjectTypesSchema = {
             name: {
                 type: "string",
             },
+            components: {
+                type: "array",
+                items: {
+                    enum: ["event", "task"],
+                },
+            },
         },
     },
 

--- a/packages/schemas/src/index.test.data.streams.ts
+++ b/packages/schemas/src/index.test.data.streams.ts
@@ -75,6 +75,7 @@ export default [
                 id: "https://calendar.example/calendars/alice/work/",
                 type: "calendar",
                 name: "Work",
+                components: ["event", "task"],
             },
             object: {
                 type: "message",

--- a/packages/schemas/src/index.test.data.streams.ts
+++ b/packages/schemas/src/index.test.data.streams.ts
@@ -59,6 +59,33 @@ export default [
     ],
 
     [
+        "calendar target",
+        {
+            type: "send",
+            "@context": [
+                "https://www.w3.org/ns/activitystreams",
+                "https://sockethub.org/ns/context/v1.jsonld",
+                "https://sockethub.org/ns/context/platform/dood/v1.jsonld",
+            ],
+            actor: {
+                id: "caldav:alice",
+                type: "person",
+            },
+            target: {
+                id: "https://calendar.example/calendars/alice/work/",
+                type: "calendar",
+                name: "Work",
+            },
+            object: {
+                type: "message",
+                content: "calendar target validation",
+            },
+        },
+        true,
+        "",
+    ],
+
+    [
         "type:credentials, object:credentials",
         {
             type: "credentials",

--- a/packages/schemas/src/index.test.ts
+++ b/packages/schemas/src/index.test.ts
@@ -5,6 +5,7 @@ import testCredentialsData from "./index.test.data.credentials";
 import testPlatformSchemaData from "./index.test.data.platform";
 import testActivityStreamsData from "./index.test.data.streams";
 import { ActivityStreamSchema } from "./schemas/activity-stream";
+import { ObjectTypesSchema } from "./helpers/objects";
 import {
     addPlatformContext,
     addPlatformSchema,
@@ -158,6 +159,21 @@ const RESP_CTX = "https://sockethub.org/ns/context/platform/respplat/v1.jsonld";
 const NO_RESP_CTX = "https://sockethub.org/ns/context/platform/dood/v1.jsonld";
 
 describe("schemas/src/index.ts", () => {
+    describe("shared object schemas", () => {
+        it("constrains calendar targets and their supported components", () => {
+            expect(ObjectTypesSchema.calendar.properties.type).toEqual({
+                enum: ["calendar"],
+            });
+            expect(ObjectTypesSchema.calendar.properties.components).toEqual({
+                type: "array",
+                items: { enum: ["event", "task"] },
+            });
+            expect(ObjectTypesSchema.person.properties).not.toHaveProperty(
+                "components",
+            );
+        });
+    });
+
     describe("Platform schema validation", () => {
         it("returns an empty error for a valid schema", () => {
             const err = validatePlatformSchema(testPlatformSchemaData);

--- a/packages/server/src/middleware/validate.test.data.ts
+++ b/packages/server/src/middleware/validate.test.data.ts
@@ -107,7 +107,7 @@ export default [
         // AJV can report different first errors depending on evaluation order.
         error: [
             "Error: [fakeplatform] /actor: must be object",
-            "Error: [fakeplatform] /target: must match exactly one schema in oneOf: person, room, service, feed, website, address",
+            "Error: [fakeplatform] /target: must match exactly one schema in oneOf: person, room, service, feed, website, address, calendar",
         ],
     },
     {


### PR DESCRIPTION
## Summary

- add a simple CalDAV example for setting credentials and discovering calendars
- allow creating events and to-dos in a selected calendar
- add `calendar` to the shared ActivityStreams target vocabulary so CalDAV mutations pass client validation
- enable the local Radicale development settings and cover the page's credential-state behavior

## Why

The CalDAV platform shipped without an examples page. The new page demonstrates a small, meaningful workflow without becoming a full calendar client. While exercising creation, the shared client validator also rejected the platform's valid `target.type: "calendar"`; this PR aligns the shared target vocabulary with the CalDAV platform schema.

## Validation

- `bun test packages/schemas/src/index.test.ts` (38 passed)
- `bun run --filter @sockethub/examples build`
- `bun run lint` (passes with four pre-existing `platform-metadata` warnings)
- Svelte autofixer reports no issues
- `git diff --check`

The Playwright smoke suite could not execute locally because its Chromium binary is not installed; it failed before running test code.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a CalDAV example for connecting with credentials, browsing calendars, and creating events or to-do items.
  * Added CalDAV navigation with calendar and task descriptions.
  * Added support for calendars as valid activity targets and event/task components.
  * Enabled CalDAV example connections in supported development environments.
* **Bug Fixes**
  * Improved validation messaging to recognize calendar targets.
* **Tests**
  * Added coverage for CalDAV interactions, credential updates, and calendar-targeted activities.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->