### PR TITLE
fix(server): enable resource caps by default

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -53,7 +53,11 @@ does not start).
   "rateLimiter": {
     "windowMs": 1000,
     "maxRequests": 100,
-    "blockDurationMs": 5000
+    "blockDurationMs": 5000,
+    "maxConnectionsPerIp": 20
+  },
+  "limits": {
+    "maxPlatformInstances": 100
   },
   "credentialCheck": {
     "reconnectIpSource": "socket",
@@ -189,12 +193,20 @@ Protect against event flooding from individual clients:
   "rateLimiter": {
     "windowMs": 1000,          // Time window in milliseconds
     "maxRequests": 100,        // Max events per window per client
-    "blockDurationMs": 5000    // Block duration after exceeding limit
+    "blockDurationMs": 5000,   // Block duration after exceeding limit
+    "maxConnectionsPerIp": 20  // Concurrent sockets per client IP
+  },
+  "limits": {
+    "maxPlatformInstances": 100 // Concurrent platform child processes
   }
 }
 ```
 
-**Default limits:** 100 events per second per client, 5 second block.
+**Default limits:** 100 events per second per client, a 5 second block, 20
+concurrent sockets per client IP, and 100 concurrent platform processes.
+
+Set either resource cap to `0` only when an external control provides the
+equivalent protection.
 
 The rate limiter operates per WebSocket connection and blocks clients that exceed the configured
 thresholds. Blocked clients are automatically unblocked after the `blockDurationMs` expires.

--- a/packages/schemas/src/schemas/sockethub-config.ts
+++ b/packages/schemas/src/schemas/sockethub-config.ts
@@ -202,7 +202,7 @@ export const SockethubConfigSchema = {
                 maxConnectionsPerIp: {
                     type: "number",
                     minimum: 0,
-                    default: 0,
+                    default: 20,
                     description:
                         "Maximum concurrent socket connections per client IP. " +
                         "The per-event rate limiter is keyed by socket id, so " +
@@ -218,7 +218,7 @@ export const SockethubConfigSchema = {
                 maxPlatformInstances: {
                     type: "number",
                     minimum: 0,
-                    default: 0,
+                    default: 100,
                     description:
                         "Upper bound on concurrently running platform instances " +
                         "(child processes). Each persistent-platform actor forks " +


### PR DESCRIPTION
## Summary

- limit each client IP to 20 concurrent Socket.IO connections by default
- limit the server to 100 concurrent platform child processes by default
- document how operators can override or disable the caps

## Root cause

Both resource controls existed but defaulted to disabled, allowing connection fan-out to bypass per-socket event limiting and permitting unbounded platform process creation.

## Impact

Default installations now retain bounded concurrency while operators with external controls can explicitly set either cap to zero.

## Validation

- targeted server tests (45 passed)
- `git diff --check`
- `bun run lint`