### PR TITLE
docs: explain platform instance limit sizing

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -225,8 +225,7 @@ platforms.
 
 Setting `maxPlatformInstances` to `0` removes the server-wide platform process
 limit entirely. Setting `maxConnectionsPerIp` to `0` likewise removes the
-per-IP connection limit. Disable either cap only when an external control
-provides equivalent protection.
+per-IP connection limit.
 
 The rate limiter operates per WebSocket connection and blocks clients that exceed the configured
 thresholds. Blocked clients are automatically unblocked after the `blockDurationMs` expires.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -223,8 +223,10 @@ additional process for each identity. Increase the default for deployments that
 expect more than 100 concurrent persistent actors, allowing for active stateless
 platforms.
 
-Set either resource cap to `0` only when an external control provides the
-equivalent protection.
+Setting `maxPlatformInstances` to `0` removes the server-wide platform process
+limit entirely. Setting `maxConnectionsPerIp` to `0` likewise removes the
+per-IP connection limit. Disable either cap only when an external control
+provides equivalent protection.
 
 The rate limiter operates per WebSocket connection and blocks clients that exceed the configured
 thresholds. Blocked clients are automatically unblocked after the `blockDurationMs` expires.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -214,10 +214,10 @@ concurrent sockets per client IP, and 100 concurrent platform processes.
 `maxPlatformInstances` is a server-wide limit, not a per-user limit. Persistent
 platforms such as IRC and XMPP use one process for each unique actor, while
 sessions for the same actor reuse that process. Stateless platforms such as
-CalDAV, CardDAV, dummy, feeds, and metadata use one shared process per platform.
+CalDAV, CardDAV, feeds, and metadata use one shared process per platform.
 
-As a sizing example, 20 users each connected to IRC and XMPP, with all five
-stateless platforms active, use approximately `20 * 2 + 5 = 45` platform
+As a sizing example, 20 users each connected to IRC and XMPP, with all four
+stateless platforms active, use approximately `20 * 2 + 4 = 44` platform
 processes. Users with multiple identities on a persistent platform use an
 additional process for each identity. Increase the default for deployments that
 expect more than 100 concurrent persistent actors, allowing for active stateless

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -211,6 +211,18 @@ Protect against event flooding from individual clients:
 **Default limits:** 100 events per second per client, a 5 second block, 20
 concurrent sockets per client IP, and 100 concurrent platform processes.
 
+`maxPlatformInstances` is a server-wide limit, not a per-user limit. Persistent
+platforms such as IRC and XMPP use one process for each unique actor, while
+sessions for the same actor reuse that process. Stateless platforms such as
+CalDAV, CardDAV, dummy, feeds, and metadata use one shared process per platform.
+
+As a sizing example, 20 users each connected to IRC and XMPP, with all five
+stateless platforms active, use approximately `20 * 2 + 5 = 45` platform
+processes. Users with multiple identities on a persistent platform use an
+additional process for each identity. Increase the default for deployments that
+expect more than 100 concurrent persistent actors, allowing for active stateless
+platforms.
+
 Set either resource cap to `0` only when an external control provides the
 equivalent protection.
 


### PR DESCRIPTION
## Summary

- clarify that maxPlatformInstances is a server-wide cap
- explain process reuse for persistent and stateless platforms
- add a concrete 20-user sizing example and tuning guidance




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Expanded rate-limiting guidance, including server-wide instance limits and persistent versus stateless platform usage.
  * Added a sizing example for configuring limits.
  * Documented that setting limits to `0` disables the corresponding rate limit.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->