### PR TITLE
fix(data-layer): return one uniform error for every refused session attach

### DIFF
--- a/docs/client-guide.md
+++ b/docs/client-guide.md
@@ -254,7 +254,7 @@ The rejected request returns an ActivityStream response with an `error`:
   "type": "connect",
   "actor": { "id": "mynick@irc.libera.chat", "type": "person", "name": "mynick" },
   "id": "1",
-  "error": "username already in use"
+  "error": "unable to attach session for this actor"
 }
 ```
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -246,8 +246,9 @@ When another socket is already attached to that actor:
 
 - Session-share validation runs in the data layer.
 - Credentials with a non-empty `password` are considered shareable.
-- Credentials without a non-empty `password` are not shareable and return
-  `username already in use`.
+- Credentials without a non-empty `password` are not shareable.
+- Every rejection returns the same message, `unable to attach session for this
+  actor`, so the reason is not disclosed to the caller.
 
 This prevents anonymous/username-only accounts from accidentally sharing the
 same platform thread across different users.

--- a/integration/browser/multiclient.integration.js
+++ b/integration/browser/multiclient.integration.js
@@ -431,7 +431,9 @@ describe(`Multi-Client XMPP Integration Tests at ${config.sockethub.url}`, () =>
             } catch (error) {
                 // Connection should fail
                 expect(error.message).to.include("Connect failed");
-                expect(error.message).to.include("invalid credentials");
+                expect(error.message).to.include(
+                    "unable to attach session for this actor",
+                );
             } finally {
                 // Clean up
                 newSockethubClient.socket.disconnect();

--- a/packages/data-layer/integration/redis.integration.ts
+++ b/packages/data-layer/integration/redis.integration.ts
@@ -5,6 +5,7 @@ import {
     JobQueue,
     JobWorker,
     redisCheck,
+    SESSION_SHARE_DENIED,
 } from "@sockethub/data-layer";
 import {
     type ActivityStream,
@@ -100,7 +101,7 @@ describe("CredentialsStore", () => {
 
         await expect(
             store.get(actor, undefined, { validateSessionShare: true }),
-        ).rejects.toThrow("username already in use");
+        ).rejects.toThrow(SESSION_SHARE_DENIED);
     });
 
     it("isolates credentials by session", async () => {

--- a/packages/data-layer/src/credentials-store.test.ts
+++ b/packages/data-layer/src/credentials-store.test.ts
@@ -8,6 +8,7 @@ import {
     CredentialsNotShareableError,
     CredentialsStore,
     purgeCredentialsStoreKeys,
+    SESSION_SHARE_DENIED,
 } from "./credentials-store";
 
 const mockLogger: Logger = {
@@ -230,9 +231,7 @@ describe("CredentialsStore", () => {
                     // Reported as "not shareable" rather than "mismatch" so the
                     // same-IP anonymous reconnect path stays reachable.
                     expect(err).toBeInstanceOf(CredentialsNotShareableError);
-                    expect(err.toString()).toEqual(
-                        "Error: username already in use",
-                    );
+                    expect(err.message).toEqual(SESSION_SHARE_DENIED);
                 }
             });
 
@@ -248,9 +247,7 @@ describe("CredentialsStore", () => {
                     expect(false).toEqual(true);
                 } catch (err) {
                     expect(err).toBeInstanceOf(CredentialsMismatchError);
-                    expect(err.toString()).toEqual(
-                        "Error: invalid credentials for an actor",
-                    );
+                    expect(err.message).toEqual(SESSION_SHARE_DENIED);
                 }
             });
 
@@ -270,6 +267,63 @@ describe("CredentialsStore", () => {
             });
         });
 
+        // A caller probing guessed actor ids must not learn *why* it was
+        // turned away — every attach failure reports the same string.
+        describe("session-share rejections are indistinguishable", () => {
+            it("uses the generic message when no credentials are stored", async () => {
+                MockStoreGet.returns(undefined);
+                try {
+                    await credentialsStore.get("an actor", undefined, {
+                        validateSessionShare: true,
+                    });
+                    expect(false).toEqual(true);
+                } catch (err) {
+                    expect(err.message).toEqual(SESSION_SHARE_DENIED);
+                    // must NOT be "not shareable": only that class is eligible
+                    // for the same-IP anonymous reconnect escape hatch
+                    expect(err).not.toBeInstanceOf(CredentialsNotShareableError);
+                }
+            });
+
+            it("uses the generic message when the credential object is empty", async () => {
+                MockStoreGet.returns({ object: {} });
+                try {
+                    await credentialsStore.get("an actor", undefined, {
+                        validateSessionShare: true,
+                    });
+                    expect(false).toEqual(true);
+                } catch (err) {
+                    expect(err.message).toEqual(SESSION_SHARE_DENIED);
+                }
+            });
+
+            it("uses the generic message when no secret is present", async () => {
+                MockStoreGet.returns({ object: { type: "credentials" } });
+                try {
+                    await credentialsStore.get("an actor", undefined, {
+                        validateSessionShare: true,
+                    });
+                    expect(false).toEqual(true);
+                } catch (err) {
+                    expect(err.message).toEqual(SESSION_SHARE_DENIED);
+                }
+            });
+
+            it("keeps detailed messages for the platform's own reads", async () => {
+                // validateSessionShare is not set: the caller already owns
+                // these credentials, so there is nothing to disclose.
+                MockStoreGet.returns(undefined);
+                try {
+                    await credentialsStore.get("an actor");
+                    expect(false).toEqual(true);
+                } catch (err) {
+                    expect(err.message).toEqual(
+                        "credentials not found for an actor",
+                    );
+                }
+            });
+        });
+
         it("rejects credentials without password or token for session-share validation", async () => {
             MockStoreGet.returns({
                 object: { type: "credentials" },
@@ -280,7 +334,7 @@ describe("CredentialsStore", () => {
                 });
                 expect(false).toEqual(true);
             } catch (err) {
-                expect(err.toString()).toEqual("Error: username already in use");
+                expect(err.toString()).toEqual(`Error: ${SESSION_SHARE_DENIED}`);
                 expect(err).toBeInstanceOf(CredentialsNotShareableError);
             }
             sinon.assert.calledOnce(MockStoreGet);

--- a/packages/data-layer/src/credentials-store.ts
+++ b/packages/data-layer/src/credentials-store.ts
@@ -159,6 +159,13 @@ export class CredentialsMismatchError extends Error {
     }
 }
 
+/**
+ * The single message returned for every failed attach to an existing
+ * persistent platform instance, whatever the underlying reason. Callers still
+ * distinguish the cases by error *class* internally; clients see one string.
+ */
+export const SESSION_SHARE_DENIED = "unable to attach session for this actor";
+
 export class CredentialsNotShareableError extends Error {
     constructor(message: string) {
         super(message);
@@ -275,9 +282,21 @@ export class CredentialsStore implements CredentialsStoreInterface {
         if (!this.store.isConnected) {
             await this.store.connect();
         }
+        // Attach attempts get one uniform message for every rejection reason.
+        // Distinct texts ("not found" / "invalid" / "already in use") let a
+        // caller probing guessed actor ids learn *why* it was turned away.
+        // Detailed messages are kept for the platform's own credential reads,
+        // where the caller already owns the credentials being described.
+        const share = options.validateSessionShare === true;
+        const denied = (detail: string) =>
+            share ? SESSION_SHARE_DENIED : detail;
+
         const credentials: CredentialsObject = await this.store.get(actor);
         if (!credentials) {
-            throw new Error(`credentials not found for ${actor}`);
+            // Deliberately NOT a CredentialsNotShareableError: only that class
+            // is eligible for the same-IP anonymous reconnect escape hatch,
+            // and a session with no stored credentials at all must not be.
+            throw new Error(denied(`credentials not found for ${actor}`));
         }
         if (
             !credentials.object ||
@@ -286,7 +305,7 @@ export class CredentialsStore implements CredentialsStoreInterface {
             Object.keys(credentials.object).length === 0
         ) {
             throw new CredentialsMismatchError(
-                `invalid credentials for ${actor}`,
+                denied(`invalid credentials for ${actor}`),
             );
         }
 
@@ -304,9 +323,7 @@ export class CredentialsStore implements CredentialsStoreInterface {
             // Credentials must include a non-empty secret before an additional
             // session can attach to the same persistent actor instance.
             if (!hasPassword && !hasToken) {
-                throw new CredentialsNotShareableError(
-                    "username already in use",
-                );
+                throw new CredentialsNotShareableError(SESSION_SHARE_DENIED);
             }
         }
 
@@ -315,7 +332,7 @@ export class CredentialsStore implements CredentialsStoreInterface {
             // "same actor, different credentials" reuse attempts.
             if (credentialsHash !== this.objectHash(credentials.object)) {
                 throw new CredentialsMismatchError(
-                    `invalid credentials for ${actor}`,
+                    denied(`invalid credentials for ${actor}`),
                 );
             }
         }

--- a/packages/data-layer/src/index.ts
+++ b/packages/data-layer/src/index.ts
@@ -15,6 +15,7 @@ import {
     resetSharedCredentialsRedisConnection,
     resetSharedIdempotencyRedisConnection,
     resetSharedRateLimitRedisConnection,
+    SESSION_SHARE_DENIED,
     verifySecureStore,
 } from "./credentials-store.js";
 import {
@@ -72,4 +73,5 @@ export {
     resetSharedIdempotencyRedisConnection,
     resetSharedRateLimitRedisConnection,
     resetSharedRedisConnection,
+    SESSION_SHARE_DENIED,
 };

--- a/packages/server/README.md
+++ b/packages/server/README.md
@@ -31,7 +31,11 @@ Session sharing rules:
 - Share is allowed only when credentials include a non-empty `password` or
   `token` field (e.g. IRC OAuth). Credential objects with neither are treated
   as anonymous and cannot be shared across connections.
-- Username-only/anonymous credentials are rejected with `username already in use`.
+- Every rejected share attempt returns the same message,
+  `unable to attach session for this actor`, whatever the reason (no
+  credentials stored, anonymous credentials, or credentials that do not match
+  the ones that opened the connection). The reason is deliberately not
+  disclosed, so a caller cannot probe guessed actor ids for detail.
 
 Reconnect exception for anonymous credentials:
 

--- a/packages/server/src/middleware/credential-check.test.ts
+++ b/packages/server/src/middleware/credential-check.test.ts
@@ -12,6 +12,7 @@ import {
     CredentialsNotShareableError,
     type CredentialsStoreInterface,
     type CredentialsValidationOptions,
+    SESSION_SHARE_DENIED,
 } from "@sockethub/data-layer";
 import {
     type ActivityStream,
@@ -346,7 +347,7 @@ describe("Middleware: credentialCheck", () => {
 
     test("allows anonymous reconnect when prior session is stale and IP matches", async () => {
         store.get = async () =>
-            Promise.reject(new CredentialsNotShareableError("username already in use"));
+            Promise.reject(new CredentialsNotShareableError(SESSION_SHARE_DENIED));
         platformInstances.set(
             platformKey,
             {
@@ -369,7 +370,7 @@ describe("Middleware: credentialCheck", () => {
 
     test("blocks anonymous reconnect when prior session IP differs", async () => {
         store.get = async () =>
-            Promise.reject(new CredentialsNotShareableError("username already in use"));
+            Promise.reject(new CredentialsNotShareableError(SESSION_SHARE_DENIED));
         platformInstances.set(
             platformKey,
             {
@@ -388,12 +389,12 @@ describe("Middleware: credentialCheck", () => {
         });
 
         expect(result instanceof Error).toEqual(true);
-        expect(result.toString()).toEqual("Error: username already in use");
+        expect(result.toString()).toEqual(`Error: ${SESSION_SHARE_DENIED}`);
     });
 
     test("blocks anonymous reconnect when prior session is still active", async () => {
         store.get = async () =>
-            Promise.reject(new CredentialsNotShareableError("username already in use"));
+            Promise.reject(new CredentialsNotShareableError(SESSION_SHARE_DENIED));
         platformInstances.set(
             platformKey,
             {
@@ -412,6 +413,6 @@ describe("Middleware: credentialCheck", () => {
         });
 
         expect(result instanceof Error).toEqual(true);
-        expect(result.toString()).toEqual("Error: username already in use");
+        expect(result.toString()).toEqual(`Error: ${SESSION_SHARE_DENIED}`);
     });
 });

--- a/packages/server/src/middleware/credential-check.test.ts
+++ b/packages/server/src/middleware/credential-check.test.ts
@@ -233,6 +233,9 @@ describe("Middleware: credentialCheck", () => {
             );
 
             expect(result instanceof Error).toEqual(true);
+            expect(result.toString()).toEqual(
+                `Error: ${SESSION_SHARE_DENIED}`,
+            );
         });
 
         it("admits a concurrent connect once the hash arrives and matches", async () => {

--- a/packages/server/src/middleware/credential-check.ts
+++ b/packages/server/src/middleware/credential-check.ts
@@ -105,9 +105,7 @@ export default function credentialCheck(
                 );
                 next(
                     toError(
-                        new CredentialsNotShareableError(
-                            "username already in use",
-                        ),
+                        new CredentialsNotShareableError(SESSION_SHARE_DENIED),
                     ),
                 );
                 return;

--- a/packages/server/src/middleware/credential-check.ts
+++ b/packages/server/src/middleware/credential-check.ts
@@ -2,6 +2,7 @@ import {
     CredentialsMismatchError,
     CredentialsNotShareableError,
     type CredentialsStoreInterface,
+    SESSION_SHARE_DENIED,
 } from "@sockethub/data-layer";
 import { createLogger } from "@sockethub/logger";
 import { type ActivityStream, resolvePlatformId } from "@sockethub/schemas";
@@ -167,7 +168,8 @@ function isExpectedCredentialValidationError(err: unknown): boolean {
     }
     return (
         err instanceof Error &&
-        err.message.startsWith("credentials not found for ")
+        (err.message.startsWith("credentials not found for ") ||
+            err.message === SESSION_SHARE_DENIED)
     );
 }
 


### PR DESCRIPTION
One of three followups split out of the #1131 review. Independent of the ID-format discussion, and independent of #1222.

## Problem

`credentials not found for X`, `invalid credentials for X` and `username already in use` were three distinguishable answers to an attach attempt, so a caller probing guessed actor ids learned *why* it was refused.

## Fix

All attach failures return a single `SESSION_SHARE_DENIED` message.

Error **classes** are unchanged, so behaviour that keys off them is preserved:
- same-IP anonymous reconnect still keys off `CredentialsNotShareableError`
- a missing-credentials failure is deliberately still a plain `Error`, so it stays *ineligible* for that reconnect path

Detailed messages are kept for the platform's own credential reads, where the caller already owns the credentials being described.

## Scope — this narrows disclosure, it does not close it

Accept-vs-reject is inherently observable: an attacker can still infer that *some* session holds a given actor id. Only the reason is now hidden. Fully closing it would mean rejecting unknown actors too, which isn't viable. Calling that out so the PR isn't read as more than it is.

## Behaviour change

The client-visible error for a refused share is now `unable to attach session for this actor`. `docs/client-guide.md`, `docs/configuration.md` and `packages/server/README.md` are updated.

## Tests

- all four rejection paths (no credentials stored, empty credential object, no secret present, and the existing anonymous case) return the identical message
- detailed messages survive for non-share reads

`bun test` 820 pass / 0 fail. `biome check`, `markdownlint` on changed docs, and build clean.

## Related

- #1222 — verify credentials match before attaching. Touches `credential-check.ts`; whichever merges second needs a trivial rebase.
- #1224, #1226 — the other two followups