### PR TITLE
perf: skip declaration generation during dev

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,12 +39,13 @@
     "socket.io": "4.8.3"
   },
   "scripts": {
-    "build": "bun run build:foundations && bun run --filter='!@sockethub/{util,dav,schemas,client}' build && bun run build:server:post && bun run build:types",
+    "build": "bun run build:runtime && bun run build:types",
     "build:foundations": "bun run --filter='@sockethub/util' build && bun run --filter='@sockethub/dav' build && bun run --filter='@sockethub/schemas' build && bun run --filter='@sockethub/client' build",
+    "build:runtime": "bun run build:foundations && bun run --filter='!@sockethub/{util,dav,schemas,client}' build && bun run build:server:post",
     "build:server:post": "rm -rf packages/server/res && mkdir -p packages/server/res && cp node_modules/@sockethub/client/dist/sockethub-client.browser.js packages/server/res/sockethub-client.js && cp node_modules/@sockethub/client/dist/sockethub-client.min.js packages/server/res/sockethub-client.min.js && cp node_modules/socket.io-client/dist/socket.io.js packages/server/res/socket.io.js",
     "clean": "bun run --filter='*' clean",
     "clean:deps": "bun run --filter='*' clean:deps && rm -rf node_modules",
-    "dev": "bun run build && cd packages/sockethub && bun run dev",
+    "dev": "bun run build:runtime && cd packages/sockethub && bun run dev",
     "doc": "bun run --filter='*' doc",
     "docker:start": "bun run docker:start:xmpp && bun run docker:start:irc && bun run docker:start:caldav && docker compose up sockethub -d",
     "docker:start:xmpp": "bash scripts/docker-compose-retry.sh up prosody -d",


### PR DESCRIPTION
## Summary

- split the root build into runtime and declaration phases
- keep `bun run build` producing both runtime bundles and TypeScript declarations
- make `bun run dev` run only the runtime build before starting Sockethub

## Why

Declaration generation was added for published package consumers, but the existing `dev` script invoked the full production build. That caused `scripts/build-types.js` to run for every package on each development startup even though workspace development does not consume those generated declarations.

This preserves release and package-build behavior while removing the unnecessary development startup cost.

Closes #1199.

## Validation

- `bun run lint`
- `bun run build:runtime`
- `bun run build:types`
- `bun test` — 798 passed
- `bun run dev` — confirmed the runtime build completes without invoking `build-types`; Sockethub reached startup and then exited because Redis was not running locally


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Build & Development**
  * Updated the build process to separate runtime compilation from type generation.
  * Improved development startup by using the runtime build pipeline directly.
  * Added server post-processing to the runtime build workflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->