### PR TITLE
fix(server): redact HTTP credentials acknowledgements

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -389,13 +389,14 @@ JSON
 Response format: NDJSON (newline-delimited JSON). The endpoint streams one
 complete JSON object per line. If you send an array of actions, you receive one
 line per action result. Successful credential submissions return a minimal
-`credentials-ack` containing only the actor ID. The credential object is never
-included in the response or cached idempotency results.
+`credentials-ack` containing the submitted actor ID for correlation. The
+credential object is never included in the response or cached idempotency
+results.
 
 Example streamed response (`@context` arrays abbreviated):
 
 ```ndjson
-{"@context":["https://www.w3.org/ns/activitystreams","https://sockethub.org/ns/context/v1.jsonld","https://sockethub.org/ns/context/platform/sockethub:internal/v1.jsonld"],"type":"credentials-ack","actor":{"id":"sockethub-server","type":"service"}}
+{"@context":["https://www.w3.org/ns/activitystreams","https://sockethub.org/ns/context/v1.jsonld","https://sockethub.org/ns/context/platform/sockethub:internal/v1.jsonld"],"type":"credentials-ack","actor":{"id":"me@jabber.net","type":"person"}}
 {"type":"echo","@context":["..."],"object":{"type":"message","content":"ok"}}
 {"type":"error","@context":["..."],"error":"invalid credentials"}
 ```

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -388,11 +388,14 @@ JSON
 
 Response format: NDJSON (newline-delimited JSON). The endpoint streams one
 complete JSON object per line. If you send an array of actions, you receive one
-line per action result.
+line per action result. Successful credential submissions return a minimal
+`credentials-ack` containing only the actor ID. The credential object is never
+included in the response or cached idempotency results.
 
 Example streamed response (`@context` arrays abbreviated):
 
 ```ndjson
+{"type":"credentials-ack","actor":{"id":"me@jabber.net"}}
 {"type":"echo","@context":["..."],"object":{"type":"message","content":"ok"}}
 {"type":"error","@context":["..."],"error":"invalid credentials"}
 ```

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -395,7 +395,7 @@ included in the response or cached idempotency results.
 Example streamed response (`@context` arrays abbreviated):
 
 ```ndjson
-{"type":"credentials-ack","actor":{"id":"me@jabber.net"}}
+{"@context":["https://www.w3.org/ns/activitystreams","https://sockethub.org/ns/context/v1.jsonld","https://sockethub.org/ns/context/platform/sockethub:internal/v1.jsonld"],"type":"credentials-ack","actor":{"id":"sockethub-server","type":"service"}}
 {"type":"echo","@context":["..."],"object":{"type":"message","content":"ok"}}
 {"type":"error","@context":["..."],"error":"invalid credentials"}
 ```

--- a/packages/server/src/http/actions.test.ts
+++ b/packages/server/src/http/actions.test.ts
@@ -327,7 +327,7 @@ describe("http actions", () => {
             `${JSON.stringify({
                 "@context": credentialsAckContext,
                 type: "credentials-ack",
-                actor: { id: "sockethub-server", type: "service" },
+                actor: { id: "caldav:alice", type: "person" },
             })}\n`,
         ]);
         const cached = fakeRedis.lists.get(
@@ -337,7 +337,7 @@ describe("http actions", () => {
             JSON.stringify({
                 "@context": credentialsAckContext,
                 type: "credentials-ack",
-                actor: { id: "sockethub-server", type: "service" },
+                actor: { id: "caldav:alice", type: "person" },
             }),
         ]);
         expect(JSON.stringify({ writes, cached })).not.toContain(
@@ -380,7 +380,7 @@ describe("http actions", () => {
         const expected = JSON.stringify({
             "@context": credentialsAckContext,
             type: "credentials-ack",
-            actor: { id: "sockethub-server", type: "service" },
+            actor: { id: "caldav:alice", type: "person" },
             error: "invalid credentials",
         });
         expect(writes).toEqual([`${expected}\n`]);

--- a/packages/server/src/http/actions.test.ts
+++ b/packages/server/src/http/actions.test.ts
@@ -283,6 +283,60 @@ describe("http actions", () => {
         expect(replay.writes.length).toBe(2);
     });
 
+    it("redacts credentials from streamed and cached acknowledgements", async () => {
+        const fakeRedis = new FakeRedis();
+        const handlers = buildHandlers({
+            fakeRedis,
+            createMessageHandlersOverride: () => ({
+                credentials: (payload: unknown, cb: (data: unknown) => void) =>
+                    cb(payload),
+                message: (_payload: unknown, cb: (data: unknown) => void) =>
+                    cb({ type: "collection" }),
+            }),
+        });
+        const requestId = "credentials-redaction";
+        const credentials = {
+            "@context": [
+                "https://www.w3.org/ns/activitystreams",
+                "https://sockethub.org/ns/context/platform/caldav/v1.jsonld",
+            ],
+            type: "credentials",
+            actor: { id: "caldav:alice", type: "person" },
+            object: {
+                type: "credentials",
+                url: "https://calendar.example/alice/",
+                username: "alice",
+                password: "calendar-test-password",
+            },
+        };
+        const { req, res, writes } = createReqRes({
+            body: [credentials],
+            headers: { "x-request-id": requestId },
+        });
+
+        await handlers["/sockethub-http"](req, res);
+        await new Promise((resolve) => setTimeout(resolve, 0));
+
+        expect(writes).toEqual([
+            `${JSON.stringify({
+                type: "credentials-ack",
+                actor: { id: "caldav:alice" },
+            })}\n`,
+        ]);
+        const cached = fakeRedis.lists.get(
+            `sockethub:http-actions:results:${requestId}`,
+        );
+        expect(cached).toEqual([
+            JSON.stringify({
+                type: "credentials-ack",
+                actor: { id: "caldav:alice" },
+            }),
+        ]);
+        expect(JSON.stringify({ writes, cached })).not.toContain(
+            "calendar-test-password",
+        );
+    });
+
     it("serves cached results via GET", async () => {
         const fakeRedis = new FakeRedis();
         const handlers = buildHandlers({ fakeRedis });

--- a/packages/server/src/http/actions.test.ts
+++ b/packages/server/src/http/actions.test.ts
@@ -95,6 +95,12 @@ const singlePayload = {
     actor: { id: "me" },
 };
 
+const credentialsAckContext = [
+    "https://www.w3.org/ns/activitystreams",
+    "https://sockethub.org/ns/context/v1.jsonld",
+    "https://sockethub.org/ns/context/platform/sockethub:internal/v1.jsonld",
+];
+
 function createReqRes({
     body,
     headers = {},
@@ -319,8 +325,9 @@ describe("http actions", () => {
 
         expect(writes).toEqual([
             `${JSON.stringify({
+                "@context": credentialsAckContext,
                 type: "credentials-ack",
-                actor: { id: "caldav:alice" },
+                actor: { id: "sockethub-server", type: "service" },
             })}\n`,
         ]);
         const cached = fakeRedis.lists.get(
@@ -328,12 +335,65 @@ describe("http actions", () => {
         );
         expect(cached).toEqual([
             JSON.stringify({
+                "@context": credentialsAckContext,
                 type: "credentials-ack",
-                actor: { id: "caldav:alice" },
+                actor: { id: "sockethub-server", type: "service" },
             }),
         ]);
         expect(JSON.stringify({ writes, cached })).not.toContain(
             "calendar-test-password",
+        );
+    });
+
+    it("redacts credentials from handler error acknowledgements", async () => {
+        const fakeRedis = new FakeRedis();
+        const handlers = buildHandlers({
+            fakeRedis,
+            createMessageHandlersOverride: () => ({
+                credentials: (
+                    payload: Record<string, unknown>,
+                    cb: (data: unknown) => void,
+                ) => cb({ ...payload, error: "invalid credentials" }),
+                message: (_payload: unknown, cb: (data: unknown) => void) =>
+                    cb({ type: "collection" }),
+            }),
+        });
+        const requestId = "credentials-error-redaction";
+        const credentials = {
+            "@context": credentialsAckContext,
+            type: "credentials",
+            actor: { id: "caldav:alice", type: "person" },
+            object: {
+                type: "credentials",
+                username: "alice",
+                password: "calendar-test-password",
+            },
+        };
+        const { req, res, writes } = createReqRes({
+            body: [credentials],
+            headers: { "x-request-id": requestId },
+        });
+
+        await handlers["/sockethub-http"](req, res);
+        await new Promise((resolve) => setTimeout(resolve, 0));
+
+        const expected = JSON.stringify({
+            "@context": credentialsAckContext,
+            type: "credentials-ack",
+            actor: { id: "sockethub-server", type: "service" },
+            error: "invalid credentials",
+        });
+        expect(writes).toEqual([`${expected}\n`]);
+        expect(
+            fakeRedis.lists.get(
+                `sockethub:http-actions:results:${requestId}`,
+            ),
+        ).toEqual([expected]);
+        expect(JSON.stringify({ writes, cached: fakeRedis.lists })).not.toContain(
+            "calendar-test-password",
+        );
+        expect(JSON.stringify({ writes, cached: fakeRedis.lists })).not.toContain(
+            '"username"',
         );
     });
 

--- a/packages/server/src/http/actions.ts
+++ b/packages/server/src/http/actions.ts
@@ -19,6 +19,7 @@ import type {
 import {
     buildCanonicalContext,
     ERROR_PLATFORM_CONTEXT_URL,
+    INTERNAL_PLATFORM_CONTEXT_URL,
 } from "@sockethub/schemas";
 import { crypto } from "@sockethub/util/crypto";
 import express, {
@@ -143,18 +144,17 @@ function buildServerError(message: string, requestId?: string) {
  * HTTP results may be cached for idempotent replay, so only explicitly safe
  * fields are copied from the submitted activity.
  */
-function buildCredentialsAck(
-    payload: ActivityStream,
-    result?: ActivityStream | Error,
-) {
+function buildCredentialsAck(result?: ActivityStream | Error) {
     if (result instanceof Error) {
         return result;
     }
 
-    const ack: Record<string, unknown> = {
+    const ack: ActivityStream = {
+        "@context": buildCanonicalContext(INTERNAL_PLATFORM_CONTEXT_URL),
         type: "credentials-ack",
         actor: {
-            id: payload.actor.id,
+            id: "sockethub-server",
+            type: "service",
         },
     };
     if (isObject(result) && typeof result.error === "string") {
@@ -931,12 +931,7 @@ export function registerHttpActionsRoutes(
                         handlers.credentials(
                             payload as ActivityStream,
                             (result) =>
-                                writeResult(
-                                    buildCredentialsAck(
-                                        payload as ActivityStream,
-                                        result,
-                                    ),
-                                ),
+                                writeResult(buildCredentialsAck(result)),
                         );
                         break;
                     case "message":

--- a/packages/server/src/http/actions.ts
+++ b/packages/server/src/http/actions.ts
@@ -142,9 +142,13 @@ function buildServerError(message: string, requestId?: string) {
 /**
  * Acknowledge credential storage without returning the credential object.
  * HTTP results may be cached for idempotent replay, so only explicitly safe
- * fields are copied from the submitted activity.
+ * fields are copied from the submitted activity. The actor ID is retained so
+ * batched credential acknowledgements can be correlated with their inputs.
  */
-function buildCredentialsAck(result?: ActivityStream | Error) {
+function buildCredentialsAck(
+    payload: ActivityStream,
+    result?: ActivityStream | Error,
+) {
     if (result instanceof Error) {
         return result;
     }
@@ -153,8 +157,8 @@ function buildCredentialsAck(result?: ActivityStream | Error) {
         "@context": buildCanonicalContext(INTERNAL_PLATFORM_CONTEXT_URL),
         type: "credentials-ack",
         actor: {
-            id: "sockethub-server",
-            type: "service",
+            id: payload.actor.id,
+            type: "person",
         },
     };
     if (isObject(result) && typeof result.error === "string") {
@@ -931,7 +935,12 @@ export function registerHttpActionsRoutes(
                         handlers.credentials(
                             payload as ActivityStream,
                             (result) =>
-                                writeResult(buildCredentialsAck(result)),
+                                writeResult(
+                                    buildCredentialsAck(
+                                        payload as ActivityStream,
+                                        result,
+                                    ),
+                                ),
                         );
                         break;
                     case "message":

--- a/packages/server/src/http/actions.ts
+++ b/packages/server/src/http/actions.ts
@@ -138,6 +138,31 @@ function buildServerError(message: string, requestId?: string) {
     return payload;
 }
 
+/**
+ * Acknowledge credential storage without returning the credential object.
+ * HTTP results may be cached for idempotent replay, so only explicitly safe
+ * fields are copied from the submitted activity.
+ */
+function buildCredentialsAck(
+    payload: ActivityStream,
+    result?: ActivityStream | Error,
+) {
+    if (result instanceof Error) {
+        return result;
+    }
+
+    const ack: Record<string, unknown> = {
+        type: "credentials-ack",
+        actor: {
+            id: payload.actor.id,
+        },
+    };
+    if (isObject(result) && typeof result.error === "string") {
+        ack.error = result.error;
+    }
+    return ack;
+}
+
 function normalizeRequestId(value: unknown): RequestIdResolution {
     if (typeof value !== "string") {
         return {};
@@ -905,7 +930,13 @@ export function registerHttpActionsRoutes(
                     case "credentials":
                         handlers.credentials(
                             payload as ActivityStream,
-                            writeResult,
+                            (result) =>
+                                writeResult(
+                                    buildCredentialsAck(
+                                        payload as ActivityStream,
+                                        result,
+                                    ),
+                                ),
                         );
                         break;
                     case "message":


### PR DESCRIPTION
## Summary

- replace HTTP credentials echoes with a minimal `credentials-ack` containing the submitted `actor.id` for batch correlation
- ensure neither streamed NDJSON nor cached idempotency results contain credential objects
- document the redacted acknowledgement shape

## Root cause

The HTTP actions route passed the credentials middleware result directly to the shared result writer. Successful credentials middleware returns the submitted activity, so the full credential object—including passwords or tokens—was serialized to the response and persisted for idempotent replay.

The route now converts credential results to an explicit safe acknowledgement before the shared serialization and persistence boundary. It retains only the submitted actor ID for correlation; credential errors additionally preserve only their error message.

## Impact

HTTP actions clients still receive one result line per submitted action, but successful credential lines now have this shape:

```json
{"@context":["https://www.w3.org/ns/activitystreams","https://sockethub.org/ns/context/v1.jsonld","https://sockethub.org/ns/context/platform/sockethub:internal/v1.jsonld"],"type":"credentials-ack","actor":{"id":"caldav:alice","type":"person"}}
```

The submitted actor ID allows clients to correlate results from multi-actor batches even when callbacks complete out of order. Cleartext credentials cannot appear in response streams, proxy logs, Redis replay storage, or later GET replays.

Closes #1195.

## Validation

- `bun test packages/server/src/http/actions.test.ts` (20 passing)
- `bun run --filter @sockethub/server build`
- `bun run lint`
- `bun test` (743 passing)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Credential submissions now return only a minimal acknowledgment with the actor ID and any error message.
  * Sensitive credential data, including passwords, URLs, and usernames, is excluded from streamed responses and idempotency-cache replays.
  * Error acknowledgments preserve error details without exposing submitted credentials.

* **Documentation**
  * Updated HTTP Actions response documentation and examples to reflect the sanitized credential acknowledgment format.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
