### PR TITLE
ci: raise the local registry body limit for package publish tests

### DIFF
--- a/scripts/test-installed-version/verdaccio.yaml
+++ b/scripts/test-installed-version/verdaccio.yaml
@@ -1,5 +1,10 @@
 storage: ./storage
 
+# The bundled @sockethub/server tarball is ~7MB, and npm publish sends it
+# base64-encoded in a JSON body (~1.34x), which overruns Verdaccio's 10mb
+# default and fails the publish with HTTP 413.
+max_body_size: 100mb
+
 auth:
   htpasswd:
     file: ./htpasswd


### PR DESCRIPTION
## Problem

The **Prepare Release** run
[32428648938](https://github.com/sockethub/sockethub/actions/runs/32428648938/job/96615677403)
failed in `test-local-packages / test-packaged-current (node)` at the
*Publish packages to local registry* step:

```
statusCode: 413, code: 'E413', method: 'PUT'
uri: 'http://127.0.0.1:4873/@sockethub%2fserver'
body: { error: 'request entity too large' }
pkgid: '@sockethub/server@5.0.0-alpha.20'
```

Nothing to do with the release logic or the code under test. The suite publishes every workspace
package to a throwaway Verdaccio instance, and `npm publish` sends the tarball base64-encoded inside
a JSON body (~1.34x the tarball size). The bundled `@sockethub/server` tarball has been creeping up —
6883 KB at `alpha.17` → 6935 KB at `alpha.20` — and at that size the encoded body finally crossed
Verdaccio's **10mb `max_body_size` default**, which our config never overrode.

It is a threshold crossing, not a regression: the 2026-08-15 prepare-release run squeaked under the
line, this one did not. It is also a registry-harness limit rather than an npm one, so it could only
ever break CI, never a real publish.

## Fix

Set `max_body_size: 100mb` in the harness's Verdaccio config, with a comment explaining why the
default is not enough.

## Verification

Reproduced and fixed locally against real Verdaccio 6.10.0, using the local build's tarball (9.7MB —
larger than CI's, so a strictly harder case than the failure):

- **Pre-fix config:** `npm error 413 Payload Too Large - PUT .../@sockethub%2fserver - request entity too large` — exact reproduction of the CI failure.
- **With this change:** `+ @sockethub/server@5.0.0-alpha.20` — publishes cleanly.

`bun run lint` and `biome check` pass (233 files, no findings).

## Follow-up

This unblocks the release but does not address *why* the package is big enough to hit a 10mb cap.
The published artifact is 34MB unpacked, 57% of it sourcemaps. Tracked in #1232.
