### PR TITLE
fix(examples): escape feed entry titles

### DIFF
--- a/packages/examples/src/components/logs/platforms/FeedsEntry.svelte
+++ b/packages/examples/src/components/logs/platforms/FeedsEntry.svelte
@@ -47,11 +47,7 @@ const actorName = $derived(
     {/if}
     <span>
         <a rel="noreferrer" href={entry.object?.url} target="_blank" class="text-blue-600 hover:text-blue-800 underline">
-            {#if entry.object?.contentType === "html"}
-                {@html entry.object?.title}
-            {:else}
-                {entry.object?.title || typeof entry.target === "string" ? entry.target : entry.target?.id}
-            {/if}
+            {entry.object?.title || typeof entry.target === "string" ? entry.target : entry.target?.id}
         </a>
     </span>
     {#if entry.object?.published}

--- a/packages/examples/src/components/logs/platforms/FeedsEntry.svelte
+++ b/packages/examples/src/components/logs/platforms/FeedsEntry.svelte
@@ -47,7 +47,8 @@ const actorName = $derived(
     {/if}
     <span>
         <a rel="noreferrer" href={entry.object?.url} target="_blank" class="text-blue-600 hover:text-blue-800 underline">
-            {entry.object?.title || typeof entry.target === "string" ? entry.target : entry.target?.id}
+            {entry.object?.title ||
+                (typeof entry.target === "string" ? entry.target : entry.target?.id)}
         </a>
     </span>
     {#if entry.object?.published}


### PR DESCRIPTION
## Summary

Render feed entry titles through normal Svelte text interpolation instead of `{@html}`.

## Root cause

The title used raw HTML whenever the entry content type was HTML, but that content type is derived from the feed description rather than from the title. An attacker-controlled feed could therefore supply active HTML in its title.

## Impact

Feed titles are always escaped and cannot execute markup in the examples application.

## Validation

- Svelte autofixer
- `git diff --check`
- `bun run lint`
- `bun run build`