### PR TITLE
feat(examples): add CardDAV example page

### DIFF
--- a/packages/examples/src/components/Nav.svelte
+++ b/packages/examples/src/components/Nav.svelte
@@ -8,6 +8,7 @@ const navItems = [
     ["📰", "Feeds", "/feeds", "RSS/ATOM feed parsing"],
     ["🔍", "Metadata", "/metadata", "Web page metadata extraction"],
     ["📅", "CalDAV", "/caldav", "Calendars and tasks"],
+    ["👤", "CardDAV", "/carddav", "Address books and contacts"],
     ["💬", "IRC", "/irc", "Internet Relay Chat • Advanced"],
     ["📨", "XMPP", "/xmpp", "Extensible messaging • Advanced"],
 ];

--- a/packages/examples/src/routes/+page.svelte
+++ b/packages/examples/src/routes/+page.svelte
@@ -80,6 +80,16 @@ import Intro from "../components/Intro.svelte";
                     </a>
                 </div>
                 <div class="grid md:grid-cols-2 gap-3">
+                    <a href="{base}/caldav" class="block p-3 bg-white rounded border hover:bg-purple-50 transition-colors">
+                        <div class="font-semibold text-purple-800">📅 CalDAV Calendars</div>
+                        <div class="text-purple-600">Discover calendars and create events or tasks</div>
+                    </a>
+                    <a href="{base}/carddav" class="block p-3 bg-white rounded border hover:bg-purple-50 transition-colors">
+                        <div class="font-semibold text-purple-800">👤 CardDAV Contacts</div>
+                        <div class="text-purple-600">Discover address books and find contacts</div>
+                    </a>
+                </div>
+                <div class="grid md:grid-cols-2 gap-3">
                     <a href="{base}/irc" class="block p-3 bg-white rounded border hover:bg-purple-50 transition-colors border-l-4 border-l-orange-400">
                         <div class="flex items-center justify-between">
                             <div>

--- a/packages/examples/src/routes/carddav/+page.svelte
+++ b/packages/examples/src/routes/carddav/+page.svelte
@@ -1,0 +1,270 @@
+<script lang="ts">
+import BaseExample from "$components/BaseExample.svelte";
+import FormField from "$components/FormField.svelte";
+import SockethubButton from "$components/SockethubButton.svelte";
+import { contextFor, ensureClientReady, sc, send } from "$lib/sockethub";
+import type { AnyActivityStream, SockethubResponse } from "$lib/sockethub";
+
+type AddressBook = {
+    id: string;
+    type: "addressBook";
+    name: string;
+    description?: string;
+};
+
+type Contact = {
+    id: string;
+    type: "person";
+    name: string;
+    emails?: { value: string }[];
+    telephones?: { value: string }[];
+    organization?: string;
+};
+
+let actorId = $state("carddav:alice");
+let serviceUrl = $state("");
+let username = $state("");
+let password = $state("");
+let credentialsSet = $state(false);
+let addressBooks = $state<AddressBook[]>([]);
+let selectedAddressBookId = $state("");
+let contactName = $state("");
+let contacts = $state<Contact[]>([]);
+let busy = $state(false);
+let error = $state<string | null>(null);
+let success = $state<string | null>(null);
+let credentialError = $state<string | null>(null);
+let credentialSuccess = $state<string | null>(null);
+
+const selectedAddressBook = $derived(
+    addressBooks.find(
+        (addressBook) => addressBook.id === selectedAddressBookId,
+    ),
+);
+
+function actor() {
+    return { id: actorId, type: "person" };
+}
+
+function invalidateCredentials(): void {
+    if (!credentialsSet) return;
+    credentialsSet = false;
+    addressBooks = [];
+    selectedAddressBookId = "";
+    contacts = [];
+    credentialError = null;
+    credentialSuccess = null;
+}
+
+async function setCredentials(): Promise<void> {
+    credentialError = null;
+    credentialSuccess = null;
+    busy = true;
+    try {
+        await ensureClientReady();
+        const credentials = {
+            "@context": await contextFor("carddav"),
+            type: "credentials",
+            actor: actor(),
+            object: {
+                type: "credentials",
+                url: serviceUrl,
+                username,
+                password,
+            },
+        };
+        await new Promise<void>((resolve, reject) => {
+            sc.socket.emit(
+                "credentials",
+                credentials,
+                (response: SockethubResponse) => {
+                    if (response?.error) {
+                        reject(new Error(response.error));
+                        return;
+                    }
+                    resolve();
+                },
+            );
+        });
+        credentialsSet = true;
+        credentialSuccess = "Credentials set for this Sockethub session.";
+    } catch (err) {
+        credentialError = err instanceof Error ? err.message : String(err);
+    } finally {
+        busy = false;
+    }
+}
+
+async function fetchAddressBooks(): Promise<void> {
+    error = null;
+    success = null;
+    contacts = [];
+    busy = true;
+    try {
+        const response = await send({
+            "@context": await contextFor("carddav"),
+            type: "fetch",
+            actor: actor(),
+        } as AnyActivityStream);
+        addressBooks = (response.items ?? []).filter(
+            (item): item is AnyActivityStream & AddressBook =>
+                item.type === "addressBook" &&
+                typeof item.id === "string" &&
+                typeof (item as unknown as AddressBook).name === "string",
+        ) as AddressBook[];
+        selectedAddressBookId = addressBooks[0]?.id ?? "";
+        success = `Found ${addressBooks.length} address book${addressBooks.length === 1 ? "" : "s"}.`;
+    } catch (err) {
+        error = err instanceof Error ? err.message : String(err);
+    } finally {
+        busy = false;
+    }
+}
+
+async function queryContacts(): Promise<void> {
+    if (!selectedAddressBook) return;
+    error = null;
+    success = null;
+    contacts = [];
+    busy = true;
+    try {
+        const response = await send({
+            "@context": await contextFor("carddav"),
+            type: "query",
+            actor: actor(),
+            target: { id: selectedAddressBook.id, type: "addressBook" },
+            object: {
+                type: "contactQuery",
+                text: contactName,
+                fields: ["name"],
+                limit: 50,
+            },
+        } as unknown as AnyActivityStream);
+        contacts = (response.items ?? []).filter(
+            (item): item is AnyActivityStream & Contact =>
+                item.type === "person" &&
+                typeof item.id === "string" &&
+                typeof (item as unknown as Contact).name === "string",
+        ) as Contact[];
+        success = `Found ${contacts.length} contact${contacts.length === 1 ? "" : "s"}.`;
+    } catch (err) {
+        error = err instanceof Error ? err.message : String(err);
+    } finally {
+        busy = false;
+    }
+}
+</script>
+
+<BaseExample
+    title="CardDAV Platform Example"
+    description="Discover the address books in a CardDAV account, then find contacts by name."
+>
+    <section class="space-y-4">
+        <h2 class="text-xl font-semibold text-gray-900">1. Set credentials</h2>
+        <p class="text-sm text-gray-600">
+            Use an app password when your contacts provider supports one. Credentials stay in this Sockethub session.
+        </p>
+        <FormField
+            label="Actor ID"
+            id="carddav-actor"
+            bind:value={actorId}
+            placeholder="carddav:alice"
+            onInput={invalidateCredentials}
+        />
+        <FormField
+            label="CardDAV URL"
+            id="carddav-url"
+            type="url"
+            bind:value={serviceUrl}
+            placeholder="https://contacts.example/dav/"
+            onInput={invalidateCredentials}
+        />
+        <FormField label="Username" id="carddav-username" bind:value={username} onInput={invalidateCredentials} />
+        <FormField
+            label="Password"
+            id="carddav-password"
+            type="password"
+            bind:value={password}
+            onInput={invalidateCredentials}
+        />
+        <div class="flex justify-end">
+            <SockethubButton
+                buttonAction={setCredentials}
+                disabled={credentialsSet || busy || !actorId || !serviceUrl || !username || !password}
+            >
+                {credentialsSet ? "Credentials Set" : busy ? "Setting Credentials…" : "Set Credentials"}
+            </SockethubButton>
+        </div>
+        {#if credentialError}
+            <div class="rounded-lg border border-red-200 bg-red-50 p-4 text-sm text-red-800" role="alert">
+                {credentialError}
+            </div>
+        {/if}
+        {#if credentialSuccess}
+            <div class="rounded-lg border border-green-200 bg-green-50 p-4 text-sm text-green-800" role="status">
+                {credentialSuccess}
+            </div>
+        {/if}
+    </section>
+
+    <section class="space-y-4 border-t border-gray-200 pt-6">
+        <h2 class="text-xl font-semibold text-gray-900">2. Choose an address book</h2>
+        <div class="flex justify-end">
+            <SockethubButton buttonAction={fetchAddressBooks} disabled={busy || !credentialsSet}>
+                Fetch Address Books
+            </SockethubButton>
+        </div>
+        {#if addressBooks.length > 0}
+            <label for="carddav-address-book" class="block text-sm font-semibold text-gray-700">Address book</label>
+            <select
+                id="carddav-address-book"
+                bind:value={selectedAddressBookId}
+                class="w-full rounded-lg border border-gray-300 bg-white px-4 py-3"
+            >
+                {#each addressBooks as addressBook (addressBook.id)}
+                    <option value={addressBook.id}>{addressBook.name}</option>
+                {/each}
+            </select>
+            {#if selectedAddressBook?.description}
+                <p class="text-sm text-gray-600">{selectedAddressBook.description}</p>
+            {/if}
+        {/if}
+    </section>
+
+    <section class="space-y-4 border-t border-gray-200 pt-6">
+        <h2 class="text-xl font-semibold text-gray-900">3. Find contacts</h2>
+        <FormField label="Contact name" id="carddav-contact-name" bind:value={contactName} placeholder="Bob" />
+        <div class="flex justify-end">
+            <SockethubButton buttonAction={queryContacts} disabled={busy || !selectedAddressBook || !contactName.trim()}>
+                Search Contacts
+            </SockethubButton>
+        </div>
+        {#if contacts.length > 0}
+            <ul class="divide-y divide-gray-200 rounded-lg border border-gray-200">
+                {#each contacts as contact (contact.id)}
+                    <li class="space-y-1 p-4">
+                        <h3 class="font-semibold text-gray-900">{contact.name}</h3>
+                        {#if contact.organization}
+                            <p class="text-sm text-gray-600">{contact.organization}</p>
+                        {/if}
+                        {#if contact.emails?.length}
+                            <p class="text-sm text-gray-600">{contact.emails.map((email) => email.value).join(", ")}</p>
+                        {/if}
+                        {#if contact.telephones?.length}
+                            <p class="text-sm text-gray-600">
+                                {contact.telephones.map((telephone) => telephone.value).join(", ")}
+                            </p>
+                        {/if}
+                    </li>
+                {/each}
+            </ul>
+        {/if}
+    </section>
+
+    {#if error}
+        <div class="rounded-lg border border-red-200 bg-red-50 p-4 text-sm text-red-800" role="alert">{error}</div>
+    {/if}
+    {#if success}
+        <div class="rounded-lg border border-green-200 bg-green-50 p-4 text-sm text-green-800" role="status">{success}</div>
+    {/if}
+</BaseExample>

--- a/packages/examples/src/routes/carddav/+page.svelte
+++ b/packages/examples/src/routes/carddav/+page.svelte
@@ -3,7 +3,7 @@ import BaseExample from "$components/BaseExample.svelte";
 import FormField from "$components/FormField.svelte";
 import SockethubButton from "$components/SockethubButton.svelte";
 import { contextFor, ensureClientReady, sc, send } from "$lib/sockethub";
-import type { AnyActivityStream, SockethubResponse } from "$lib/sockethub";
+import type { AnyActivityStream } from "$lib/sockethub";
 
 type AddressBook = {
     id: string;
@@ -35,6 +35,8 @@ let error = $state<string | null>(null);
 let success = $state<string | null>(null);
 let credentialError = $state<string | null>(null);
 let credentialSuccess = $state<string | null>(null);
+let credentialRevision = 0;
+let contactRequestRevision = 0;
 
 const selectedAddressBook = $derived(
     addressBooks.find(
@@ -47,7 +49,8 @@ function actor() {
 }
 
 function invalidateCredentials(): void {
-    if (!credentialsSet) return;
+    credentialRevision += 1;
+    contactRequestRevision += 1;
     credentialsSet = false;
     addressBooks = [];
     selectedAddressBookId = "";
@@ -56,7 +59,15 @@ function invalidateCredentials(): void {
     credentialSuccess = null;
 }
 
+function selectAddressBook(): void {
+    contactRequestRevision += 1;
+    contacts = [];
+    error = null;
+    success = null;
+}
+
 async function setCredentials(): Promise<void> {
+    const revision = credentialRevision;
     credentialError = null;
     credentialSuccess = null;
     busy = true;
@@ -77,7 +88,7 @@ async function setCredentials(): Promise<void> {
             sc.socket.emit(
                 "credentials",
                 credentials,
-                (response: SockethubResponse) => {
+                (response?: { error?: string }) => {
                     if (response?.error) {
                         reject(new Error(response.error));
                         return;
@@ -86,16 +97,22 @@ async function setCredentials(): Promise<void> {
                 },
             );
         });
-        credentialsSet = true;
-        credentialSuccess = "Credentials set for this Sockethub session.";
+        if (revision === credentialRevision) {
+            credentialsSet = true;
+            credentialSuccess = "Credentials set for this Sockethub session.";
+        }
     } catch (err) {
-        credentialError = err instanceof Error ? err.message : String(err);
+        if (revision === credentialRevision) {
+            credentialError = err instanceof Error ? err.message : String(err);
+        }
     } finally {
         busy = false;
     }
 }
 
 async function fetchAddressBooks(): Promise<void> {
+    if (!credentialsSet) return;
+    const revision = credentialRevision;
     error = null;
     success = null;
     contacts = [];
@@ -106,6 +123,7 @@ async function fetchAddressBooks(): Promise<void> {
             type: "fetch",
             actor: actor(),
         } as AnyActivityStream);
+        if (revision !== credentialRevision || !credentialsSet) return;
         addressBooks = (response.items ?? []).filter(
             (item): item is AnyActivityStream & AddressBook =>
                 item.type === "addressBook" &&
@@ -115,14 +133,19 @@ async function fetchAddressBooks(): Promise<void> {
         selectedAddressBookId = addressBooks[0]?.id ?? "";
         success = `Found ${addressBooks.length} address book${addressBooks.length === 1 ? "" : "s"}.`;
     } catch (err) {
-        error = err instanceof Error ? err.message : String(err);
+        if (revision === credentialRevision) {
+            error = err instanceof Error ? err.message : String(err);
+        }
     } finally {
         busy = false;
     }
 }
 
 async function queryContacts(): Promise<void> {
-    if (!selectedAddressBook) return;
+    if (!credentialsSet || !selectedAddressBook) return;
+    const revision = credentialRevision;
+    const requestRevision = ++contactRequestRevision;
+    const addressBookId = selectedAddressBook.id;
     error = null;
     success = null;
     contacts = [];
@@ -132,7 +155,7 @@ async function queryContacts(): Promise<void> {
             "@context": await contextFor("carddav"),
             type: "query",
             actor: actor(),
-            target: { id: selectedAddressBook.id, type: "addressBook" },
+            target: { id: addressBookId, type: "addressBook" },
             object: {
                 type: "contactQuery",
                 text: contactName,
@@ -140,6 +163,13 @@ async function queryContacts(): Promise<void> {
                 limit: 50,
             },
         } as unknown as AnyActivityStream);
+        if (
+            revision !== credentialRevision ||
+            requestRevision !== contactRequestRevision ||
+            selectedAddressBookId !== addressBookId ||
+            !credentialsSet
+        )
+            return;
         contacts = (response.items ?? []).filter(
             (item): item is AnyActivityStream & Contact =>
                 item.type === "person" &&
@@ -148,7 +178,12 @@ async function queryContacts(): Promise<void> {
         ) as Contact[];
         success = `Found ${contacts.length} contact${contacts.length === 1 ? "" : "s"}.`;
     } catch (err) {
-        error = err instanceof Error ? err.message : String(err);
+        if (
+            revision === credentialRevision &&
+            requestRevision === contactRequestRevision
+        ) {
+            error = err instanceof Error ? err.message : String(err);
+        }
     } finally {
         busy = false;
     }
@@ -219,6 +254,7 @@ async function queryContacts(): Promise<void> {
             <select
                 id="carddav-address-book"
                 bind:value={selectedAddressBookId}
+                onchange={selectAddressBook}
                 class="w-full rounded-lg border border-gray-300 bg-white px-4 py-3"
             >
                 {#each addressBooks as addressBook (addressBook.id)}
@@ -235,7 +271,10 @@ async function queryContacts(): Promise<void> {
         <h2 class="text-xl font-semibold text-gray-900">3. Find contacts</h2>
         <FormField label="Contact name" id="carddav-contact-name" bind:value={contactName} placeholder="Bob" />
         <div class="flex justify-end">
-            <SockethubButton buttonAction={queryContacts} disabled={busy || !selectedAddressBook || !contactName.trim()}>
+            <SockethubButton
+                buttonAction={queryContacts}
+                disabled={busy || !credentialsSet || !selectedAddressBook || !contactName.trim()}
+            >
                 Search Contacts
             </SockethubButton>
         </div>

--- a/packages/examples/tests/smoke.spec.ts
+++ b/packages/examples/tests/smoke.spec.ts
@@ -78,4 +78,34 @@ test.describe("examples smoke against sockethub --examples", () => {
             page.getByRole("button", { name: "Set Credentials" }),
         ).toBeEnabled();
     });
+
+    test("carddav page exposes the address-book query flow", async ({
+        page,
+    }) => {
+        await page.goto("/carddav");
+        await expect(
+            page.getByRole("heading", { name: "CardDAV Platform Example" }),
+        ).toBeVisible();
+        await expect(
+            page.getByRole("button", { name: "Fetch Address Books" }),
+        ).toBeDisabled();
+        await expect(
+            page.getByRole("button", { name: "Search Contacts" }),
+        ).toBeDisabled();
+
+        await page
+            .getByLabel("CardDAV URL")
+            .fill("https://contacts.example/dav/");
+        await page.getByLabel("Username").fill("alice");
+        await page.getByLabel("Password").fill("app-password");
+        await page.getByRole("button", { name: "Set Credentials" }).click();
+        await expect(
+            page.getByRole("button", { name: "Credentials Set" }),
+        ).toBeDisabled();
+
+        await page.getByLabel("Username").fill("alice-changed");
+        await expect(
+            page.getByRole("button", { name: "Set Credentials" }),
+        ).toBeEnabled();
+    });
 });


### PR DESCRIPTION
## Summary

- add a CardDAV example page for setting session credentials
- discover and select an address book
- query contacts by name and display basic contact details
- expose CardDAV in the examples navigation and home page
- add browser smoke coverage for the new flow

Closes #1205

## Validation

- `bun run lint`
- `bun run build`
- `bun run check` in `packages/examples`
- `bun run test:unit` in `packages/examples`

The Playwright smoke suite was attempted, but its tests could not start because the required Playwright Chromium binary is not installed in the local environment.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a CardDAV example for discovering address books and searching contacts by name.
  - Added navigation and examples-page links for CalDAV and CardDAV functionality.
  - Added clear credential, loading, success, and error states with address-book and contact details.

- **Tests**
  - Added smoke coverage for CardDAV controls, credential submission, and updating credentials.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->