### PR TITLE
fix: run development image as non-root

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,4 +25,5 @@ ENV LOG_LEVEL=${LOG_LEVEL}
 WORKDIR /app
 COPY --from=build /app ./
 RUN echo "Running sockethub (prod) on node: LOG_LEVEL=${LOG_LEVEL}"
+USER node
 CMD ["node", "/app/packages/sockethub/bin/sockethub", "--host", "0.0.0.0"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -23,7 +23,8 @@ FROM node:22-slim AS prod
 ARG LOG_LEVEL=info
 ENV LOG_LEVEL=${LOG_LEVEL}
 WORKDIR /app
-COPY --from=build /app ./
+COPY --chown=node:node --from=build /app ./
 RUN echo "Running sockethub (prod) on node: LOG_LEVEL=${LOG_LEVEL}"
+RUN chown node:node /app
 USER node
 CMD ["node", "/app/packages/sockethub/bin/sockethub", "--host", "0.0.0.0"]


### PR DESCRIPTION
## Summary

- run the main Dockerfile production stage as the existing node user
- align the development and CI image posture with the release image

## Root cause

The main Dockerfile did not set a runtime user, so its final stage inherited root.

## Impact

Processes started from the development and CI image no longer run as UID 0 by default.

## Validation

- git diff --check
- bun run lint