### PR TITLE
fix: bind development Redis to localhost

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -21,7 +21,7 @@ services:
     redis:
         image: redis
         ports:
-            - "6379:6379"
+            - "127.0.0.1:6379:6379"
         networks:
             - sockethub-net
     prosody:


### PR DESCRIPTION
## Summary

- publish the development Redis port on 127.0.0.1 only
- retain host access for local integration workflows

## Root cause

The development and CI Compose harness published unauthenticated Redis on every host interface.

## Impact

Redis remains reachable from the local host and the Compose network, but is no longer exposed to other machines through the host port by default.

## Validation

- docker compose config --quiet
- git diff --check
- bun run lint

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security**
  * Restricted Redis access to the local machine by binding its service port to loopback only.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->