### PR TITLE
fix(server): scope stored credentials by platform as well as actor

### DIFF
--- a/packages/client/src/sockethub-client.test.ts
+++ b/packages/client/src/sockethub-client.test.ts
@@ -708,6 +708,33 @@ describe("SockethubClient", () => {
         });
     });
 
+    describe("replay keys are scoped by platform", () => {
+        beforeEach(() => {
+            sc.socket.connected = true;
+            sc._socket.connected = true;
+            socket.emit("schemas", TEST_REGISTRY);
+            sandbox.stub(sc, "validateActivity").returns("");
+        });
+
+        it("keeps credentials for one actor id on two platforms separate", () => {
+            // Regression: keyed by actor alone, the second platform's
+            // credentials replaced the first, so a reconnect replayed only one.
+            const actor = { id: "alice@example.org", type: "person" };
+            sc.socket.emit("credentials", {
+                "@context": sc.contextFor("test-xmpp"),
+                actor,
+                object: { type: "credentials", password: "xmpp-pass" },
+            });
+            sc.socket.emit("credentials", {
+                "@context": sc.contextFor("dummy"),
+                actor,
+                object: { type: "credentials", password: "dummy-pass" },
+            });
+
+            expect(sc.events.credentials.size).to.equal(2);
+        });
+    });
+
     describe("clearCredentials", () => {
         beforeEach(() => {
             sc.socket.connected = true;

--- a/packages/client/src/sockethub-client.ts
+++ b/packages/client/src/sockethub-client.ts
@@ -3,6 +3,7 @@ import {
     addPlatformContext,
     addPlatformSchema,
     normalizeActivityStream,
+    resolvePlatformId,
     validateActivityStream,
     validateCredentials,
 } from "@sockethub/schemas";
@@ -528,9 +529,10 @@ export default class SockethubClient {
 
     private eventCredentials(content: ActivityStream) {
         if (content.object && content.object.type === "credentials") {
-            const key: string =
-                content.actor.id || (content.actor as unknown as string);
-            this.events.credentials.set(key, content);
+            this.events.credentials.set(
+                SockethubClient.getKey(content),
+                content,
+            );
         }
     }
 
@@ -550,6 +552,12 @@ export default class SockethubClient {
         }
     }
 
+    /**
+     * Key for the replay maps. Scoped by platform: the same visible actor id
+     * can exist on more than one platform (an `alice@example.org` that is both
+     * an IRC nick and an XMPP JID), and keyed by actor alone one platform's
+     * stored credentials/connect/join would replace the other's on reconnect.
+     */
     private static getKey(content: ActivityStream) {
         const actor = content.actor?.id || content.actor;
         if (!actor) {
@@ -560,7 +568,8 @@ export default class SockethubClient {
         const target = content.target
             ? content.target.id || content.target
             : "";
-        return `${actor}-${target}`;
+        const platform = resolvePlatformId(content) ?? "";
+        return `${platform}:${actor}-${target}`;
     }
 
     private buildPlatformRegistryPayload(): PlatformRegistryPayload {

--- a/packages/data-layer/src/index.ts
+++ b/packages/data-layer/src/index.ts
@@ -24,6 +24,7 @@ import {
 } from "./job-base.js";
 import { JobQueue, verifyJobQueue } from "./job-queue.js";
 import { JobWorker, type JobWorkerOptions } from "./job-worker.js";
+import { buildCredentialsKey } from "./queue-id.js";
 
 export * from "./types.js";
 
@@ -53,6 +54,7 @@ async function redisCheck(config: RedisConfig): Promise<void> {
 }
 
 export {
+    buildCredentialsKey,
     CredentialsMismatchError,
     CredentialsNotShareableError,
     CredentialsStore,

--- a/packages/data-layer/src/queue-id.test.ts
+++ b/packages/data-layer/src/queue-id.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, it } from "bun:test";
 
-import { buildCredentialsStoreId, buildQueueId } from "./queue-id";
+import {
+    buildCredentialsKey,
+    buildCredentialsStoreId,
+    buildQueueId,
+} from "./queue-id";
 
 describe("queue-id helpers", () => {
     it("buildQueueId uses canonical namespace", () => {
@@ -12,6 +16,22 @@ describe("queue-id helpers", () => {
     it("buildCredentialsStoreId uses canonical namespace", () => {
         expect(buildCredentialsStoreId("parent", "session")).toBe(
             "sockethub:parent:data-layer:credentials-store:session",
+        );
+    });
+});
+
+describe("buildCredentialsKey", () => {
+    it("scopes an actor id by platform", () => {
+        expect(buildCredentialsKey("irc", "alice@example.org")).toEqual(
+            "irc:alice@example.org",
+        );
+    });
+
+    it("keeps the same actor id on two platforms distinct", () => {
+        // Regression: keyed by actor alone, saving XMPP credentials silently
+        // overwrote the IRC credentials for the same visible id.
+        expect(buildCredentialsKey("irc", "alice@example.org")).not.toEqual(
+            buildCredentialsKey("xmpp", "alice@example.org"),
         );
     });
 });

--- a/packages/data-layer/src/queue-id.ts
+++ b/packages/data-layer/src/queue-id.ts
@@ -12,3 +12,19 @@ export function buildCredentialsStoreId(
 ): string {
     return `${REDIS_QUEUE_PREFIX}:${parentId}:data-layer:credentials-store:${sessionId}`;
 }
+
+/**
+ * Field key for one actor's credentials inside a session's credential store.
+ *
+ * Scoped by platform as well as actor: a single session may hold credentials
+ * for the same visible `actor.id` on more than one platform (e.g. an
+ * `alice@example.org` that is both an IRC nick and an XMPP JID). Keyed by
+ * actor alone, saving one would silently overwrite the other.
+ *
+ * Both sides of the fork must derive this identically — the parent resolves
+ * the platform from the message `@context`, the child from the platform name
+ * it was forked with, and those are the same string.
+ */
+export function buildCredentialsKey(platform: string, actor: string): string {
+    return `${platform}:${actor}`;
+}

--- a/packages/server/src/middleware/credential-check.test.ts
+++ b/packages/server/src/middleware/credential-check.test.ts
@@ -8,6 +8,7 @@ import {
     test,
 } from "bun:test";
 import {
+    buildCredentialsKey,
     CredentialsMismatchError,
     CredentialsNotShareableError,
     type CredentialsStoreInterface,
@@ -90,7 +91,7 @@ describe("Middleware: credentialCheck", () => {
             credentialsHash: string | undefined,
             options: CredentialsValidationOptions | undefined,
         ) => {
-            expect(actor).toEqual(baseMessage.actor.id);
+            expect(actor).toEqual(buildCredentialsKey("irc", baseMessage.actor.id));
             expect(credentialsHash).toBeUndefined();
             expect(options).toEqual({ validateSessionShare: true });
             return makeCredentials({ type: "credentials", password: "abc123" });

--- a/packages/server/src/middleware/credential-check.ts
+++ b/packages/server/src/middleware/credential-check.ts
@@ -1,4 +1,5 @@
 import {
+    buildCredentialsKey,
     CredentialsMismatchError,
     CredentialsNotShareableError,
     type CredentialsStoreInterface,
@@ -117,7 +118,7 @@ export default function credentialCheck(
         // the incumbent's hash makes `get()` require an exact match, on top of
         // the non-empty-secret rule `validateSessionShare` applies.
         return credentialsStore
-            .get(msg.actor.id, incumbentHash, {
+            .get(buildCredentialsKey(platformId, msg.actor.id), incumbentHash, {
                 validateSessionShare: true,
             })
             .then(() => {

--- a/packages/server/src/middleware/store-credentials.test.ts
+++ b/packages/server/src/middleware/store-credentials.test.ts
@@ -2,7 +2,18 @@ import { afterEach, beforeEach, describe, expect, it } from "bun:test";
 import * as sinon from "sinon";
 
 import type { CredentialsObject } from "@sockethub/schemas";
+import { buildCredentialsKey } from "@sockethub/data-layer";
+import { addPlatformContext } from "@sockethub/schemas";
 import storeCredentials from "./store-credentials.js";
+
+// The `validate` middleware runs before this one and rejects unregistered
+// platforms, so by the time credentials are stored the context is always
+// resolvable. Register it here to match that guarantee.
+addPlatformContext(
+    "dummy",
+    "https://sockethub.org/ns/context/platform/dummy/v1.jsonld",
+);
+const expectedKey = buildCredentialsKey("dummy", "dood@irc.freenode.net");
 
 const creds: CredentialsObject = {
     type: "credentials",
@@ -71,7 +82,7 @@ describe("Middleware: storeCredentials", () => {
         const sc = storeCredentials(storeSuccess);
         sc(creds as CredentialsObject, (err: any) => {
             expect(saveSuccessFake.callCount).toEqual(1);
-            expect(saveSuccessFake.firstArg).toEqual(creds.actor.id);
+            expect(saveSuccessFake.firstArg).toEqual(expectedKey);
             expect(err).toEqual(creds);
             done();
         });
@@ -81,7 +92,7 @@ describe("Middleware: storeCredentials", () => {
         const sc = storeCredentials(storeError);
         sc(creds as CredentialsObject, (err: any) => {
             expect(saveErrorFake.callCount).toEqual(1);
-            expect(saveErrorFake.firstArg).toEqual(creds.actor.id);
+            expect(saveErrorFake.firstArg).toEqual(expectedKey);
             expect(err.toString()).toEqual("Error: some error");
             done();
         });

--- a/packages/server/src/middleware/store-credentials.ts
+++ b/packages/server/src/middleware/store-credentials.ts
@@ -1,5 +1,9 @@
-import type { CredentialsStoreInterface } from "@sockethub/data-layer";
+import {
+    buildCredentialsKey,
+    type CredentialsStoreInterface,
+} from "@sockethub/data-layer";
 import type { ActivityStream, CredentialsObject } from "@sockethub/schemas";
+import { resolvePlatformId } from "@sockethub/schemas";
 import { toError } from "@sockethub/util/error";
 
 import type { MiddlewareChainInterface } from "../middleware.js";
@@ -11,8 +15,15 @@ export default function storeCredentials(store: CredentialsStoreInterface) {
     ) => {
         const credentials = creds as CredentialsObject;
         try {
+            // Scope by platform: the same visible actor id can exist on more
+            // than one platform, and keyed by actor alone the second save
+            // silently overwrote the first.
+            const key = buildCredentialsKey(
+                resolvePlatformId(creds) ?? "",
+                credentials.actor.id,
+            );
             store
-                .save(credentials.actor.id, credentials)
+                .save(key, credentials)
                 .then(() => done(creds))
                 .catch((err) => done(toError(err)));
         } catch (err) {

--- a/packages/server/src/platform.ts
+++ b/packages/server/src/platform.ts
@@ -12,6 +12,7 @@
 
 import type { JobHandler } from "@sockethub/data-layer";
 import {
+    buildCredentialsKey,
     CredentialsStore,
     type JobDataDecrypted,
     JobWorker,
@@ -396,7 +397,10 @@ async function startPlatformProcess() {
                         : undefined;
 
                     credentialStore
-                        .get(job.msg.actor.id, credentialsHash)
+                        .get(
+                            buildCredentialsKey(platformName, job.msg.actor.id),
+                            credentialsHash,
+                        )
                         .then((credentials) => {
                             // Create wrapper callback that updates credentialsHash after successful call
                             const wrappedCallback: PlatformCallback = (


### PR DESCRIPTION
One of three followups split out of the #1131 review. Independent of the ID-format discussion, and independent of #1222.

## Problem

Credentials were keyed by `actor.id` alone, with no platform component, so one session holding credentials for the same visible id on two platforms — an `alice@example.org` that is both an IRC nick and an XMPP JID — had the second save silently overwrite the first.

This is the one place raucao's "can we guarantee uniqueness when a domain supports multiple protocols?" is a real server-side bug rather than a client-side concern. Platform *instance* routing was already safe: `getPlatformId()` hashes the platform name together with the actor.

## Fix

New `buildCredentialsKey(platform, actor)`, used by the store-credentials middleware, credential-check, and the child's per-job read.

The parent resolves the platform from `@context` and the child from the platform name it was forked with. Those are the same string — `PlatformInstance` forks with `params.platform`, which is `resolvePlatformId(msg)`. The `validate` middleware runs before store-credentials and rejects unregistered platforms, so the id is always resolvable by the time credentials are stored or read.

The client had the same bug in its reconnect replay maps (`events.credentials`, `connect`, `join`), so `SockethubClient.getKey()` is scoped by platform too.

## Tests

- `buildCredentialsKey` keeps the same actor id on two platforms distinct
- `store-credentials` / `credential-check` use the composite key
- client: credentials for one actor on two platforms no longer collide in the replay map

`bun test` 819 pass / 0 fail. `biome check` and build clean.

## Note

Keys are per-session and TTL'd, so nothing needs migrating. A server restart mid-session invalidates in-flight credentials, which clients re-send on reconnect.

## Related

- #1222 — touches `credential-check.ts` and `platform.ts`; whichever merges second needs a trivial rebase.
- #1224, #1225 — the other two followups

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented credentials for the same actor on different platforms from overwriting one another.
  * Updated credential storage and retrieval to use platform-specific keys.
  * Preserved credential validation and shared-session behavior with the corrected keying.

* **Tests**
  * Added regression coverage confirming credentials remain separate across platforms.
  * Expanded validation for platform-qualified credential lookups and storage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->