### PR TITLE
fix(examples): show batch response log details

### DIFF
--- a/packages/examples/src/components/logs/Logger.svelte
+++ b/packages/examples/src/components/logs/Logger.svelte
@@ -1,6 +1,7 @@
 <script lang="ts" module>
 import type { AnyActivityStream } from "$lib/sockethub";
 import { writable } from "svelte/store";
+import { resolveLogDetails, type LogMetadata } from "./log-details";
 
 type LogEntries = Record<
     string,
@@ -10,11 +11,6 @@ type LogEntries = Record<
     ]
 >;
 const Logs = writable({} as LogEntries);
-type LogMetadata = {
-    timestamp: number;
-    sortKey: number;
-    requestId?: string;
-};
 const LogMeta = writable({} as Record<string, LogMetadata>);
 let counter = 0;
 
@@ -63,18 +59,6 @@ export function addObject(
         return currentLogs;
     });
     return obj;
-}
-
-export function resolveLogDetails(
-    logs: LogEntries,
-    meta: Record<string, LogMetadata>,
-    id: string,
-) {
-    const requestId = meta[id]?.requestId ?? id;
-    return {
-        sent: logs[requestId]?.[0],
-        response: logs[id]?.[1],
-    };
 }
 
 export type SchemaLogType = "schemas" | "ready" | "init_error";

--- a/packages/examples/src/components/logs/Logger.svelte
+++ b/packages/examples/src/components/logs/Logger.svelte
@@ -10,9 +10,12 @@ type LogEntries = Record<
     ]
 >;
 const Logs = writable({} as LogEntries);
-const LogMeta = writable(
-    {} as Record<string, { timestamp: number; sortKey: number }>,
-);
+type LogMetadata = {
+    timestamp: number;
+    sortKey: number;
+    requestId?: string;
+};
+const LogMeta = writable({} as Record<string, LogMetadata>);
 let counter = 0;
 
 type ObjectType = "SEND" | "RESP";
@@ -21,6 +24,7 @@ export function addObject(
     type: ObjectType,
     obj: AnyActivityStream,
     isBatch = false,
+    requestId?: string,
 ): AnyActivityStream {
     let index: string;
     const sortKey = ++counter;
@@ -40,7 +44,7 @@ export function addObject(
     const now = Date.now();
     LogMeta.update((meta) => {
         if (!meta[index]) {
-            meta[index] = { timestamp: now, sortKey };
+            meta[index] = { timestamp: now, sortKey, requestId };
         }
         return meta;
     });
@@ -59,6 +63,18 @@ export function addObject(
         return currentLogs;
     });
     return obj;
+}
+
+export function resolveLogDetails(
+    logs: LogEntries,
+    meta: Record<string, LogMetadata>,
+    id: string,
+) {
+    const requestId = meta[id]?.requestId ?? id;
+    return {
+        sent: logs[requestId]?.[0],
+        response: logs[id]?.[1],
+    };
 }
 
 export type SchemaLogType = "schemas" | "ready" | "init_error";
@@ -98,7 +114,7 @@ export { SchemaLogs };
         | { kind: "schema"; sortKey: number; entry: SchemaLogEntry };
 
     let logs: LogEntries = $state({} as LogEntries);
-    let meta: Record<string, { timestamp: number; sortKey: number }> = $state({});
+    let meta: Record<string, LogMetadata> = $state({});
     let schemaLogs: SchemaLogEntry[] = $state([]);
     let logModalState = $state(false);
     let jsonSend = $state("");
@@ -108,7 +124,7 @@ export { SchemaLogs };
     Logs.subscribe((data: LogEntries) => {
         logs = data;
     });
-    LogMeta.subscribe((data: Record<string, { timestamp: number; sortKey: number }>) => {
+    LogMeta.subscribe((data: Record<string, LogMetadata>) => {
         meta = data;
     });
     SchemaLogs.subscribe((data: SchemaLogEntry[]) => {
@@ -130,20 +146,13 @@ export { SchemaLogs };
 
     function showLog(uid: string) {
         return () => {
-            let indexSend = uid;
-            let indexResp = uid;
-            if (uid.includes("-")) {
-                indexSend = uid.split("-")[0];
-            }
-            console.log(`indexSend:${indexSend} indexResp:${indexResp}`);
-            console.log("logs: ", logs);
+            const { sent, response } = resolveLogDetails(logs, meta, uid);
             modalTitle = "ActivityStreams Data Exchange";
             logModalState = true;
-            jsonSend = JSON.stringify(logs[indexSend][0], null, 2);
-            const resp = logs[indexResp]?.[1];
+            jsonSend = sent ? JSON.stringify(sent, null, 2) : "";
             jsonResp =
-                resp && Object.keys(resp as object).length > 0
-                    ? JSON.stringify(resp, null, 2)
+                response && Object.keys(response as object).length > 0
+                    ? JSON.stringify(response, null, 2)
                     : "";
         };
     }

--- a/packages/examples/src/components/logs/Logger.test.ts
+++ b/packages/examples/src/components/logs/Logger.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { resolveLogDetails } from "./Logger.svelte";
+import { resolveLogDetails } from "./log-details";
 
 describe("activity log details", () => {
     it("associates a URL-shaped batch response with its originating request", () => {

--- a/packages/examples/src/components/logs/Logger.test.ts
+++ b/packages/examples/src/components/logs/Logger.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from "vitest";
+import { resolveLogDetails } from "./Logger.svelte";
+
+describe("activity log details", () => {
+    it("associates a URL-shaped batch response with its originating request", () => {
+        const request = { "@context": ["https://example.test"], type: "fetch" };
+        const calendar = {
+            "@context": ["https://example.test"],
+            id: "https://calendar.example.test/team-events/",
+            type: "calendar",
+        };
+        const batchId = `${calendar.id}-2`;
+        const logs: Parameters<typeof resolveLogDetails>[0] = {
+            "1": [request, {}],
+            [batchId]: [{}, calendar],
+        };
+        const meta = {
+            "1": { timestamp: 1, sortKey: 1 },
+            [batchId]: { timestamp: 2, sortKey: 2, requestId: "1" },
+        };
+
+        expect(resolveLogDetails(logs, meta, batchId)).toEqual({
+            sent: request,
+            response: calendar,
+        });
+    });
+});

--- a/packages/examples/src/components/logs/log-details.ts
+++ b/packages/examples/src/components/logs/log-details.ts
@@ -1,0 +1,19 @@
+export type LogMetadata = {
+    timestamp: number;
+    sortKey: number;
+    requestId?: string;
+};
+
+type LogEntries = Record<string, readonly [unknown, unknown]>;
+
+export function resolveLogDetails(
+    logs: LogEntries,
+    meta: Record<string, LogMetadata>,
+    id: string,
+) {
+    const requestId = meta[id]?.requestId ?? id;
+    return {
+        sent: logs[requestId]?.[0],
+        response: logs[id]?.[1],
+    };
+}

--- a/packages/examples/src/lib/sockethub.ts
+++ b/packages/examples/src/lib/sockethub.ts
@@ -115,25 +115,22 @@ export async function send(obj: AnyActivityStream) {
     console.log("sending ->", obj);
 
     return new Promise<AnyActivityStream>((resolve, reject) => {
-        sc.socket.emit(
-            "message",
-            addObject("SEND", obj),
-            (resp: AnyActivityStream) => {
-                console.log("received <-", resp);
-                addObject("RESP", resp);
-                if (resp.totalItems && resp.items) {
-                    for (const item of resp.items.reverse()) {
-                        addObject("RESP", item, true);
-                    }
+        const request = addObject("SEND", obj);
+        sc.socket.emit("message", request, (resp: AnyActivityStream) => {
+            console.log("received <-", resp);
+            addObject("RESP", resp);
+            if (resp.totalItems && resp.items) {
+                for (const item of resp.items.reverse()) {
+                    addObject("RESP", item, true, request.id);
                 }
-                displayMessage(resp, true);
-                if (resp.error) {
-                    reject(resp.error);
-                } else {
-                    resolve(resp);
-                }
-            },
-        );
+            }
+            displayMessage(resp, true);
+            if (resp.error) {
+                reject(resp.error);
+            } else {
+                resolve(resp);
+            }
+        });
     });
 }
 


### PR DESCRIPTION
## Summary

- retain the originating request ID in activity-log metadata for batch responses
- resolve modal content through that explicit relationship instead of parsing synthetic IDs
- add regression coverage for a CalDAV-style URL item ID containing hyphens

## Root cause

Collection entries use synthetic log keys derived from response item IDs. The details handler attempted to recover the parent request by splitting those keys on hyphens. URL-shaped CalDAV IDs therefore resolved to a nonexistent log entry and threw after opening the modal, leaving it blank.

Fixes #1201.

## Validation

- `bun run test:unit` in `packages/examples`
- `bun run check` in `packages/examples`
- `bun run build` in `packages/examples`
- `bun run lint`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved log detail matching so responses are correctly associated with their originating requests, including calendar batch responses.
  * Enhanced log views to reliably display corresponding sent requests and responses.

* **Tests**
  * Added coverage verifying request and response association for URL-based calendar batch responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->