### PR TITLE
fix(server): bound Socket.IO payload size

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -69,7 +69,8 @@ does not start).
   "sockethub": {
     "port": 10550,
     "host": "localhost", 
-    "path": "/sockethub"
+    "path": "/sockethub",
+    "maxPayloadBytes": 262144
   },
   "httpActions": {
     "enabled": false,
@@ -94,6 +95,7 @@ does not start).
     "port": 10550,          // Port Sockethub listens on
     "host": "localhost",    // Bind address
     "path": "/sockethub",   // WebSocket endpoint path
+    "maxPayloadBytes": 262144, // Maximum Socket.IO message size
     "cors": {
       "origin": "https://app.example.com, https://admin.example.com"
     }
@@ -108,6 +110,10 @@ list is configured, the matching request origin is echoed back in
 `Access-Control-Allow-Origin`. See [CORS](#cors) for details. It can also be
 set with the `SOCKETHUB_CORS_ORIGIN` environment variable or the
 `--cors.origin` command-line flag.
+
+`sockethub:maxPayloadBytes` (default `262144`, or 256 KiB) limits each
+Socket.IO message before it enters validation or the Redis-backed job queue.
+It can be overridden with `SOCKETHUB_MAX_PAYLOAD_BYTES`.
 
 ### Public Settings
 

--- a/packages/schemas/src/schemas/sockethub-config.ts
+++ b/packages/schemas/src/schemas/sockethub-config.ts
@@ -284,7 +284,7 @@ export const SockethubConfigSchema = {
                     default: "/sockethub",
                 },
                 maxPayloadBytes: {
-                    type: "number",
+                    type: "integer",
                     minimum: 1,
                     default: 262144,
                     description:

--- a/packages/schemas/src/schemas/sockethub-config.ts
+++ b/packages/schemas/src/schemas/sockethub-config.ts
@@ -283,6 +283,13 @@ export const SockethubConfigSchema = {
                     type: "string",
                     default: "/sockethub",
                 },
+                maxPayloadBytes: {
+                    type: "number",
+                    minimum: 1,
+                    default: 262144,
+                    description:
+                        "Maximum size in bytes of a single Socket.IO message.",
+                },
                 cors: {
                     type: "object",
                     additionalProperties: false,

--- a/packages/server/src/config-schema.ts
+++ b/packages/server/src/config-schema.ts
@@ -41,6 +41,22 @@ type OverlayEntry = {
     default?: unknown;
 };
 
+convict.addFormat({
+    name: "positive-integer",
+    validate(value: unknown): void {
+        if (
+            typeof value !== "number" ||
+            !Number.isInteger(value) ||
+            value < 1
+        ) {
+            throw new Error("must be a positive integer");
+        }
+    },
+    coerce(value: unknown): number {
+        return Number(value);
+    },
+});
+
 const OVERLAY: Record<string, OverlayEntry> = {
     $schema: { default: "" },
     examples: { arg: "examples" },
@@ -77,7 +93,7 @@ const OVERLAY: Record<string, OverlayEntry> = {
     },
     "sockethub.host": { env: "HOST", emptyEnvIsUnset: true, arg: "host" },
     "sockethub.maxPayloadBytes": {
-        format: "nat",
+        format: "positive-integer",
         env: "SOCKETHUB_MAX_PAYLOAD_BYTES",
         emptyEnvIsUnset: true,
     },

--- a/packages/server/src/config-schema.ts
+++ b/packages/server/src/config-schema.ts
@@ -76,6 +76,11 @@ const OVERLAY: Record<string, OverlayEntry> = {
         arg: "port",
     },
     "sockethub.host": { env: "HOST", emptyEnvIsUnset: true, arg: "host" },
+    "sockethub.maxPayloadBytes": {
+        format: "nat",
+        env: "SOCKETHUB_MAX_PAYLOAD_BYTES",
+        emptyEnvIsUnset: true,
+    },
     "sockethub.cors.origin": {
         env: "SOCKETHUB_CORS_ORIGIN",
         arg: "cors.origin",

--- a/packages/server/src/config.test.ts
+++ b/packages/server/src/config.test.ts
@@ -49,6 +49,15 @@ describe("config", () => {
         expect(config.get("sockethub:host")).toEqual(hostname);
     });
 
+    it("bounds Socket.IO messages and accepts an environment override", () => {
+        const defaults = new Config();
+        expect(defaults.get("sockethub:maxPayloadBytes")).toBe(262144);
+
+        process.env.SOCKETHUB_MAX_PAYLOAD_BYTES = "131072";
+        const overridden = new Config();
+        expect(overridden.get("sockethub:maxPayloadBytes")).toBe(131072);
+    });
+
     it("defaults to redis config", () => {
         process.env.REDIS_URL = "";
         const config = new Config();

--- a/packages/server/src/config.test.ts
+++ b/packages/server/src/config.test.ts
@@ -58,6 +58,14 @@ describe("config", () => {
         expect(overridden.get("sockethub:maxPayloadBytes")).toBe(131072);
     });
 
+    it.each(["0", "1.5", "not-a-number"])(
+        "rejects invalid Socket.IO payload limit %s",
+        (value) => {
+            process.env.SOCKETHUB_MAX_PAYLOAD_BYTES = value;
+            expect(() => new Config()).toThrow();
+        },
+    );
+
     it("defaults to redis config", () => {
         process.env.REDIS_URL = "";
         const config = new Config();

--- a/packages/server/src/listener.ts
+++ b/packages/server/src/listener.ts
@@ -45,6 +45,9 @@ class Listener {
         this.http = new HTTP.Server(app);
         this.io = new Server(this.http, {
             path: config.get("sockethub:path") as string,
+            maxHttpBufferSize: config.get(
+                "sockethub:maxPayloadBytes",
+            ) as number,
             cors: {
                 origin: Listener.corsOrigin(),
                 methods: ["GET", "POST"],


### PR DESCRIPTION
## Summary

- cap individual Socket.IO messages at 256 KiB by default
- expose the cap through config and `SOCKETHUB_MAX_PAYLOAD_BYTES`
- document and test the new setting

## Root cause

Socket.IO used its 1 MiB default buffer limit, allowing relatively large ActivityStreams messages to reach validation and Redis-backed processing.

## Impact

Oversized messages are rejected at the transport boundary, reducing per-message memory and Redis pressure while retaining an operator override.

## Validation

- targeted server configuration tests (37 passed)
- `git diff --check`
- `bun run lint`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a configurable limit for incoming Socket.IO message sizes.
  * The default limit is 262,144 bytes (256 KiB).
  * The limit can be customized through configuration or the `SOCKETHUB_MAX_PAYLOAD_BYTES` environment variable.
* **Documentation**
  * Updated configuration examples and guidance for the new payload-size setting.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->