### PR TITLE
fix(server): detach unauthorized sessions, unify share errors, scope credentials by platform

### DIFF
--- a/docs/client-guide.md
+++ b/docs/client-guide.md
@@ -254,7 +254,7 @@ The rejected request returns an ActivityStream response with an `error`:
   "type": "connect",
   "actor": { "id": "mynick@irc.libera.chat", "type": "person", "name": "mynick" },
   "id": "1",
-  "error": "username already in use"
+  "error": "unable to attach session for this actor"
 }
 ```
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -239,8 +239,9 @@ When another socket is already attached to that actor:
 
 - Session-share validation runs in the data layer.
 - Credentials with a non-empty `password` are considered shareable.
-- Credentials without a non-empty `password` are not shareable and return
-  `username already in use`.
+- Credentials without a non-empty `password` are not shareable.
+- Every rejection returns the same message, `unable to attach session for this
+  actor`, so the reason is not disclosed to the caller.
 
 This prevents anonymous/username-only accounts from accidentally sharing the
 same platform thread across different users.

--- a/packages/client/src/sockethub-client.test.ts
+++ b/packages/client/src/sockethub-client.test.ts
@@ -708,6 +708,33 @@ describe("SockethubClient", () => {
         });
     });
 
+    describe("replay keys are scoped by platform", () => {
+        beforeEach(() => {
+            sc.socket.connected = true;
+            sc._socket.connected = true;
+            socket.emit("schemas", TEST_REGISTRY);
+            sandbox.stub(sc, "validateActivity").returns("");
+        });
+
+        it("keeps credentials for one actor id on two platforms separate", () => {
+            // Regression: keyed by actor alone, the second platform's
+            // credentials replaced the first, so a reconnect replayed only one.
+            const actor = { id: "alice@example.org", type: "person" };
+            sc.socket.emit("credentials", {
+                "@context": sc.contextFor("test-xmpp"),
+                actor,
+                object: { type: "credentials", password: "xmpp-pass" },
+            });
+            sc.socket.emit("credentials", {
+                "@context": sc.contextFor("dummy"),
+                actor,
+                object: { type: "credentials", password: "dummy-pass" },
+            });
+
+            expect(sc.events.credentials.size).to.equal(2);
+        });
+    });
+
     describe("clearCredentials", () => {
         beforeEach(() => {
             sc.socket.connected = true;

--- a/packages/client/src/sockethub-client.ts
+++ b/packages/client/src/sockethub-client.ts
@@ -3,6 +3,7 @@ import {
     addPlatformContext,
     addPlatformSchema,
     normalizeActivityStream,
+    resolvePlatformId,
     validateActivityStream,
     validateCredentials,
 } from "@sockethub/schemas";
@@ -528,9 +529,10 @@ export default class SockethubClient {
 
     private eventCredentials(content: ActivityStream) {
         if (content.object && content.object.type === "credentials") {
-            const key: string =
-                content.actor.id || (content.actor as unknown as string);
-            this.events.credentials.set(key, content);
+            this.events.credentials.set(
+                SockethubClient.getKey(content),
+                content,
+            );
         }
     }
 
@@ -550,6 +552,12 @@ export default class SockethubClient {
         }
     }
 
+    /**
+     * Key for the replay maps. Scoped by platform: the same visible actor id
+     * can exist on more than one platform (an `alice@example.org` that is both
+     * an IRC nick and an XMPP JID), and keyed by actor alone one platform's
+     * stored credentials/connect/join would replace the other's on reconnect.
+     */
     private static getKey(content: ActivityStream) {
         const actor = content.actor?.id || content.actor;
         if (!actor) {
@@ -560,7 +568,8 @@ export default class SockethubClient {
         const target = content.target
             ? content.target.id || content.target
             : "";
-        return `${actor}-${target}`;
+        const platform = resolvePlatformId(content) ?? "";
+        return `${platform}:${actor}-${target}`;
     }
 
     private buildPlatformRegistryPayload(): PlatformRegistryPayload {

--- a/packages/data-layer/integration/redis.integration.ts
+++ b/packages/data-layer/integration/redis.integration.ts
@@ -5,6 +5,7 @@ import {
     JobQueue,
     JobWorker,
     redisCheck,
+    SESSION_SHARE_DENIED,
 } from "@sockethub/data-layer";
 import {
     type ActivityStream,
@@ -98,7 +99,7 @@ describe("CredentialsStore", () => {
 
         await expect(
             store.get(actor, undefined, { validateSessionShare: true }),
-        ).rejects.toThrow("username already in use");
+        ).rejects.toThrow(SESSION_SHARE_DENIED);
     });
 
     it("isolates credentials by session", async () => {

--- a/packages/data-layer/src/credentials-store.test.ts
+++ b/packages/data-layer/src/credentials-store.test.ts
@@ -8,6 +8,7 @@ import {
     CredentialsNotShareableError,
     CredentialsStore,
     purgeCredentialsStoreKeys,
+    SESSION_SHARE_DENIED,
 } from "./credentials-store";
 
 const mockLogger: Logger = {
@@ -209,6 +210,63 @@ describe("CredentialsStore", () => {
             });
         });
 
+        // A caller probing guessed actor ids must not learn *why* it was
+        // turned away — every attach failure reports the same string.
+        describe("session-share rejections are indistinguishable", () => {
+            it("uses the generic message when no credentials are stored", async () => {
+                MockStoreGet.returns(undefined);
+                try {
+                    await credentialsStore.get("an actor", undefined, {
+                        validateSessionShare: true,
+                    });
+                    expect(false).toEqual(true);
+                } catch (err) {
+                    expect(err.message).toEqual(SESSION_SHARE_DENIED);
+                    // must NOT be "not shareable": only that class is eligible
+                    // for the same-IP anonymous reconnect escape hatch
+                    expect(err).not.toBeInstanceOf(CredentialsNotShareableError);
+                }
+            });
+
+            it("uses the generic message when the credential object is empty", async () => {
+                MockStoreGet.returns({ object: {} });
+                try {
+                    await credentialsStore.get("an actor", undefined, {
+                        validateSessionShare: true,
+                    });
+                    expect(false).toEqual(true);
+                } catch (err) {
+                    expect(err.message).toEqual(SESSION_SHARE_DENIED);
+                }
+            });
+
+            it("uses the generic message when no secret is present", async () => {
+                MockStoreGet.returns({ object: { type: "credentials" } });
+                try {
+                    await credentialsStore.get("an actor", undefined, {
+                        validateSessionShare: true,
+                    });
+                    expect(false).toEqual(true);
+                } catch (err) {
+                    expect(err.message).toEqual(SESSION_SHARE_DENIED);
+                }
+            });
+
+            it("keeps detailed messages for the platform's own reads", async () => {
+                // validateSessionShare is not set: the caller already owns
+                // these credentials, so there is nothing to disclose.
+                MockStoreGet.returns(undefined);
+                try {
+                    await credentialsStore.get("an actor");
+                    expect(false).toEqual(true);
+                } catch (err) {
+                    expect(err.message).toEqual(
+                        "credentials not found for an actor",
+                    );
+                }
+            });
+        });
+
         it("rejects credentials without password or token for session-share validation", async () => {
             MockStoreGet.returns({
                 object: { type: "credentials" },
@@ -219,7 +277,7 @@ describe("CredentialsStore", () => {
                 });
                 expect(false).toEqual(true);
             } catch (err) {
-                expect(err.toString()).toEqual("Error: username already in use");
+                expect(err.toString()).toEqual(`Error: ${SESSION_SHARE_DENIED}`);
                 expect(err).toBeInstanceOf(CredentialsNotShareableError);
             }
             sinon.assert.calledOnce(MockStoreGet);

--- a/packages/data-layer/src/credentials-store.ts
+++ b/packages/data-layer/src/credentials-store.ts
@@ -159,6 +159,13 @@ export class CredentialsMismatchError extends Error {
     }
 }
 
+/**
+ * The single message returned for every failed attach to an existing
+ * persistent platform instance, whatever the underlying reason. Callers still
+ * distinguish the cases by error *class* internally; clients see one string.
+ */
+export const SESSION_SHARE_DENIED = "unable to attach session for this actor";
+
 export class CredentialsNotShareableError extends Error {
     constructor(message: string) {
         super(message);
@@ -275,9 +282,21 @@ export class CredentialsStore implements CredentialsStoreInterface {
         if (!this.store.isConnected) {
             await this.store.connect();
         }
+        // Attach attempts get one uniform message for every rejection reason.
+        // Distinct texts ("not found" / "invalid" / "already in use") let a
+        // caller probing guessed actor ids learn *why* it was turned away.
+        // Detailed messages are kept for the platform's own credential reads,
+        // where the caller already owns the credentials being described.
+        const share = options.validateSessionShare === true;
+        const denied = (detail: string) =>
+            share ? SESSION_SHARE_DENIED : detail;
+
         const credentials: CredentialsObject = await this.store.get(actor);
         if (!credentials) {
-            throw new Error(`credentials not found for ${actor}`);
+            // Deliberately NOT a CredentialsNotShareableError: only that class
+            // is eligible for the same-IP anonymous reconnect escape hatch,
+            // and a session with no stored credentials at all must not be.
+            throw new Error(denied(`credentials not found for ${actor}`));
         }
         if (
             !credentials.object ||
@@ -286,7 +305,7 @@ export class CredentialsStore implements CredentialsStoreInterface {
             Object.keys(credentials.object).length === 0
         ) {
             throw new CredentialsMismatchError(
-                `invalid credentials for ${actor}`,
+                denied(`invalid credentials for ${actor}`),
             );
         }
 
@@ -295,7 +314,7 @@ export class CredentialsStore implements CredentialsStoreInterface {
             // "same actor, different credentials" reuse attempts.
             if (credentialsHash !== this.objectHash(credentials.object)) {
                 throw new CredentialsMismatchError(
-                    `invalid credentials for ${actor}`,
+                    denied(`invalid credentials for ${actor}`),
                 );
             }
         }
@@ -310,9 +329,7 @@ export class CredentialsStore implements CredentialsStoreInterface {
             // Credentials must include a non-empty secret before an additional
             // session can attach to the same persistent actor instance.
             if (!hasPassword && !hasToken) {
-                throw new CredentialsNotShareableError(
-                    "username already in use",
-                );
+                throw new CredentialsNotShareableError(SESSION_SHARE_DENIED);
             }
         }
         return credentials;

--- a/packages/data-layer/src/index.ts
+++ b/packages/data-layer/src/index.ts
@@ -15,6 +15,7 @@ import {
     resetSharedCredentialsRedisConnection,
     resetSharedIdempotencyRedisConnection,
     resetSharedRateLimitRedisConnection,
+    SESSION_SHARE_DENIED,
     verifySecureStore,
 } from "./credentials-store.js";
 import {
@@ -23,6 +24,7 @@ import {
 } from "./job-base.js";
 import { JobQueue, verifyJobQueue } from "./job-queue.js";
 import { JobWorker, type JobWorkerOptions } from "./job-worker.js";
+import { buildCredentialsKey } from "./queue-id.js";
 
 export * from "./types.js";
 
@@ -52,6 +54,7 @@ async function redisCheck(config: RedisConfig): Promise<void> {
 }
 
 export {
+    buildCredentialsKey,
     CredentialsMismatchError,
     CredentialsNotShareableError,
     CredentialsStore,
@@ -65,6 +68,7 @@ export {
     JobQueue,
     purgeCredentialsStoreKeys,
     purgeCredentialsStores,
+    SESSION_SHARE_DENIED,
     JobWorker,
     type JobWorkerOptions,
     redisCheck,

--- a/packages/data-layer/src/queue-id.test.ts
+++ b/packages/data-layer/src/queue-id.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, it } from "bun:test";
 
-import { buildCredentialsStoreId, buildQueueId } from "./queue-id";
+import {
+    buildCredentialsKey,
+    buildCredentialsStoreId,
+    buildQueueId,
+} from "./queue-id";
 
 describe("queue-id helpers", () => {
     it("buildQueueId uses canonical namespace", () => {
@@ -12,6 +16,22 @@ describe("queue-id helpers", () => {
     it("buildCredentialsStoreId uses canonical namespace", () => {
         expect(buildCredentialsStoreId("parent", "session")).toBe(
             "sockethub:parent:data-layer:credentials-store:session",
+        );
+    });
+});
+
+describe("buildCredentialsKey", () => {
+    it("scopes an actor id by platform", () => {
+        expect(buildCredentialsKey("irc", "alice@example.org")).toEqual(
+            "irc:alice@example.org",
+        );
+    });
+
+    it("keeps the same actor id on two platforms distinct", () => {
+        // Regression: keyed by actor alone, saving XMPP credentials silently
+        // overwrote the IRC credentials for the same visible id.
+        expect(buildCredentialsKey("irc", "alice@example.org")).not.toEqual(
+            buildCredentialsKey("xmpp", "alice@example.org"),
         );
     });
 });

--- a/packages/data-layer/src/queue-id.ts
+++ b/packages/data-layer/src/queue-id.ts
@@ -12,3 +12,19 @@ export function buildCredentialsStoreId(
 ): string {
     return `${REDIS_QUEUE_PREFIX}:${parentId}:data-layer:credentials-store:${sessionId}`;
 }
+
+/**
+ * Field key for one actor's credentials inside a session's credential store.
+ *
+ * Scoped by platform as well as actor: a single session may hold credentials
+ * for the same visible `actor.id` on more than one platform (e.g. an
+ * `alice@example.org` that is both an IRC nick and an XMPP JID). Keyed by
+ * actor alone, saving one would silently overwrite the other.
+ *
+ * Both sides of the fork must derive this identically — the parent resolves
+ * the platform from the message `@context`, the child from the platform name
+ * it was forked with, and those are the same string.
+ */
+export function buildCredentialsKey(platform: string, actor: string): string {
+    return `${platform}:${actor}`;
+}

--- a/packages/server/README.md
+++ b/packages/server/README.md
@@ -31,7 +31,11 @@ Session sharing rules:
 - Share is allowed only when credentials include a non-empty `password` or
   `token` field (e.g. IRC OAuth). Credential objects with neither are treated
   as anonymous and cannot be shared across connections.
-- Username-only/anonymous credentials are rejected with `username already in use`.
+- Every rejected share attempt returns the same message,
+  `unable to attach session for this actor`, whatever the reason (no
+  credentials stored, anonymous credentials, or credentials that do not match
+  the ones that opened the connection). The reason is deliberately not
+  disclosed, so a caller cannot probe guessed actor ids for detail.
 
 Reconnect exception for anonymous credentials:
 

--- a/packages/server/src/middleware/credential-check.test.ts
+++ b/packages/server/src/middleware/credential-check.test.ts
@@ -1,8 +1,10 @@
 import { afterEach, beforeAll, beforeEach, describe, expect, test } from "bun:test";
 import {
+    buildCredentialsKey,
     CredentialsNotShareableError,
     type CredentialsStoreInterface,
     type CredentialsValidationOptions,
+    SESSION_SHARE_DENIED,
 } from "@sockethub/data-layer";
 import {
     type ActivityStream,
@@ -80,7 +82,7 @@ describe("Middleware: credentialCheck", () => {
             credentialsHash: string | undefined,
             options: CredentialsValidationOptions | undefined,
         ) => {
-            expect(actor).toEqual(baseMessage.actor.id);
+            expect(actor).toEqual(buildCredentialsKey("irc", baseMessage.actor.id));
             expect(credentialsHash).toBeUndefined();
             expect(options).toEqual({ validateSessionShare: true });
             return makeCredentials({ type: "credentials", password: "abc123" });
@@ -120,7 +122,7 @@ describe("Middleware: credentialCheck", () => {
 
     test("allows anonymous reconnect when prior session is stale and IP matches", async () => {
         store.get = async () =>
-            Promise.reject(new CredentialsNotShareableError("username already in use"));
+            Promise.reject(new CredentialsNotShareableError(SESSION_SHARE_DENIED));
         platformInstances.set(
             platformKey,
             {
@@ -143,7 +145,7 @@ describe("Middleware: credentialCheck", () => {
 
     test("blocks anonymous reconnect when prior session IP differs", async () => {
         store.get = async () =>
-            Promise.reject(new CredentialsNotShareableError("username already in use"));
+            Promise.reject(new CredentialsNotShareableError(SESSION_SHARE_DENIED));
         platformInstances.set(
             platformKey,
             {
@@ -162,12 +164,12 @@ describe("Middleware: credentialCheck", () => {
         });
 
         expect(result instanceof Error).toEqual(true);
-        expect(result.toString()).toEqual("Error: username already in use");
+        expect(result.toString()).toEqual(`Error: ${SESSION_SHARE_DENIED}`);
     });
 
     test("blocks anonymous reconnect when prior session is still active", async () => {
         store.get = async () =>
-            Promise.reject(new CredentialsNotShareableError("username already in use"));
+            Promise.reject(new CredentialsNotShareableError(SESSION_SHARE_DENIED));
         platformInstances.set(
             platformKey,
             {
@@ -186,6 +188,6 @@ describe("Middleware: credentialCheck", () => {
         });
 
         expect(result instanceof Error).toEqual(true);
-        expect(result.toString()).toEqual("Error: username already in use");
+        expect(result.toString()).toEqual(`Error: ${SESSION_SHARE_DENIED}`);
     });
 });

--- a/packages/server/src/middleware/credential-check.ts
+++ b/packages/server/src/middleware/credential-check.ts
@@ -1,7 +1,9 @@
 import {
+    buildCredentialsKey,
     CredentialsMismatchError,
     CredentialsNotShareableError,
     type CredentialsStoreInterface,
+    SESSION_SHARE_DENIED,
 } from "@sockethub/data-layer";
 import { createLogger } from "@sockethub/logger";
 import { type ActivityStream, resolvePlatformId } from "@sockethub/schemas";
@@ -46,7 +48,9 @@ export default function credentialCheck(
         // Only shared-session attach attempts need credential-share validation.
         // The data layer owns the credential semantics for this check.
         credentialsStore
-            .get(msg.actor.id, undefined, { validateSessionShare: true })
+            .get(buildCredentialsKey(platformId, msg.actor.id), undefined, {
+                validateSessionShare: true,
+            })
             .then(() => {
                 next(msg);
             })
@@ -93,7 +97,8 @@ function isExpectedCredentialValidationError(err: unknown): boolean {
     }
     return (
         err instanceof Error &&
-        err.message.startsWith("credentials not found for ")
+        (err.message.startsWith("credentials not found for ") ||
+            err.message === SESSION_SHARE_DENIED)
     );
 }
 

--- a/packages/server/src/middleware/store-credentials.test.ts
+++ b/packages/server/src/middleware/store-credentials.test.ts
@@ -2,7 +2,18 @@ import { afterEach, beforeEach, describe, expect, it } from "bun:test";
 import * as sinon from "sinon";
 
 import type { CredentialsObject } from "@sockethub/schemas";
+import { buildCredentialsKey } from "@sockethub/data-layer";
+import { addPlatformContext } from "@sockethub/schemas";
 import storeCredentials from "./store-credentials.js";
+
+// The `validate` middleware runs before this one and rejects unregistered
+// platforms, so by the time credentials are stored the context is always
+// resolvable. Register it here to match that guarantee.
+addPlatformContext(
+    "dummy",
+    "https://sockethub.org/ns/context/platform/dummy/v1.jsonld",
+);
+const expectedKey = buildCredentialsKey("dummy", "dood@irc.freenode.net");
 
 const creds: CredentialsObject = {
     type: "credentials",
@@ -71,7 +82,7 @@ describe("Middleware: storeCredentials", () => {
         const sc = storeCredentials(storeSuccess);
         sc(creds as CredentialsObject, (err: any) => {
             expect(saveSuccessFake.callCount).toEqual(1);
-            expect(saveSuccessFake.firstArg).toEqual(creds.actor.id);
+            expect(saveSuccessFake.firstArg).toEqual(expectedKey);
             expect(err).toEqual(creds);
             done();
         });
@@ -81,7 +92,7 @@ describe("Middleware: storeCredentials", () => {
         const sc = storeCredentials(storeError);
         sc(creds as CredentialsObject, (err: any) => {
             expect(saveErrorFake.callCount).toEqual(1);
-            expect(saveErrorFake.firstArg).toEqual(creds.actor.id);
+            expect(saveErrorFake.firstArg).toEqual(expectedKey);
             expect(err.toString()).toEqual("Error: some error");
             done();
         });

--- a/packages/server/src/middleware/store-credentials.ts
+++ b/packages/server/src/middleware/store-credentials.ts
@@ -1,5 +1,9 @@
-import type { CredentialsStoreInterface } from "@sockethub/data-layer";
+import {
+    buildCredentialsKey,
+    type CredentialsStoreInterface,
+} from "@sockethub/data-layer";
 import type { ActivityStream, CredentialsObject } from "@sockethub/schemas";
+import { resolvePlatformId } from "@sockethub/schemas";
 import { toError } from "@sockethub/util/error";
 
 import type { MiddlewareChainInterface } from "../middleware.js";
@@ -11,8 +15,15 @@ export default function storeCredentials(store: CredentialsStoreInterface) {
     ) => {
         const credentials = creds as CredentialsObject;
         try {
+            // Scope by platform: the same visible actor id can exist on more
+            // than one platform, and keyed by actor alone the second save
+            // silently overwrote the first.
+            const key = buildCredentialsKey(
+                resolvePlatformId(creds) ?? "",
+                credentials.actor.id,
+            );
             store
-                .save(credentials.actor.id, credentials)
+                .save(key, credentials)
                 .then(() => done(creds))
                 .catch((err) => done(toError(err)));
         } catch (err) {

--- a/packages/server/src/platform-instance.test.ts
+++ b/packages/server/src/platform-instance.test.ts
@@ -482,6 +482,52 @@ describe("PlatformInstance", () => {
                 sandbox.assert.calledWith(pi.updateIdentifier, { foo: "bar" });
             });
 
+            test("message events from platform thread are routed based on command: sessionUnauthorized", async () => {
+                pi.registerSession("good session", "203.0.113.1");
+                pi.registerSession("bad session", "203.0.113.2");
+
+                await pi.handleProcessMessage([
+                    "sessionUnauthorized",
+                    undefined,
+                    "bad session",
+                ]);
+
+                expect(pi.sessions.has("bad session")).toEqual(false);
+                expect(pi.sessionIps.has("bad session")).toEqual(false);
+                expect(pi.sessions.has("good session")).toEqual(true);
+                // control message, not client traffic
+                sandbox.assert.notCalled(pi.sendToClient);
+            });
+
+            test("a deregistered session no longer receives platform messages", async () => {
+                pi.registerSession("stays");
+                pi.registerSession("goes");
+                await pi.handleProcessMessage([
+                    "sessionUnauthorized",
+                    undefined,
+                    "goes",
+                ]);
+
+                await pi.handleProcessMessage(["blah", { foo: "bar" }]);
+
+                sandbox.assert.calledWith(pi.sendToClient, "stays", {
+                    foo: "bar",
+                });
+                sandbox.assert.neverCalledWith(pi.sendToClient, "goes", {
+                    foo: "bar",
+                });
+            });
+
+            test("deregistering an unknown session is a no-op", async () => {
+                pi.registerSession("stays");
+                await pi.handleProcessMessage([
+                    "sessionUnauthorized",
+                    undefined,
+                    "never registered",
+                ]);
+                expect(pi.sessions.has("stays")).toEqual(true);
+            });
+
             test("message events from platform thread are delivered to every registered session", async () => {
                 pi.sessions.add("session one");
                 pi.sessions.add("session two");

--- a/packages/server/src/platform-instance.ts
+++ b/packages/server/src/platform-instance.ts
@@ -42,6 +42,7 @@ type EnvFormat = {
 
 type MessageFromPlatform =
     | ["updateActor", ActivityStream | undefined, string]
+    | ["sessionUnauthorized", undefined, string]
     | ["error", string]
     | ["heartbeat", ActivityStream]
     | [string, ActivityStream, string?];
@@ -344,6 +345,19 @@ export default class PlatformInstance {
     }
 
     /**
+     * Stop delivering this instance's messages to a session. Used when the
+     * session loses (or never had) the right to be attached; the janitor
+     * separately drops sessions whose sockets have gone away.
+     */
+    public deregisterSession(sessionId: string) {
+        if (!this.sessions.delete(sessionId)) {
+            return;
+        }
+        this.sessionIps.delete(sessionId);
+        this.log.debug(`deregistered session ${sessionId}`);
+    }
+
+    /**
      * Sends a message to client (user), can be registered with an event emitted from the platform
      * process.
      * @param sessionId ID of the socket connection to send the message to
@@ -583,6 +597,13 @@ export default class PlatformInstance {
             // Internal control message: platform process is reporting a new actor id.
             // We need to update the key to the store in order to find it in the future.
             this.updateIdentifier(third);
+        } else if (first === "sessionUnauthorized") {
+            // The child could not validate this session's credentials against
+            // the running connection. Drop it so the fan-out in this method
+            // (and broadcastToSharedPeers) stops delivering the connection's
+            // traffic to it. A session that later presents valid credentials
+            // re-registers through ProcessManager on its next message.
+            this.deregisterSession(third);
         } else if (first === "error") {
             // Error messages travel over IPC as plain objects; normalize to a string.
             let normalizedError: string;

--- a/packages/server/src/platform.ts
+++ b/packages/server/src/platform.ts
@@ -12,6 +12,7 @@
 
 import type { JobHandler } from "@sockethub/data-layer";
 import {
+    buildCredentialsKey,
     CredentialsStore,
     type JobDataDecrypted,
     JobWorker,
@@ -183,7 +184,7 @@ async function startPlatformProcess() {
     /**
      * Safely send message to parent process, handling IPC channel closure
      */
-    function safeProcessSend(message: [string, unknown]) {
+    function safeProcessSend(message: [string, unknown, unknown?]) {
         if (process.send && process.connected) {
             try {
                 process.send(message);
@@ -396,7 +397,10 @@ async function startPlatformProcess() {
                         : undefined;
 
                     credentialStore
-                        .get(job.msg.actor.id, credentialsHash)
+                        .get(
+                            buildCredentialsKey(platformName, job.msg.actor.id),
+                            credentialsHash,
+                        )
                         .then((credentials) => {
                             // Create wrapper callback that updates credentialsHash after successful call
                             const wrappedCallback: PlatformCallback = (
@@ -461,7 +465,18 @@ async function startPlatformProcess() {
                              * - Error is reported to Sentry for monitoring authentication issues.
                              */
                             if (platform.isInitialized()) {
-                                // Platform already running - reject job only, preserve platform instance
+                                // Platform already running - reject job only, preserve platform instance.
+                                // This session has failed to prove it holds
+                                // credentials for this connection, so it must
+                                // also stop receiving the connection's traffic:
+                                // rejecting the job alone left it registered
+                                // (and subscribed to the fan-out) until the
+                                // janitor noticed its socket had gone.
+                                safeProcessSend([
+                                    "sessionUnauthorized",
+                                    undefined,
+                                    job.sessionId,
+                                ]);
                                 doneCallback(toError(err), null);
                             } else {
                                 // Platform not initialized - terminate platform process


### PR DESCRIPTION
Three related session/credential hygiene issues found while reviewing #1131. Each is independent of the ID-format discussion there, and independent of #1222 (branched from `master`, not stacked).

## 1. Detach on credential failure

When the child rejected a credentialed job on an already-initialized platform, only that job failed. The session stayed in `platformInstance.sessions` — and kept receiving the connection's traffic through the fan-out in `handleProcessMessage` and `broadcastToSharedPeers` — until the janitor noticed its socket had gone. `janitor.ts:62` held the only `sessions.delete` call site.

The child now emits a `sessionUnauthorized` control message naming the session, and `PlatformInstance.deregisterSession()` drops it.

Signalling explicitly, rather than inferring from job failure, is deliberate: a `connect` can also fail because the remote server is unreachable, and detaching a healthy session on a network blip would silently stop its messages. Only credential-store rejections trigger it. A session that later presents valid credentials re-registers through `ProcessManager` on its next message.

## 2. Uniform session-share rejections

`credentials not found for X`, `invalid credentials for X` and `username already in use` were three distinguishable answers to an attach attempt, so a caller probing guessed actor ids learned *why* it was refused. All attach failures now return a single `SESSION_SHARE_DENIED` message.

Error **classes** are unchanged, so behaviour that depends on them is preserved:
- same-IP anonymous reconnect still keys off `CredentialsNotShareableError`
- a missing-credentials failure is deliberately still a plain `Error`, so it stays *ineligible* for that reconnect path

Detailed messages are kept for the platform's own credential reads, where the caller already owns the credentials being described.

**This narrows but does not close presence disclosure.** Accept-vs-reject is inherently observable — an attacker can still infer that *some* session holds a given actor id. Only the reason is now hidden. Fully closing it would mean rejecting unknown actors too, which isn't viable.

## 3. Platform-scoped credential keys

Credentials were keyed by `actor.id` alone with no platform component, so one session holding credentials for the same visible id on two platforms (an `alice@example.org` that is both an IRC nick and an XMPP JID) had the second save silently overwrite the first.

New `buildCredentialsKey(platform, actor)` is used by `store-credentials`, `credential-check`, and the child's per-job read. The parent resolves the platform from `@context`, the child from the platform name it was forked with — verified to be the same string (`PlatformInstance` forks with `params.platform`, which is `resolvePlatformId(msg)`).

The client had the same bug in its reconnect replay maps (`events.credentials`, `connect`, `join`), so `SockethubClient.getKey()` is scoped by platform too.

## Tests

- `queue-id.test.ts` — the same actor id on two platforms yields distinct keys
- `credentials-store.test.ts` — all four attach-rejection paths return the identical message; detailed messages survive for non-share reads
- `platform-instance.test.ts` — `sessionUnauthorized` deregisters; a deregistered session stops receiving platform messages; unknown session is a no-op
- `store-credentials.test.ts` / `credential-check.test.ts` — updated for the platform-scoped key
- `sockethub-client.test.ts` — credentials for one actor on two platforms no longer collide

`bun test` — 826 pass, 0 fail. `biome check` clean, `markdownlint` clean on changed docs, `bun run build` clean.

## Notes for review

- **Behaviour change:** the client-visible error for a refused share is now `unable to attach session for this actor`. `docs/client-guide.md`, `docs/configuration.md` and `packages/server/README.md` are updated.
- **Credential key shape changed.** Keys are per-session and TTL'd, so nothing needs migrating, but a server restart mid-session invalidates in-flight credentials (they are re-sent on reconnect).
- **Overlaps #1222** in `credentials-store.ts` and `credential-check.ts`. Whichever lands second will need a small rebase; the changes are complementary (that PR adds the exact-match comparison, this one changes what the rejection *says* and how the key is built).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Credentials are now stored separately across platforms, preventing accounts with matching identifiers from overwriting one another.
  * Unauthorized sessions are automatically disconnected and prevented from receiving further platform messages.
  * Session-sharing failures now use a consistent, privacy-preserving error message without revealing the specific cause.

* **Documentation**
  * Updated client, server, and configuration guidance to reflect credential-sharing requirements and standardized rejection messages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->