### PR TITLE
fix: prevent PR metadata shell injection

### DIFF
--- a/.github/workflows/validate-branch.yml
+++ b/.github/workflows/validate-branch.yml
@@ -7,11 +7,13 @@ on:
 jobs:
   validate:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - name: Validate branch name
+        env:
+          BRANCH: ${{ github.head_ref }}
         run: |
-          BRANCH="${{ github.head_ref }}"
-          
           # Allow release branches (created by automation)
           if [[ "$BRANCH" =~ ^release/v[0-9]+\.[0-9]+\.[0-9]+ ]]; then
             echo "✅ Release branch: $BRANCH"
@@ -63,9 +65,9 @@ jobs:
           fi
 
       - name: Validate PR title
+        env:
+          TITLE: ${{ github.event.pull_request.title }}
         run: |
-          TITLE="${{ github.event.pull_request.title }}"
-          
           # Allow release PR titles (created by automation)
           if [[ "$TITLE" =~ ^Release\ v[0-9]+\.[0-9]+\.[0-9]+ ]]; then
             echo "✅ Release PR title: $TITLE"


### PR DESCRIPTION
## Summary

- pass pull request titles and branch names to validation scripts through environment variables
- restrict the validation job token to read-only repository contents

## Root cause

The workflow interpolated pull request metadata directly into generated shell source. A crafted title or branch name could therefore alter the shell program executed by the runner.

## Impact

Untrusted pull request metadata is now treated as data rather than executable shell syntax.

## Validation

- `git diff --check`
- `bun run lint`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated branch and pull request title validation workflow permissions to read-only access.
  * Improved how validation inputs are passed between workflow steps without changing validation behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->