### PR TITLE
fix(server): detach a session when the platform rejects its credentials

### DIFF
--- a/packages/data-layer/integration/redis.integration.ts
+++ b/packages/data-layer/integration/redis.integration.ts
@@ -138,12 +138,16 @@ describe("connect and disconnect", () => {
     ]) {
         describe(o.name, () => {
             let i: JobInstance;
-            beforeEach(() => {
-                i = new o.class("testid", "sessionid", testSecret, {
+            beforeEach(async () => {
+                i = new o.class("lifecycle-testid", "sessionid", testSecret, {
                     url: REDIS_URL,
                 }) as unknown as JobInstance;
                 if (o.name === "worker") {
                     i.init();
+                    // BullMQ opens worker connections asynchronously. Let them
+                    // settle before the test tears the worker down; otherwise
+                    // Bun can report late socket-close errors in the next test.
+                    await new Promise((resolve) => setTimeout(resolve, 100));
                 }
             });
 

--- a/packages/server/src/platform-instance.test.ts
+++ b/packages/server/src/platform-instance.test.ts
@@ -526,11 +526,16 @@ describe("PlatformInstance", () => {
                 pi.registerSession("good session", "203.0.113.1");
                 pi.registerSession("bad session", "203.0.113.2");
 
-                await pi.handleProcessMessage([
-                    "sessionUnauthorized",
-                    undefined,
-                    "bad session",
-                ]);
+                // Exercise the JSON serialization used by child_process IPC:
+                // an empty tuple slot arrives as null, not undefined.
+                const ipcMessage = JSON.parse(
+                    JSON.stringify([
+                        "sessionUnauthorized",
+                        null,
+                        "bad session",
+                    ]),
+                );
+                await pi.handleProcessMessage(ipcMessage);
 
                 expect(pi.sessions.has("bad session")).toEqual(false);
                 expect(pi.sessionIps.has("bad session")).toEqual(false);
@@ -544,7 +549,7 @@ describe("PlatformInstance", () => {
                 pi.registerSession("goes");
                 await pi.handleProcessMessage([
                     "sessionUnauthorized",
-                    undefined,
+                    null,
                     "goes",
                 ]);
 
@@ -584,6 +589,18 @@ describe("PlatformInstance", () => {
                 expect(pi.sessions.has("stays")).toEqual(true);
                 expect(pi.sessionIps.get("stays")).toEqual("203.0.113.1");
                 sandbox.assert.calledTwice(errorSpy);
+                sandbox.assert.calledWith(
+                    errorSpy,
+                    sinon.match("platform=a platform name"),
+                );
+                sandbox.assert.calledWith(
+                    errorSpy,
+                    sinon.match("action=sessionUnauthorized"),
+                );
+                sandbox.assert.calledWith(
+                    errorSpy,
+                    sinon.match('sessionId="stays"'),
+                );
             });
 
             it("deregistering an unknown session is a no-op", async () => {

--- a/packages/server/src/platform-instance.test.ts
+++ b/packages/server/src/platform-instance.test.ts
@@ -548,14 +548,42 @@ describe("PlatformInstance", () => {
                     "goes",
                 ]);
 
-                await pi.handleProcessMessage(["blah", { foo: "bar" }]);
+                const message = {
+                    "@context": buildCanonicalContext(
+                        INTERNAL_PLATFORM_CONTEXT_URL,
+                    ),
+                    type: "message",
+                    actor: { id: "platform", type: "service" },
+                    object: { type: "message", content: "hello" },
+                };
+                await pi.handleProcessMessage(["message", message]);
 
-                sandbox.assert.calledWith(pi.sendToClient, "stays", {
-                    foo: "bar",
-                });
-                sandbox.assert.neverCalledWith(pi.sendToClient, "goes", {
-                    foo: "bar",
-                });
+                sandbox.assert.calledWith(pi.sendToClient, "stays", message);
+                sandbox.assert.neverCalledWith(
+                    pi.sendToClient,
+                    "goes",
+                    message,
+                );
+            });
+
+            it("malformed sessionUnauthorized messages leave sessions unchanged", async () => {
+                const errorSpy = sandbox.spy(pi.log, "error");
+                pi.registerSession("stays", "203.0.113.1");
+
+                await pi.handleProcessMessage([
+                    "sessionUnauthorized",
+                    { unexpected: true },
+                    "stays",
+                ]);
+                await pi.handleProcessMessage([
+                    "sessionUnauthorized",
+                    undefined,
+                    42,
+                ]);
+
+                expect(pi.sessions.has("stays")).toEqual(true);
+                expect(pi.sessionIps.get("stays")).toEqual("203.0.113.1");
+                sandbox.assert.calledTwice(errorSpy);
             });
 
             it("deregistering an unknown session is a no-op", async () => {

--- a/packages/server/src/platform-instance.test.ts
+++ b/packages/server/src/platform-instance.test.ts
@@ -522,6 +522,52 @@ describe("PlatformInstance", () => {
                 sandbox.assert.notCalled(pi.sendToClient);
             });
 
+            it("message events from platform thread are routed based on command: sessionUnauthorized", async () => {
+                pi.registerSession("good session", "203.0.113.1");
+                pi.registerSession("bad session", "203.0.113.2");
+
+                await pi.handleProcessMessage([
+                    "sessionUnauthorized",
+                    undefined,
+                    "bad session",
+                ]);
+
+                expect(pi.sessions.has("bad session")).toEqual(false);
+                expect(pi.sessionIps.has("bad session")).toEqual(false);
+                expect(pi.sessions.has("good session")).toEqual(true);
+                // control message, not client traffic
+                sandbox.assert.notCalled(pi.sendToClient);
+            });
+
+            it("a deregistered session no longer receives platform messages", async () => {
+                pi.registerSession("stays");
+                pi.registerSession("goes");
+                await pi.handleProcessMessage([
+                    "sessionUnauthorized",
+                    undefined,
+                    "goes",
+                ]);
+
+                await pi.handleProcessMessage(["blah", { foo: "bar" }]);
+
+                sandbox.assert.calledWith(pi.sendToClient, "stays", {
+                    foo: "bar",
+                });
+                sandbox.assert.neverCalledWith(pi.sendToClient, "goes", {
+                    foo: "bar",
+                });
+            });
+
+            it("deregistering an unknown session is a no-op", async () => {
+                pi.registerSession("stays");
+                await pi.handleProcessMessage([
+                    "sessionUnauthorized",
+                    undefined,
+                    "never registered",
+                ]);
+                expect(pi.sessions.has("stays")).toEqual(true);
+            });
+
             test("message events from platform thread are delivered to every registered session", async () => {
                 pi.sessions.add("session one");
                 pi.sessions.add("session two");

--- a/packages/server/src/platform-instance.ts
+++ b/packages/server/src/platform-instance.ts
@@ -661,6 +661,16 @@ export default class PlatformInstance {
             // (or refuse) additional sessions attaching to this instance.
             this.setCredentialsHash(third);
         } else if (first === "sessionUnauthorized") {
+            if (
+                typeof third !== "string" ||
+                third.length === 0 ||
+                typeof second !== "undefined"
+            ) {
+                this.log.error(
+                    "ignoring malformed sessionUnauthorized control message",
+                );
+                return;
+            }
             // The child could not validate this session's credentials against
             // the running connection. Drop it so the fan-out in this method
             // (and broadcastToSharedPeers) stops delivering the connection's

--- a/packages/server/src/platform-instance.ts
+++ b/packages/server/src/platform-instance.ts
@@ -43,6 +43,7 @@ type EnvFormat = {
 type MessageFromPlatform =
     | ["updateActor", ActivityStream | undefined, string]
     | ["credentialsHash", undefined, string]
+    | ["sessionUnauthorized", undefined, string]
     | ["error", string]
     | ["heartbeat", ActivityStream]
     | [string, ActivityStream, string?];
@@ -402,6 +403,19 @@ export default class PlatformInstance {
     }
 
     /**
+     * Stop delivering this instance's messages to a session. Used when the
+     * session loses (or never had) the right to be attached; the janitor
+     * separately drops sessions whose sockets have gone away.
+     */
+    public deregisterSession(sessionId: string) {
+        if (!this.sessions.delete(sessionId)) {
+            return;
+        }
+        this.sessionIps.delete(sessionId);
+        this.log.debug(`deregistered session ${sessionId}`);
+    }
+
+    /**
      * Sends a message to client (user), can be registered with an event emitted from the platform
      * process.
      * @param sessionId ID of the socket connection to send the message to
@@ -646,6 +660,13 @@ export default class PlatformInstance {
             // its remote connection is bound to, so the parent can authorize
             // (or refuse) additional sessions attaching to this instance.
             this.setCredentialsHash(third);
+        } else if (first === "sessionUnauthorized") {
+            // The child could not validate this session's credentials against
+            // the running connection. Drop it so the fan-out in this method
+            // (and broadcastToSharedPeers) stops delivering the connection's
+            // traffic to it. A session that later presents valid credentials
+            // re-registers through ProcessManager on its next message.
+            this.deregisterSession(third);
         } else if (first === "error") {
             // Error messages travel over IPC as plain objects; normalize to a string.
             let normalizedError: string;

--- a/packages/server/src/platform-instance.ts
+++ b/packages/server/src/platform-instance.ts
@@ -41,9 +41,9 @@ type EnvFormat = {
 };
 
 type MessageFromPlatform =
-    | ["updateActor", ActivityStream | undefined, string]
-    | ["credentialsHash", undefined, string]
-    | ["sessionUnauthorized", undefined, string]
+    | ["updateActor", ActivityStream | null | undefined, string]
+    | ["credentialsHash", null | undefined, string]
+    | ["sessionUnauthorized", null | undefined, string]
     | ["error", string]
     | ["heartbeat", ActivityStream]
     | [string, ActivityStream, string?];
@@ -664,10 +664,14 @@ export default class PlatformInstance {
             if (
                 typeof third !== "string" ||
                 third.length === 0 ||
-                typeof second !== "undefined"
+                (typeof second !== "undefined" && second !== null)
             ) {
+                const sessionContext =
+                    typeof third === "string"
+                        ? ` sessionId=${JSON.stringify(third)}`
+                        : "";
                 this.log.error(
-                    "ignoring malformed sessionUnauthorized control message",
+                    `ignoring malformed platform IPC control message platform=${this.name} action=sessionUnauthorized${sessionContext}`,
                 );
                 return;
             }

--- a/packages/server/src/platform.ts
+++ b/packages/server/src/platform.ts
@@ -183,7 +183,7 @@ async function startPlatformProcess() {
     /**
      * Safely send message to parent process, handling IPC channel closure
      */
-    function safeProcessSend(message: [string, unknown]) {
+    function safeProcessSend(message: [string, unknown, unknown?]) {
         if (process.send && process.connected) {
             try {
                 process.send(message);
@@ -464,7 +464,18 @@ async function startPlatformProcess() {
                              * - Error is reported to Sentry for monitoring authentication issues.
                              */
                             if (platform.isInitialized()) {
-                                // Platform already running - reject job only, preserve platform instance
+                                // Platform already running - reject job only, preserve platform instance.
+                                // This session has failed to prove it holds
+                                // credentials for this connection, so it must
+                                // also stop receiving the connection's traffic:
+                                // rejecting the job alone left it registered
+                                // (and subscribed to the fan-out) until the
+                                // janitor noticed its socket had gone.
+                                safeProcessSend([
+                                    "sessionUnauthorized",
+                                    undefined,
+                                    job.sessionId,
+                                ]);
                                 doneCallback(toError(err), null);
                             } else {
                                 // Platform not initialized - terminate platform process

--- a/packages/server/src/platform.ts
+++ b/packages/server/src/platform.ts
@@ -473,7 +473,7 @@ async function startPlatformProcess() {
                                 // janitor noticed its socket had gone.
                                 safeProcessSend([
                                     "sessionUnauthorized",
-                                    undefined,
+                                    null,
                                     job.sessionId,
                                 ]);
                                 doneCallback(toError(err), null);


### PR DESCRIPTION
One of three followups split out of the #1131 review. Independent of the ID-format discussion, and independent of #1222.

## Problem

When the child rejected a credentialed job on an already-initialized platform, only that job failed. The session stayed in `platformInstance.sessions` — and kept receiving the connection's traffic through the fan-out in `handleProcessMessage` and `broadcastToSharedPeers` — until the janitor noticed its socket had gone. `janitor.ts:62` held the only `sessions.delete` call site.

## Fix

The child emits a `sessionUnauthorized` control message naming the session, and `PlatformInstance.deregisterSession()` drops it.

Signalling explicitly, rather than inferring from job failure, is deliberate: a `connect` can also fail because the remote server is unreachable, and detaching a healthy session on a network blip would silently stop its messages. Only credential-store rejections trigger it. A session that later presents valid credentials re-registers through `ProcessManager` on its next message.

## Tests

- `sessionUnauthorized` deregisters the named session and its recorded IP, leaving others attached
- a deregistered session stops receiving platform messages
- deregistering an unknown session is a no-op

`bun test` 819 pass / 0 fail. `biome check` and build clean.

## Related

- #1222 — verify credentials match before attaching (gates the attach; this gates what happens after)
- #1225, #1226 — the other two followups

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Unauthorized sessions are now automatically removed when credential validation fails.
  * Associated IP tracking is cleared to prevent stale session data.
  * Remaining authorized sessions continue operating normally.
  * Deregistered sessions no longer receive platform messages.
  * Unknown-session deregistration is handled safely without disrupting processing.
  * Invalid authorization messages are safely ignored and logged without interrupting message processing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->