### PR TITLE
fix(platform-irc): reject protocol line injection

### DIFF
--- a/packages/platform-irc/src/index.test.ts
+++ b/packages/platform-irc/src/index.test.ts
@@ -468,6 +468,27 @@ describe("Initialize IRC Platform", () => {
                 platform.completeJob();
             });
 
+            it("rejects IRC line injection before writing to the socket", async () => {
+                const rawCalls: Array<unknown> = [];
+                platform.client.raw = (...args) => rawCalls.push(args);
+
+                const err = await new Promise((resolve) => {
+                    platform.send(
+                        {
+                            "@context": IRC_CONTEXT,
+                            type: "send",
+                            actor,
+                            object: { content: "hello\nJOIN #other" },
+                            target: targetRoom,
+                        } as ActivityStream,
+                        resolve,
+                    );
+                });
+
+                expect(err).toContain("must not contain CR or LF");
+                expect(rawCalls).toHaveLength(0);
+            });
+
             // Regression coverage for the /me handling: /me must report
             // synchronous success without enqueueing a jobQueue handler.
             // See the long comment in src/index.ts for the protocol-level

--- a/packages/platform-irc/src/index.test.ts
+++ b/packages/platform-irc/src/index.test.ts
@@ -631,6 +631,27 @@ describe("Initialize IRC Platform", () => {
                     );
                 });
 
+                it("rejects CR injection in query targets before writing", (done) => {
+                    platform.query(
+                        {
+                            "@context": IRC_CONTEXT,
+                            type: "query",
+                            actor,
+                            target: {
+                                type: "room",
+                                id: "irc.example.com/#a-room",
+                                name: "#a-room\rPRIVMSG victim :injected",
+                            },
+                            object: { type: "attendance" },
+                        },
+                        (err) => {
+                            expect(err).toContain("must not contain CR or LF");
+                            expect(rawCalls).toEqual([]);
+                            done();
+                        },
+                    );
+                });
+
                 // Regression coverage for sockethub/sockethub#1085: a query
                 // with no resolvable channel must error rather than emit a
                 // bare `NAMES`, which the server answers with the entire
@@ -754,6 +775,24 @@ describe("ircConnect TLS certificate validation", () => {
         });
 
         expect(capturedIrcSocketOptions?.connectOptions).toBeUndefined();
+    });
+
+    it.each([
+        ["nick", { object: { nick: "nick\rOPER root" } }],
+        ["username", { object: { username: "user\rOPER root" } }],
+        ["realname", { actor: { name: "name\rOPER root" } }],
+    ])("rejects CR injection in connect-time %s", async (_field, override) => {
+        const credentials = {
+            ...validCredentials,
+            ...override,
+            actor: { ...validCredentials.actor, ...override.actor },
+            object: { ...validCredentials.object, ...override.object },
+        };
+
+        await expect(connect(credentials)).rejects.toThrow(
+            "must not contain CR or LF",
+        );
+        expect(capturedIrcSocketOptions).toBeUndefined();
     });
 });
 

--- a/packages/platform-irc/src/index.ts
+++ b/packages/platform-irc/src/index.ts
@@ -84,19 +84,14 @@ type JobQueueHandler = (err?: Error | string) => void | Promise<void>;
 
 const IRC_LINE_BREAK = /[\r\n]/;
 
-function rejectIrcLineBreaks(
-    values: Array<unknown>,
-    done: PlatformCallback,
-): boolean {
+function ircLineBreakError(values: Array<unknown>): string | undefined {
     if (
         values.some(
             (value) => typeof value === "string" && IRC_LINE_BREAK.test(value),
         )
     ) {
-        done("IRC values must not contain CR or LF characters");
-        return true;
+        return "IRC values must not contain CR or LF characters";
     }
-    return false;
 }
 
 interface IrcSocketOptionsCapabilities {
@@ -206,8 +201,11 @@ export class IRC implements PersistentPlatformInterface {
      */
     join(job: ActivityStream, done: PlatformCallback) {
         this.log.debug(`join() called for ${job.actor.id}`);
-        if (rejectIrcLineBreaks([job.actor.name, job.target.name], done))
-            return;
+        const lineBreakError = ircLineBreakError([
+            job.actor.name,
+            job.target.name,
+        ]);
+        if (lineBreakError) return done(lineBreakError);
         this.getClient(job.actor.id, false, (err, client) => {
             if (err) {
                 return done(err);
@@ -237,7 +235,8 @@ export class IRC implements PersistentPlatformInterface {
      */
     leave(job: ActivityStream, done: PlatformCallback) {
         this.log.debug(`leave() called for ${job.actor.name}`);
-        if (rejectIrcLineBreaks([job.target.name], done)) return;
+        const lineBreakError = ircLineBreakError([job.target.name]);
+        if (lineBreakError) return done(lineBreakError);
         this.getClient(job.actor.id, false, (err, client) => {
             if (err) {
                 return done(err);
@@ -261,13 +260,12 @@ export class IRC implements PersistentPlatformInterface {
         this.log.debug(
             `send() called for ${job.actor.id} target: ${job.target.id}`,
         );
-        if (
-            rejectIrcLineBreaks(
-                [job.actor.name, job.target.name, job.object?.content],
-                done,
-            )
-        )
-            return;
+        const lineBreakError = ircLineBreakError([
+            job.actor.name,
+            job.target.name,
+            job.object?.content,
+        ]);
+        if (lineBreakError) return done(lineBreakError);
         this.getClient(job.actor.id, false, async (err, client) => {
             if (err) {
                 return done(err);
@@ -353,13 +351,12 @@ export class IRC implements PersistentPlatformInterface {
         done: PlatformCallback,
     ) {
         this.log.debug(`update() called for ${job.actor.id}`);
-        if (
-            rejectIrcLineBreaks(
-                [job.actor.name, job.target.name, job.object?.content],
-                done,
-            )
-        )
-            return;
+        const lineBreakError = ircLineBreakError([
+            job.actor.name,
+            job.target.name,
+            job.object?.content,
+        ]);
+        if (lineBreakError) return done(lineBreakError);
         this.getClient(job.actor.id, false, (err, client) => {
             if (err) {
                 return done(err);
@@ -404,6 +401,11 @@ export class IRC implements PersistentPlatformInterface {
      */
     query(job: ActivityStream, done: PlatformCallback) {
         this.log.debug(`query() called for ${job.actor.id}`);
+        const lineBreakError = ircLineBreakError([
+            job.target?.name,
+            job.target?.id,
+        ]);
+        if (lineBreakError) return done(lineBreakError);
         this.getClient(job.actor.id, false, (err, client) => {
             if (err) {
                 return done(err);
@@ -554,6 +556,13 @@ export class IRC implements PersistentPlatformInterface {
         credentials: PlatformIrcCredentialsObject,
         cb: GetClientCallback,
     ) {
+        const lineBreakError = ircLineBreakError([
+            credentials.object.nick,
+            credentials.object.username,
+            credentials.actor.name,
+        ]);
+        if (lineBreakError) return cb(lineBreakError);
+
         this.clientConnecting = true;
         const is_secure =
             typeof credentials.object.secure === "boolean"

--- a/packages/platform-irc/src/index.ts
+++ b/packages/platform-irc/src/index.ts
@@ -82,6 +82,23 @@ export type GetClientCallback = (
 
 type JobQueueHandler = (err?: Error | string) => void | Promise<void>;
 
+const IRC_LINE_BREAK = /[\r\n]/;
+
+function rejectIrcLineBreaks(
+    values: Array<unknown>,
+    done: PlatformCallback,
+): boolean {
+    if (
+        values.some(
+            (value) => typeof value === "string" && IRC_LINE_BREAK.test(value),
+        )
+    ) {
+        done("IRC values must not contain CR or LF characters");
+        return true;
+    }
+    return false;
+}
+
 interface IrcSocketOptionsCapabilities {
     requires: string[];
 }
@@ -189,6 +206,8 @@ export class IRC implements PersistentPlatformInterface {
      */
     join(job: ActivityStream, done: PlatformCallback) {
         this.log.debug(`join() called for ${job.actor.id}`);
+        if (rejectIrcLineBreaks([job.actor.name, job.target.name], done))
+            return;
         this.getClient(job.actor.id, false, (err, client) => {
             if (err) {
                 return done(err);
@@ -218,6 +237,7 @@ export class IRC implements PersistentPlatformInterface {
      */
     leave(job: ActivityStream, done: PlatformCallback) {
         this.log.debug(`leave() called for ${job.actor.name}`);
+        if (rejectIrcLineBreaks([job.target.name], done)) return;
         this.getClient(job.actor.id, false, (err, client) => {
             if (err) {
                 return done(err);
@@ -241,6 +261,13 @@ export class IRC implements PersistentPlatformInterface {
         this.log.debug(
             `send() called for ${job.actor.id} target: ${job.target.id}`,
         );
+        if (
+            rejectIrcLineBreaks(
+                [job.actor.name, job.target.name, job.object?.content],
+                done,
+            )
+        )
+            return;
         this.getClient(job.actor.id, false, async (err, client) => {
             if (err) {
                 return done(err);
@@ -326,6 +353,13 @@ export class IRC implements PersistentPlatformInterface {
         done: PlatformCallback,
     ) {
         this.log.debug(`update() called for ${job.actor.id}`);
+        if (
+            rejectIrcLineBreaks(
+                [job.actor.name, job.target.name, job.object?.content],
+                done,
+            )
+        )
+            return;
         this.getClient(job.actor.id, false, (err, client) => {
             if (err) {
                 return done(err);


### PR DESCRIPTION
## Summary

- reject CR and LF in values that flow into IRC commands
- cover actor names, targets, messages, topics, and nick changes
- add regression coverage proving malicious content is rejected before socket writes

## Root cause

User-controlled ActivityStreams values reached IRC raw command construction without rejecting protocol line delimiters. A newline could create additional IRC commands in the authenticated session.

## Impact

A Sockethub client can no longer inject additional IRC protocol lines through message or addressing fields.

## Validation

- platform IRC tests (37 passed)
- `git diff --check`
- `bun run lint`
- `bun run build`