### PR TITLE
chore: remove committed Sentry configuration

### DIFF
--- a/packages/sockethub/sockethub.config.json.sentry
+++ b/packages/sockethub/sockethub.config.json.sentry
@@ -1,7 +1,0 @@
-{
-  "$schema": "https://sockethub.org/schemas/3.0.0-alpha.4/sockethub-config.json",
-  "sentry": {
-    "dsn": "https://ffc702eb2f3b24d9e06ca20e1ef1fd09@o4508859714895872.ingest.de.sentry.io/4508859718369360",
-    "environment": "production"
-  }
-}


### PR DESCRIPTION
## Summary

- remove the tracked deployment-specific Sentry configuration
- rely on the existing gitignore rule to prevent local Sentry configuration from being recommitted

## Why

The file contained a live-looking project DSN in the public repository. Sentry DSNs are client identifiers rather than authentication secrets, but removing deployment-specific configuration reduces event-submission abuse and operational confusion.

## Impact

Deployments that used this repository file must provide Sentry configuration through their local ignored config or SENTRY_DSN environment variable. The DSN should also be rotated in Sentry if it remains active.

## Validation

- git diff --check
- bun run lint

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed the Sentry configuration for the Sockethub package.
  * Production error-reporting settings are no longer included in the package configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->