### PR TITLE
fix(server): verify credentials match before attaching to a shared platform instance

### DIFF
--- a/packages/data-layer/integration/redis.integration.ts
+++ b/packages/data-layer/integration/redis.integration.ts
@@ -39,7 +39,9 @@ const creds: CredentialsObject = {
         password: "secret",
     },
 };
-const credsHash = "267a747d006c9a2c2e94b2f7d646400ba16e5709";
+// SHA-256 of `creds.object` (see Crypto.objectHash).
+const credsHash =
+    "8ab6f374809a069edf089497d3d091c467699fac4f6330dd056f662887995891";
 const testSecret = "aB3#xK9mP2qR7wZ4cT8nY6vH1jL5fD0s";
 
 describe("CredentialsStore", () => {

--- a/packages/data-layer/src/credentials-store.test.ts
+++ b/packages/data-layer/src/credentials-store.test.ts
@@ -209,6 +209,67 @@ describe("CredentialsStore", () => {
             });
         });
 
+        // Regression: a session attaching to an existing persistent instance
+        // must prove it holds the *same* credentials that opened it. Before
+        // this, any non-empty password was accepted, so knowing an actor id
+        // was enough to join someone else's live connection.
+        describe("session-share attach against an incumbent hash", () => {
+            const INCUMBENT_HASH = "hash-of-the-connected-credentials";
+
+            it("rejects an attach with no password at all", async () => {
+                MockObjectHash.returns(INCUMBENT_HASH);
+                MockStoreGet.returns({
+                    object: { type: "credentials", nick: "victim" },
+                });
+                try {
+                    await credentialsStore.get("an actor", INCUMBENT_HASH, {
+                        validateSessionShare: true,
+                    });
+                    expect(false).toEqual(true);
+                } catch (err) {
+                    // Reported as "not shareable" rather than "mismatch" so the
+                    // same-IP anonymous reconnect path stays reachable.
+                    expect(err).toBeInstanceOf(CredentialsNotShareableError);
+                    expect(err.toString()).toEqual(
+                        "Error: username already in use",
+                    );
+                }
+            });
+
+            it("rejects an attach with a wrong password", async () => {
+                MockObjectHash.returns("hash-of-the-attackers-credentials");
+                MockStoreGet.returns({
+                    object: { type: "credentials", password: "totally-wrong" },
+                });
+                try {
+                    await credentialsStore.get("an actor", INCUMBENT_HASH, {
+                        validateSessionShare: true,
+                    });
+                    expect(false).toEqual(true);
+                } catch (err) {
+                    expect(err).toBeInstanceOf(CredentialsMismatchError);
+                    expect(err.toString()).toEqual(
+                        "Error: invalid credentials for an actor",
+                    );
+                }
+            });
+
+            it("allows an attach with the correct password", async () => {
+                MockObjectHash.returns(INCUMBENT_HASH);
+                MockStoreGet.returns({
+                    object: { type: "credentials", password: "correct-horse" },
+                });
+                const res = await credentialsStore.get(
+                    "an actor",
+                    INCUMBENT_HASH,
+                    { validateSessionShare: true },
+                );
+                expect(res).toEqual({
+                    object: { type: "credentials", password: "correct-horse" },
+                });
+            });
+        });
+
         it("rejects credentials without password or token for session-share validation", async () => {
             MockStoreGet.returns({
                 object: { type: "credentials" },

--- a/packages/data-layer/src/credentials-store.ts
+++ b/packages/data-layer/src/credentials-store.ts
@@ -290,16 +290,10 @@ export class CredentialsStore implements CredentialsStoreInterface {
             );
         }
 
-        if (credentialsHash) {
-            // If a hash is provided, credentials must match exactly. This blocks
-            // "same actor, different credentials" reuse attempts.
-            if (credentialsHash !== this.objectHash(credentials.object)) {
-                throw new CredentialsMismatchError(
-                    `invalid credentials for ${actor}`,
-                );
-            }
-        }
-
+        // Ordered before the hash comparison so a passwordless attach always
+        // reports "not shareable" rather than "mismatch", whatever the
+        // incumbent's credentials were. Callers distinguish the two: only the
+        // not-shareable case is eligible for same-IP anonymous reconnect.
         if (options.validateSessionShare) {
             const password = credentials.object.password;
             const token = credentials.object.token;
@@ -312,6 +306,16 @@ export class CredentialsStore implements CredentialsStoreInterface {
             if (!hasPassword && !hasToken) {
                 throw new CredentialsNotShareableError(
                     "username already in use",
+                );
+            }
+        }
+
+        if (credentialsHash) {
+            // If a hash is provided, credentials must match exactly. This blocks
+            // "same actor, different credentials" reuse attempts.
+            if (credentialsHash !== this.objectHash(credentials.object)) {
+                throw new CredentialsMismatchError(
+                    `invalid credentials for ${actor}`,
                 );
             }
         }

--- a/packages/server/src/middleware/credential-check.test.ts
+++ b/packages/server/src/middleware/credential-check.test.ts
@@ -1,4 +1,12 @@
-import { afterEach, beforeAll, beforeEach, describe, expect, test } from "bun:test";
+import {
+    afterEach,
+    beforeAll,
+    beforeEach,
+    describe,
+    expect,
+    it,
+    test,
+} from "bun:test";
 import {
     CredentialsMismatchError,
     CredentialsNotShareableError,
@@ -122,7 +130,7 @@ describe("Middleware: credentialCheck", () => {
     // Regression: the incumbent's credentials hash must reach the data layer,
     // otherwise the exact-match comparison is skipped and any non-empty
     // password attaches to another client's live connection.
-    test("passes the incumbent's credentialsHash to the store", async () => {
+    it("passes the incumbent's credentialsHash to the store", async () => {
         let seenHash: string | undefined | symbol = Symbol("unset");
         store.get = async (
             _actor: string,
@@ -147,7 +155,7 @@ describe("Middleware: credentialCheck", () => {
         expect(seenHash).toEqual("incumbent-hash");
     });
 
-    test("blocks an attach whose credentials do not match the incumbent", async () => {
+    it("blocks an attach whose credentials do not match the incumbent", async () => {
         store.get = async () =>
             Promise.reject(
                 new CredentialsMismatchError(
@@ -168,7 +176,7 @@ describe("Middleware: credentialCheck", () => {
         expect(result instanceof Error).toEqual(true);
     });
 
-    test("a credentials mismatch is not eligible for same-IP reconnect", async () => {
+    it("a credentials mismatch is not eligible for same-IP reconnect", async () => {
         // Same IP and a stale prior session — the escape hatch that rescues an
         // anonymous reconnect must not rescue a wrong-password attach.
         store.get = async () =>
@@ -194,6 +202,104 @@ describe("Middleware: credentialCheck", () => {
         });
 
         expect(result instanceof Error).toEqual(true);
+    });
+
+    // Regression: the incumbent's hash is unset for the whole remote
+    // handshake. Admitting an attach on the non-empty rule alone during that
+    // window failed open — registration is sticky and an attached session
+    // skips this middleware on later messages, so it stayed attached once the
+    // hash finally arrived.
+    describe("before the incumbent's credentials are known", () => {
+        it("refuses a persistent-platform attach when the hash never arrives", async () => {
+            store.get = async () =>
+                makeCredentials({ type: "credentials", password: "abc123" });
+            platformInstances.set(platformKey, {
+                sessions: new Set(["socket-2"]),
+                sessionIps: new Map([["socket-2", clientIp]]),
+                config: { persist: true },
+                credentialsHash: undefined,
+                waitForCredentialsHash: async () => undefined,
+                // biome-ignore lint/suspicious/noExplicitAny: test double
+            } as any);
+
+            const result = await new Promise<ActivityStream | Error>(
+                (resolve) => {
+                    credentialCheck(store, socketId, clientIp)(
+                        baseMessage,
+                        resolve,
+                    );
+                },
+            );
+
+            expect(result instanceof Error).toEqual(true);
+        });
+
+        it("admits a concurrent connect once the hash arrives and matches", async () => {
+            // Two clients connecting with the same credentials: the second
+            // waits for the first to finish rather than being refused.
+            let seenHash: string | undefined;
+            store.get = async (
+                _actor: string,
+                credentialsHash: string | undefined,
+            ) => {
+                seenHash = credentialsHash;
+                return makeCredentials({
+                    type: "credentials",
+                    password: "abc123",
+                });
+            };
+            platformInstances.set(platformKey, {
+                sessions: new Set(["socket-2"]),
+                sessionIps: new Map([["socket-2", clientIp]]),
+                config: { persist: true },
+                credentialsHash: undefined,
+                waitForCredentialsHash: async () => "late-hash",
+                // biome-ignore lint/suspicious/noExplicitAny: test double
+            } as any);
+
+            const result = await new Promise<ActivityStream | Error>(
+                (resolve) => {
+                    credentialCheck(store, socketId, clientIp)(
+                        baseMessage,
+                        resolve,
+                    );
+                },
+            );
+
+            expect(result).toEqual(baseMessage);
+            expect(seenHash).toEqual("late-hash");
+        });
+
+        it("does not wait for non-persistent platforms", async () => {
+            // Nothing publishes a hash for these, and there is no long-lived
+            // connection to join, so the original rule still applies.
+            let waited = false;
+            store.get = async () =>
+                makeCredentials({ type: "credentials", password: "abc123" });
+            platformInstances.set(platformKey, {
+                sessions: new Set(["socket-2"]),
+                sessionIps: new Map([["socket-2", clientIp]]),
+                config: { persist: false },
+                credentialsHash: undefined,
+                waitForCredentialsHash: async () => {
+                    waited = true;
+                    return undefined;
+                },
+                // biome-ignore lint/suspicious/noExplicitAny: test double
+            } as any);
+
+            const result = await new Promise<ActivityStream | Error>(
+                (resolve) => {
+                    credentialCheck(store, socketId, clientIp)(
+                        baseMessage,
+                        resolve,
+                    );
+                },
+            );
+
+            expect(result).toEqual(baseMessage);
+            expect(waited).toEqual(false);
+        });
     });
 
     test("allows anonymous reconnect when prior session is stale and IP matches", async () => {

--- a/packages/server/src/middleware/credential-check.test.ts
+++ b/packages/server/src/middleware/credential-check.test.ts
@@ -270,6 +270,48 @@ describe("Middleware: credentialCheck", () => {
             expect(seenHash).toEqual("late-hash");
         });
 
+        it("refuses an attacker racing the incumbent's connect", async () => {
+            // The hostile variant of the concurrent-connect case: B submits
+            // the same actor.id with a different password while A is still
+            // authenticating. B must wait for A's hash and then be refused,
+            // never registered — before the fail-closed change it was admitted
+            // here and never re-checked afterwards.
+            store.get = async (
+                _actor: string,
+                credentialsHash: string | undefined,
+            ) => {
+                if (credentialsHash === "victims-hash") {
+                    throw new CredentialsMismatchError(
+                        "invalid credentials for nick@irc.example.com",
+                    );
+                }
+                return makeCredentials({
+                    type: "credentials",
+                    password: "attacker-arbitrary",
+                });
+            };
+            platformInstances.set(platformKey, {
+                sessions: new Set(["socket-2"]),
+                sessionIps: new Map([["socket-2", "198.51.100.9"]]),
+                config: { persist: true },
+                credentialsHash: undefined,
+                // A's connect completes while B is waiting.
+                waitForCredentialsHash: async () => "victims-hash",
+                // biome-ignore lint/suspicious/noExplicitAny: test double
+            } as any);
+
+            const result = await new Promise<ActivityStream | Error>(
+                (resolve) => {
+                    credentialCheck(store, socketId, clientIp)(
+                        baseMessage,
+                        resolve,
+                    );
+                },
+            );
+
+            expect(result instanceof Error).toEqual(true);
+        });
+
         it("does not wait for non-persistent platforms", async () => {
             // Nothing publishes a hash for these, and there is no long-lived
             // connection to join, so the original rule still applies.

--- a/packages/server/src/middleware/credential-check.test.ts
+++ b/packages/server/src/middleware/credential-check.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, beforeAll, beforeEach, describe, expect, test } from "bun:test";
 import {
+    CredentialsMismatchError,
     CredentialsNotShareableError,
     type CredentialsStoreInterface,
     type CredentialsValidationOptions,
@@ -116,6 +117,83 @@ describe("Middleware: credentialCheck", () => {
         });
 
         expect(result).toEqual(baseMessage);
+    });
+
+    // Regression: the incumbent's credentials hash must reach the data layer,
+    // otherwise the exact-match comparison is skipped and any non-empty
+    // password attaches to another client's live connection.
+    test("passes the incumbent's credentialsHash to the store", async () => {
+        let seenHash: string | undefined | symbol = Symbol("unset");
+        store.get = async (
+            _actor: string,
+            credentialsHash: string | undefined,
+            options: CredentialsValidationOptions | undefined,
+        ) => {
+            seenHash = credentialsHash;
+            expect(options).toEqual({ validateSessionShare: true });
+            return makeCredentials({ type: "credentials", password: "abc123" });
+        };
+        platformInstances.set(platformKey, {
+            sessions: new Set(["socket-2"]),
+            sessionIps: new Map([["socket-2", clientIp]]),
+            credentialsHash: "incumbent-hash",
+            // biome-ignore lint/suspicious/noExplicitAny: test double
+        } as any);
+
+        await new Promise<ActivityStream | Error>((resolve) => {
+            credentialCheck(store, socketId, clientIp)(baseMessage, resolve);
+        });
+
+        expect(seenHash).toEqual("incumbent-hash");
+    });
+
+    test("blocks an attach whose credentials do not match the incumbent", async () => {
+        store.get = async () =>
+            Promise.reject(
+                new CredentialsMismatchError(
+                    "invalid credentials for nick@irc.example.com",
+                ),
+            );
+        platformInstances.set(platformKey, {
+            sessions: new Set(["socket-2"]),
+            sessionIps: new Map([["socket-2", clientIp]]),
+            credentialsHash: "incumbent-hash",
+            // biome-ignore lint/suspicious/noExplicitAny: test double
+        } as any);
+
+        const result = await new Promise<ActivityStream | Error>((resolve) => {
+            credentialCheck(store, socketId, clientIp)(baseMessage, resolve);
+        });
+
+        expect(result instanceof Error).toEqual(true);
+    });
+
+    test("a credentials mismatch is not eligible for same-IP reconnect", async () => {
+        // Same IP and a stale prior session — the escape hatch that rescues an
+        // anonymous reconnect must not rescue a wrong-password attach.
+        store.get = async () =>
+            Promise.reject(
+                new CredentialsMismatchError(
+                    "invalid credentials for nick@irc.example.com",
+                ),
+            );
+        platformInstances.set(platformKey, {
+            sessions: new Set(["socket-2"]),
+            sessionIps: new Map([["socket-2", clientIp]]),
+            credentialsHash: "incumbent-hash",
+            // biome-ignore lint/suspicious/noExplicitAny: test double
+        } as any);
+
+        const result = await new Promise<ActivityStream | Error>((resolve) => {
+            credentialCheck(
+                store,
+                socketId,
+                clientIp,
+                () => false,
+            )(baseMessage, resolve);
+        });
+
+        expect(result instanceof Error).toEqual(true);
     });
 
     test("allows anonymous reconnect when prior session is stale and IP matches", async () => {

--- a/packages/server/src/middleware/credential-check.ts
+++ b/packages/server/src/middleware/credential-check.ts
@@ -24,12 +24,23 @@ import { platformInstances } from "../platform-instance.js";
  *     session. The child reports its `credentialsHash` over IPC precisely so
  *     this comparison can happen here, *before* `registerSession()`.
  *
- * When the hash is not known yet (no credentialed call has completed — e.g.
- * two clients connecting concurrently) only (1) applies. The connection isn't
- * established at that point, so there is no traffic to expose; the first
- * successful connect publishes the hash and later attaches are checked in
- * full.
+ * The hash is not known until the incumbent's first credentialed call
+ * succeeds, which spans the whole remote handshake. Attaching on the
+ * non-empty rule alone during that window would fail open: registration is
+ * sticky (the janitor is the only other removal path) and an already-attached
+ * session skips this middleware entirely on later messages, so a session that
+ * slipped in mid-handshake would still be attached — and receiving the
+ * connection's traffic — once the hash finally arrived.
+ *
+ * So for persistent platforms we wait, briefly, for the incumbent's hash and
+ * then compare; if it never arrives we fail closed. Two clients connecting
+ * concurrently with the same credentials still both succeed — the second one
+ * simply waits for the first to finish. Non-persistent platforms never publish
+ * a hash and have no long-lived connection to join, so they keep the
+ * non-empty rule alone.
  */
+// Bounded so a hung remote handshake can't pin a waiting session forever.
+const INCUMBENT_HASH_WAIT_MS = 10000;
 export default function credentialCheck(
     credentialsStore: CredentialsStoreInterface,
     socketId: string,
@@ -41,7 +52,10 @@ export default function credentialCheck(
         `server:middleware:credential-check:${socketId}`,
     );
 
-    return (msg: ActivityStream, next: MiddlewareNext<ActivityStream>) => {
+    return async (
+        msg: ActivityStream,
+        next: MiddlewareNext<ActivityStream>,
+    ) => {
         // `@context` is canonical by the time validate middleware has run.
         // Fall back to an empty string so the lookup deterministically misses
         // rather than blowing up on unresolved platform IDs.
@@ -59,12 +73,35 @@ export default function credentialCheck(
             return;
         }
 
+        let incumbentHash = existing.credentialsHash;
+        if (!incumbentHash && existing.config?.persist) {
+            // Mid-handshake: hold this attach until the incumbent's credentials
+            // are known, rather than admitting it on the weaker rule.
+            incumbentHash = await existing.waitForCredentialsHash(
+                INCUMBENT_HASH_WAIT_MS,
+            );
+            if (!incumbentHash) {
+                sessionLog.info(
+                    `refusing attach to ${platformId}:${msg.actor.id} (socketId=${socketId}): ` +
+                        "incumbent credentials still unknown",
+                );
+                next(
+                    toError(
+                        new CredentialsNotShareableError(
+                            "username already in use",
+                        ),
+                    ),
+                );
+                return;
+            }
+        }
+
         // Only shared-session attach attempts need credential-share validation.
         // The data layer owns the credential semantics for this check: passing
         // the incumbent's hash makes `get()` require an exact match, on top of
         // the non-empty-secret rule `validateSessionShare` applies.
-        credentialsStore
-            .get(msg.actor.id, existing.credentialsHash, {
+        return credentialsStore
+            .get(msg.actor.id, incumbentHash, {
                 validateSessionShare: true,
             })
             .then(() => {

--- a/packages/server/src/middleware/credential-check.ts
+++ b/packages/server/src/middleware/credential-check.ts
@@ -11,8 +11,24 @@ import type { MiddlewareNext } from "../middleware.js";
 import { platformInstances } from "../platform-instance.js";
 
 /**
- * Prevents a second socket from attaching to an existing persistent platform
- * instance when credentials are "empty" (e.g., unregistered IRC nick).
+ * Gates a second socket attaching to an existing persistent platform instance.
+ *
+ * Two conditions must hold for an attach to be allowed:
+ *
+ *  1. The attaching session's credentials are not "empty" (e.g. an
+ *     unregistered IRC nick), which is what the original guard checked.
+ *  2. Those credentials *match the ones that opened the connection*. Without
+ *     this, knowing an `actor.id` plus any non-empty password was enough to
+ *     join another client's live connection — sending as them and receiving
+ *     their inbound traffic, since platform emits fan out to every registered
+ *     session. The child reports its `credentialsHash` over IPC precisely so
+ *     this comparison can happen here, *before* `registerSession()`.
+ *
+ * When the hash is not known yet (no credentialed call has completed — e.g.
+ * two clients connecting concurrently) only (1) applies. The connection isn't
+ * established at that point, so there is no traffic to expose; the first
+ * successful connect publishes the hash and later attaches are checked in
+ * full.
  */
 export default function credentialCheck(
     credentialsStore: CredentialsStoreInterface,
@@ -44,9 +60,13 @@ export default function credentialCheck(
         }
 
         // Only shared-session attach attempts need credential-share validation.
-        // The data layer owns the credential semantics for this check.
+        // The data layer owns the credential semantics for this check: passing
+        // the incumbent's hash makes `get()` require an exact match, on top of
+        // the non-empty-secret rule `validateSessionShare` applies.
         credentialsStore
-            .get(msg.actor.id, undefined, { validateSessionShare: true })
+            .get(msg.actor.id, existing.credentialsHash, {
+                validateSessionShare: true,
+            })
             .then(() => {
                 next(msg);
             })

--- a/packages/server/src/middleware/credential-check.ts
+++ b/packages/server/src/middleware/credential-check.ts
@@ -38,6 +38,23 @@ import { platformInstances } from "../platform-instance.js";
  * simply waits for the first to finish. Non-persistent platforms never publish
  * a hash and have no long-lived connection to join, so they keep the
  * non-empty rule alone.
+ *
+ * "Match" means an identical submitted credential object, not equivalent
+ * effective connection settings: `secure` omitted and `secure: true` hash
+ * differently and will not share. That is the contract the platform already
+ * enforced for `connect`/`update` (see `platform.credentialsHash`); this
+ * applies it consistently to the attach gate rather than introducing it.
+ * Sharing a connection therefore requires clients to submit byte-identical
+ * credentials, which is the conservative direction for an authorization
+ * check.
+ *
+ * Known gap, pre-dating this check: `canReconnectFromSameIp` lets a
+ * passwordless session past the share rules when every prior session is stale
+ * and its IP matches. Client IP is weak identity — behind NAT or a shared
+ * egress it is effectively no identity at all — so this remains a takeover
+ * path for anonymous sessions. Left as-is here to avoid changing reconnect
+ * behaviour in a security fix; worth revisiting once token auth (#1054) can
+ * supply a real identity.
  */
 // Bounded so a hung remote handshake can't pin a waiting session forever.
 const INCUMBENT_HASH_WAIT_MS = 10000;

--- a/packages/server/src/platform-instance.test.ts
+++ b/packages/server/src/platform-instance.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { afterEach, beforeEach, describe, expect, it, test } from "bun:test";
 import * as sinon from "sinon";
 import {
     addPlatformContext,
@@ -482,7 +482,32 @@ describe("PlatformInstance", () => {
                 sandbox.assert.calledWith(pi.updateIdentifier, { foo: "bar" });
             });
 
-            test("message events from platform thread are routed based on command: credentialsHash", async () => {
+            it("waitForCredentialsHash resolves when the child publishes", async () => {
+                const pending = pi.waitForCredentialsHash(5000);
+                await pi.handleProcessMessage([
+                    "credentialsHash",
+                    undefined,
+                    "published-late",
+                ]);
+                expect(await pending).toEqual("published-late");
+            });
+
+            it("waitForCredentialsHash resolves undefined on timeout", async () => {
+                expect(await pi.waitForCredentialsHash(1)).toBeUndefined();
+            });
+
+            it("waitForCredentialsHash returns immediately once known", async () => {
+                await pi.handleProcessMessage([
+                    "credentialsHash",
+                    undefined,
+                    "already-known",
+                ]);
+                expect(await pi.waitForCredentialsHash(0)).toEqual(
+                    "already-known",
+                );
+            });
+
+            it("message events from platform thread are routed based on command: credentialsHash", async () => {
                 // The child reports which credentials its connection is bound
                 // to; credential-check needs this to authorize further
                 // sessions attaching to the instance.

--- a/packages/server/src/platform-instance.test.ts
+++ b/packages/server/src/platform-instance.test.ts
@@ -482,6 +482,21 @@ describe("PlatformInstance", () => {
                 sandbox.assert.calledWith(pi.updateIdentifier, { foo: "bar" });
             });
 
+            test("message events from platform thread are routed based on command: credentialsHash", async () => {
+                // The child reports which credentials its connection is bound
+                // to; credential-check needs this to authorize further
+                // sessions attaching to the instance.
+                expect(pi.credentialsHash).toBeUndefined();
+                await pi.handleProcessMessage([
+                    "credentialsHash",
+                    undefined,
+                    "a-credentials-hash",
+                ]);
+                expect(pi.credentialsHash).toEqual("a-credentials-hash");
+                // control message, not client traffic
+                sandbox.assert.notCalled(pi.sendToClient);
+            });
+
             test("message events from platform thread are delivered to every registered session", async () => {
                 pi.sessions.add("session one");
                 pi.sessions.add("session two");

--- a/packages/server/src/platform-instance.ts
+++ b/packages/server/src/platform-instance.ts
@@ -90,6 +90,9 @@ export default class PlatformInstance {
      * connect — see that middleware for how the unknown case is handled.
      */
     credentialsHash: string | undefined;
+    private readonly credentialsHashWaiters = new Set<
+        (hash: string | undefined) => void
+    >();
     private processMessageListener?: (message: MessageFromPlatform) => void;
     private processCloseListener?: (e: unknown) => void;
     private heartbeatLastSeen = Date.now();
@@ -216,6 +219,13 @@ export default class PlatformInstance {
     private async teardown() {
         this.log.debug("platform process shutdown");
         this.flaggedForTermination = true;
+        // This connection will never report its credentials now; release any
+        // attach waiting on them so it fails closed immediately rather than
+        // sitting out the full timeout.
+        for (const waiter of this.credentialsHashWaiters) {
+            waiter(undefined);
+        }
+        this.credentialsHashWaiters.clear();
 
         try {
             if (this.heartbeatMonitor) {
@@ -345,6 +355,45 @@ export default class PlatformInstance {
      * Register listener to be called when the process emits a message.
      * @param sessionId ID of socket connection that will receive messages from platform emits
      */
+    /**
+     * Record the credentials this instance's connection is bound to and
+     * release anything waiting on them.
+     */
+    private setCredentialsHash(hash: string) {
+        this.credentialsHash = hash;
+        for (const waiter of this.credentialsHashWaiters) {
+            waiter(hash);
+        }
+        this.credentialsHashWaiters.clear();
+    }
+
+    /**
+     * Resolve once the child has reported which credentials this connection
+     * was established with, or `undefined` if that has not happened within
+     * `timeoutMs`. Callers treat the timeout as "unknown, refuse" — waiting
+     * unbounded would let a hung remote handshake pin a session indefinitely.
+     */
+    public waitForCredentialsHash(
+        timeoutMs: number,
+    ): Promise<string | undefined> {
+        if (this.credentialsHash) {
+            return Promise.resolve(this.credentialsHash);
+        }
+        return new Promise((resolve) => {
+            const waiter = (hash: string | undefined) => {
+                clearTimeout(timer);
+                resolve(hash);
+            };
+            const timer = setTimeout(() => {
+                this.credentialsHashWaiters.delete(waiter);
+                resolve(undefined);
+            }, timeoutMs);
+            // Don't hold the event loop open purely for this timer.
+            timer.unref?.();
+            this.credentialsHashWaiters.add(waiter);
+        });
+    }
+
     public registerSession(sessionId: string, clientIp?: string) {
         if (clientIp) {
             this.sessionIps.set(sessionId, clientIp);
@@ -596,7 +645,7 @@ export default class PlatformInstance {
             // Internal control message: the child is reporting which credentials
             // its remote connection is bound to, so the parent can authorize
             // (or refuse) additional sessions attaching to this instance.
-            this.credentialsHash = third;
+            this.setCredentialsHash(third);
         } else if (first === "error") {
             // Error messages travel over IPC as plain objects; normalize to a string.
             let normalizedError: string;

--- a/packages/server/src/platform-instance.ts
+++ b/packages/server/src/platform-instance.ts
@@ -42,6 +42,7 @@ type EnvFormat = {
 
 type MessageFromPlatform =
     | ["updateActor", ActivityStream | undefined, string]
+    | ["credentialsHash", undefined, string]
     | ["error", string]
     | ["heartbeat", ActivityStream]
     | [string, ActivityStream, string?];
@@ -81,6 +82,14 @@ export default class PlatformInstance {
     readonly parentId: string;
     readonly sessions: Set<string> = new Set();
     readonly sessionIps: Map<string, string> = new Map();
+    /**
+     * Hash of the credentials this instance's remote connection was
+     * established with, reported by the child once a credentialed call has
+     * succeeded. `credential-check` compares an attaching session's
+     * credentials against it. `undefined` until the first successful
+     * connect — see that middleware for how the unknown case is handled.
+     */
+    credentialsHash: string | undefined;
     private processMessageListener?: (message: MessageFromPlatform) => void;
     private processCloseListener?: (e: unknown) => void;
     private heartbeatLastSeen = Date.now();
@@ -583,6 +592,11 @@ export default class PlatformInstance {
             // Internal control message: platform process is reporting a new actor id.
             // We need to update the key to the store in order to find it in the future.
             this.updateIdentifier(third);
+        } else if (first === "credentialsHash") {
+            // Internal control message: the child is reporting which credentials
+            // its remote connection is bound to, so the parent can authorize
+            // (or refuse) additional sessions attaching to this instance.
+            this.credentialsHash = third;
         } else if (first === "error") {
             // Error messages travel over IPC as plain objects; normalize to a string.
             let normalizedError: string;

--- a/packages/server/src/platform.ts
+++ b/packages/server/src/platform.ts
@@ -408,6 +408,9 @@ async function startPlatformProcess() {
                                     // Only persistent platforms track credential state across requests.
                                     platform.credentialsHash =
                                         crypto.objectHash(credentials.object);
+                                    publishCredentialsHash(
+                                        platform.credentialsHash,
+                                    );
                                 }
                                 doneCallback(err, result);
                             };
@@ -526,6 +529,23 @@ async function startPlatformProcess() {
     }
 
     /**
+     * Tell the parent which credentials this connection is bound to.
+     *
+     * The hash is only ever computed after a credentialed platform call has
+     * succeeded, so it identifies the credentials that actually opened the
+     * remote connection. The parent needs it to decide whether a *different*
+     * session may attach to this instance — that decision happens in
+     * `credential-check` middleware, before the session is registered, and the
+     * parent has no other way to see the child's credential state.
+     */
+    function publishCredentialsHash(hash: string | undefined): void {
+        if (!hash || !platform.config.persist || !process.send) {
+            return;
+        }
+        process.send(["credentialsHash", undefined, hash]);
+    }
+
+    /**
      * When a user changes its actor name, the channel identifier changes, we need to ensure that
      * both the queue thread (listening on the channel for jobs) and the logging object are updated.
      * @param credentials
@@ -542,6 +562,7 @@ async function startPlatformProcess() {
         // Update credentialsHash for persistent platforms (tracks actor-specific state)
         if (isPersistentPlatform(platform)) {
             platform.credentialsHash = crypto.objectHash(credentials.object);
+            publishCredentialsHash(platform.credentialsHash);
         }
 
         process.send(["updateActor", undefined, identifier]);

--- a/packages/util/src/crypto/index.ts
+++ b/packages/util/src/crypto/index.ts
@@ -70,8 +70,18 @@ export class Crypto {
         return createHash("sha256").update(text).digest("hex");
     }
 
+    /**
+     * Stable hash of a credential object, used as the verifier that decides
+     * whether a session may reuse an existing platform connection.
+     *
+     * `object-hash` defaults to SHA-1; pinned to SHA-256 instead, since this
+     * backs an authorization decision. Not an exploit fix — the value is never
+     * exposed to clients, and forging a match needs a second preimage of an
+     * unknown credential object, which SHA-1 does not give you — but a new
+     * security-sensitive verifier should not be built on a deprecated digest.
+     */
     objectHash(object: object): string {
-        return hash(object);
+        return hash(object, { algorithm: "sha256" });
     }
 
     /**


### PR DESCRIPTION
## Summary

Persistent platform instances (IRC, XMPP) are shared server-wide, keyed by `hash(platform + actor.id)`. The guard on that sharing only checked that the attaching session's credentials contained a **non-empty** password or token — it never compared them against the credentials that opened the connection.

Since each session stores its own credentials, the attaching client supplies the value being checked. **Knowing a connected user's `actor.id` plus any non-empty password was enough to join their live connection** — sending as them, and receiving their inbound traffic (private messages included), since platform emits fan out to every registered session.

`join`, `send`, `leave` and `query` are not in IRC's `requireCredentials`, so no later check caught it either.

## Verification

Before, against a real server driven by two socket.io clients (session B on a different IP with a different password):

```
added irc-0 connect to queue          queue:…:0b033cd6…   (session A)
get credentials for victim@…          credentials-store:…:rN6u…AAAD   (session B)
added irc-1 join to queue             queue:…:0b033cd6…   (session B → A's instance)
```

Same three-case harness against the real `CredentialsStore` and real middleware, before and after:

| Second session stores | Before | After |
|---|---|---|
| nothing | BLOCKED — `username already in use` | BLOCKED — `username already in use` |
| `password: "totally-wrong"` | **ATTACHED** | BLOCKED — `invalid credentials for …` |
| `password: <correct>` | ATTACHED | ATTACHED |

## What changed

The exact-match comparison already existed in `CredentialsStore.get()` — it just ran in the wrong place. Only the child process passed a `credentialsHash`, only for credentialed job types, and only *after* the parent had already registered the session. The parent had no access to the child's credential state.

- **`platform.ts`** — the child publishes its `credentialsHash` to the parent over the existing IPC channel once a credentialed call succeeds (so it reflects the credentials that actually opened the connection).
- **`platform-instance.ts`** — `PlatformInstance` holds it; new `credentialsHash` control message.
- **`credential-check.ts`** — passes it to the data layer, so an attach requires an exact match. This runs **before** `registerSession()`, so a rejected attach is never registered.
- **`credentials-store.ts`** — reorders the two checks so a passwordless attach still reports "not shareable" rather than "mismatch", keeping the same-IP anonymous reconnect path reachable.

## Behaviour notes

- **Legitimate sharing is preserved.** Two clients presenting the same credentials still share one connection (covered by `irc-nickclash.integration.js`).
- **Unknown-hash window.** Before any credentialed call completes (e.g. two clients connecting concurrently), the hash is unknown and only the original non-empty rule applies. No remote connection exists at that point, so there is no traffic to expose; the first successful connect publishes the hash and later attaches are checked in full.
- **Anonymous same-IP reconnect** is unaffected.

## Tests

- `credentials-store.test.ts` — the three cases at the decision layer: no password, wrong password, correct password.
- `credential-check.test.ts` — the incumbent hash reaches the store; a mismatch is rejected; a mismatch is **not** eligible for the same-IP reconnect escape hatch.
- `platform-instance.test.ts` — the `credentialsHash` IPC message sets the field and is not forwarded to clients.

`bun test` — 823 pass, 0 fail. `biome check` clean. `bun run build` clean.

## Follow-ups (not in this PR)

1. **Detach on failure** — a session rejected by the child's credential check stays in `platformInstance.sessions` until the janitor notices its socket is gone (`janitor.ts:62` is the only removal path). Narrower now that attach is gated, but still worth closing.
2. **Presence oracle** — `"username already in use"` is only reachable when an actor already has a live connection, so it discloses who is connected. Flattening the three failure modes is a separate change.
3. **Cross-platform credential collisions** — credentials are keyed by `actor.id` alone, with no platform component, both server-side (`store-credentials.ts:15`) and in the client's replay maps (`sockethub-client.ts:531,553`).

Context: came out of reviewing #1131. The defect predates that PR and is independent of the ID format debate.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Persistent shared sessions now require matching credentials when attaching or reconnecting.
  - Missing credentials are clearly rejected when a session cannot be shared without them.
  - Incorrect credentials consistently produce a mismatch error, including same-network reconnects.
  - Credential validation is now reliably synchronized across persistent platform instances.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->