### PR TITLE
feat(server): default the Sentry release to the running version, report worker errors

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -610,6 +610,12 @@ URLs, and client IP addresses are not attached. Logs are opt-in and default to
 `warn` and `error`. Profiling is disabled by default; keep its sample rate low
 in production.
 
+These settings apply to the server process and to every platform worker it
+forks. Workers are started with a minimal environment and no config file of
+their own, so the server hands them its resolved Sentry block; errors raised
+inside a platform are reported to the same project, under the same sampling
+and redaction settings, however the server was configured.
+
 Verify delivery without starting the service:
 
 ```bash

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -596,6 +596,13 @@ LOG_LEVEL=debug LOG_FILE_LEVEL=debug sockethub
 }
 ```
 
+`release` is optional. Left unset (or empty), Sockethub reports
+`sockethub@<version>` using the version of the server package that is actually
+running, so a container image tags its own release without the deployment
+having to restate it. Set it explicitly only when you need a different
+identifier — for example a build that must match source maps uploaded under a
+git SHA.
+
 Sentry records aggregate connection and action counters, active connection
 gauges, action-duration distributions, and action traces. Metric dimensions are
 limited to platform and action names; actor IDs, credentials, message bodies,
@@ -631,7 +638,7 @@ export LOG_FILE_LEVEL=debug  # File log level (error, warn, info, debug)
 # Sentry (optional)
 export SENTRY_DSN=https://your-dsn@sentry.io/project-id
 export SENTRY_ENVIRONMENT=production
-export SENTRY_RELEASE=sockethub@5.0.0
+export SENTRY_RELEASE=sockethub@5.0.0   # optional; defaults to the running version
 ```
 
 ## Environment Examples

--- a/packages/server/README.md
+++ b/packages/server/README.md
@@ -126,7 +126,7 @@ Sentry error reporting can be configured via environment variable or config file
 
 - `SENTRY_DSN` - enable Sentry
 - `SENTRY_ENVIRONMENT` - deployment name such as `production`
-- `SENTRY_RELEASE` - deployed release identifier
+- `SENTRY_RELEASE` - deployed release identifier (defaults to `sockethub@<running version>`)
 
 **Config File:**
 For more advanced Sentry configuration, add a `sentry` section to your

--- a/packages/server/src/listener.ts
+++ b/packages/server/src/listener.ts
@@ -14,13 +14,13 @@ import { Server, type Socket } from "socket.io";
 import config from "./config.js";
 import { parseCorsOrigins } from "./cors.js";
 import routes from "./routes.js";
+import { SOCKETHUB_VERSION } from "./version.js";
 
 const require = createRequire(import.meta.url);
-const packageJson = require("../package.json");
 
 const log = createLogger("server:listener");
 // initial details
-log.info(`sockethub v${packageJson.version}`);
+log.info(`sockethub v${SOCKETHUB_VERSION}`);
 
 /**
  * Handles the initialization and access of Sockethub resources.

--- a/packages/server/src/platform-instance.test.ts
+++ b/packages/server/src/platform-instance.test.ts
@@ -19,6 +19,7 @@ addPlatformContext("respplat", RESPONSES_CTX);
 import { __dirname } from "./util.js";
 const FORK_PATH = __dirname + "/platform.js";
 
+import config from "./config.js";
 import PlatformInstance, { platformInstances } from "./platform-instance.js";
 
 describe("PlatformInstance", () => {
@@ -77,6 +78,56 @@ describe("PlatformInstance", () => {
                 "name",
                 "id",
             ]);
+            await pi.shutdown();
+        });
+    });
+
+    describe("sentry settings forwarded to the worker", () => {
+        const SENTRY = {
+            dsn: "https://key@o1.ingest.sentry.io/1",
+            environment: "staging",
+            release: "sockethub@9.9.9",
+            enableLogs: true,
+            logLevels: ["debug", "info", "warn", "error"],
+            enableMetrics: true,
+            tracesSampleRate: 1,
+            profileSessionSampleRate: 0,
+            sendDefaultPii: false,
+        };
+
+        function forkedEnv() {
+            return forkFake.lastCall.args[2];
+        }
+
+        function newInstance(resolveSentryEnv?) {
+            const TestPlatformInstance = getTestPlatformInstanceClass();
+            if (resolveSentryEnv) {
+                TestPlatformInstance.prototype.resolveSentryEnv =
+                    resolveSentryEnv;
+            }
+            return new TestPlatformInstance({
+                identifier: "id",
+                platform: "name",
+                parentId: "parentId",
+            });
+        }
+
+        // The worker is forked with an allowlisted environment and no
+        // --config, so settings it is not handed are unavailable to it.
+        test("forwards the resolved block when a dsn is configured", async () => {
+            const pi = newInstance(() => JSON.stringify(SENTRY));
+            expect(JSON.parse(forkedEnv().SOCKETHUB_SENTRY_CONFIG)).toEqual(
+                SENTRY,
+            );
+            await pi.shutdown();
+        });
+
+        // Default resolution against the loaded config, which has no DSN under
+        // test: the worker environment stays as small as it was.
+        test("omits it when no dsn is configured", async () => {
+            const pi = newInstance();
+            expect(config.get("sentry").dsn).toBe("");
+            expect(forkedEnv().SOCKETHUB_SENTRY_CONFIG).toBeUndefined();
             await pi.shutdown();
         });
     });

--- a/packages/server/src/platform-instance.ts
+++ b/packages/server/src/platform-instance.ts
@@ -22,6 +22,7 @@ import {
     reassignAnonymousScopes,
 } from "./connection-scope.js";
 import { getSocket } from "./listener.js";
+import { type SentryConfig, serializeSentryConfig } from "./sentry-config.js";
 import { __dirname } from "./util.js";
 
 // collection of platform instances, stored by `id`
@@ -48,6 +49,7 @@ type EnvFormat = {
     SOCKETHUB_PLATFORM_SCOPE?: string;
     SOCKETHUB_PLATFORM_HEARTBEAT_INTERVAL_MS?: string;
     SOCKETHUB_PLATFORM_HEARTBEAT_TIMEOUT_MS?: string;
+    SOCKETHUB_SENTRY_CONFIG?: string;
 };
 
 type MessageFromPlatform =
@@ -139,6 +141,13 @@ export default class PlatformInstance {
             env.SOCKETHUB_PLATFORM_HEARTBEAT_TIMEOUT_MS =
                 String(heartbeatTimeout);
         }
+        // Forward the parent's resolved Sentry settings. Without this a worker
+        // sees no DSN (it is not in the forked environment, and the worker gets
+        // no --config either), so its errors are logged and dropped.
+        const sentryConfig = this.resolveSentryEnv();
+        if (sentryConfig) {
+            env.SOCKETHUB_SENTRY_CONFIG = sentryConfig;
+        }
         // Forward this platform's `packageConfig` entry (keyed by package name)
         // to the forked child, which merges it onto the platform's defaults.
         const packageConfig = config.get("packageConfig") as
@@ -164,6 +173,11 @@ export default class PlatformInstance {
 
     createQueue() {
         this.JobQueue = JobQueue;
+    }
+
+    // Separate method to help with testing
+    resolveSentryEnv(): string | undefined {
+        return serializeSentryConfig(config.get("sentry") as SentryConfig);
     }
 
     initProcess(parentId: string, name: string, id: string, env: EnvFormat) {

--- a/packages/server/src/platform.ts
+++ b/packages/server/src/platform.ts
@@ -34,6 +34,7 @@ import {
 import { crypto, getPlatformId } from "@sockethub/util/crypto";
 import { errorMessage, toError } from "@sockethub/util/error";
 import config from "./config";
+import { resolveSentryConfig } from "./sentry-config.js";
 
 // Simple wrapper function to help with testing
 /**
@@ -97,7 +98,9 @@ async function startPlatformProcess() {
         },
     };
     (async () => {
-        if (config.get("sentry:dsn")) {
+        // Resolved from the parent's forwarded settings, not this process's
+        // own config: a worker is forked without the server's config file.
+        if (resolveSentryConfig().dsn) {
             logger.info("initializing sentry");
             sentry = await import("./sentry");
         }

--- a/packages/server/src/sentry-config.test.ts
+++ b/packages/server/src/sentry-config.test.ts
@@ -1,0 +1,115 @@
+import { afterEach, describe, expect, it } from "bun:test";
+
+import {
+    mergeForwardedSentryConfig,
+    resolveSentryConfig,
+    SENTRY_CONFIG_ENV,
+    type SentryConfig,
+    serializeSentryConfig,
+} from "./sentry-config.js";
+
+const BASE: SentryConfig = {
+    dsn: "",
+    environment: "production",
+    release: "",
+    enableLogs: false,
+    logLevels: ["warn", "error"],
+    enableMetrics: true,
+    tracesSampleRate: 0.1,
+    profileSessionSampleRate: 0,
+    sendDefaultPii: false,
+};
+
+const FORWARDED: SentryConfig = {
+    ...BASE,
+    dsn: "https://key@o1.ingest.sentry.io/1",
+    environment: "staging",
+    release: "sockethub@9.9.9",
+    enableLogs: true,
+    logLevels: ["debug", "info", "warn", "error"],
+    tracesSampleRate: 1,
+};
+
+describe("serializeSentryConfig", () => {
+    it("returns undefined when no dsn is configured", () => {
+        expect(serializeSentryConfig(BASE)).toBeUndefined();
+    });
+
+    it("serializes the whole block when a dsn is configured", () => {
+        const serialized = serializeSentryConfig(FORWARDED);
+        expect(serialized).toBeDefined();
+        expect(JSON.parse(serialized as string)).toEqual(FORWARDED);
+    });
+});
+
+describe("mergeForwardedSentryConfig", () => {
+    it("keeps the local block when nothing was forwarded", () => {
+        expect(mergeForwardedSentryConfig(BASE, undefined)).toEqual(BASE);
+        expect(mergeForwardedSentryConfig(BASE, "")).toEqual(BASE);
+    });
+
+    it("lets every forwarded key win, not just the dsn", () => {
+        const merged = mergeForwardedSentryConfig(
+            BASE,
+            JSON.stringify(FORWARDED),
+        );
+        expect(merged).toEqual(FORWARDED);
+        // A worker sampling at the base rate while the server samples at 1.0
+        // would silently under-report; the forwarded rate must win.
+        expect(merged.tracesSampleRate).toBe(1);
+        expect(merged.enableLogs).toBe(true);
+    });
+
+    it("keeps local values for keys the parent did not send", () => {
+        const merged = mergeForwardedSentryConfig(
+            BASE,
+            JSON.stringify({ dsn: FORWARDED.dsn }),
+        );
+        expect(merged.dsn).toBe(FORWARDED.dsn);
+        expect(merged.environment).toBe(BASE.environment);
+        expect(merged.logLevels).toEqual(BASE.logLevels);
+    });
+
+    it("throws on malformed JSON", () => {
+        expect(() => mergeForwardedSentryConfig(BASE, "{not json")).toThrow();
+    });
+
+    it("throws when the payload is not a JSON object", () => {
+        expect(() => mergeForwardedSentryConfig(BASE, '"a string"')).toThrow(
+            SENTRY_CONFIG_ENV,
+        );
+        expect(() => mergeForwardedSentryConfig(BASE, "[1,2]")).toThrow(
+            SENTRY_CONFIG_ENV,
+        );
+        expect(() => mergeForwardedSentryConfig(BASE, "null")).toThrow(
+            SENTRY_CONFIG_ENV,
+        );
+    });
+});
+
+describe("resolveSentryConfig", () => {
+    afterEach(() => {
+        delete process.env[SENTRY_CONFIG_ENV];
+    });
+
+    it("uses this process's own configuration when nothing was forwarded", () => {
+        delete process.env[SENTRY_CONFIG_ENV];
+        // No config file is loaded under test, so this is the schema default:
+        // Sentry off.
+        expect(resolveSentryConfig().dsn).toBe("");
+    });
+
+    it("applies the parent's forwarded settings", () => {
+        process.env[SENTRY_CONFIG_ENV] = JSON.stringify(FORWARDED);
+        const resolved = resolveSentryConfig();
+        expect(resolved.dsn).toBe(FORWARDED.dsn);
+        expect(resolved.environment).toBe("staging");
+        expect(resolved.tracesSampleRate).toBe(1);
+    });
+
+    it("falls back to local settings on malformed forwarded input", () => {
+        process.env[SENTRY_CONFIG_ENV] = "{not json";
+        // Logged and ignored rather than crashing the worker at startup.
+        expect(resolveSentryConfig().dsn).toBe("");
+    });
+});

--- a/packages/server/src/sentry-config.ts
+++ b/packages/server/src/sentry-config.ts
@@ -1,0 +1,83 @@
+/**
+ * Sentry settings resolution, shared by the server process and its forked
+ * platform workers.
+ *
+ * A worker is forked with an explicit environment allowlist rather than a copy
+ * of the parent's environment, and it does not receive the parent's
+ * `--config` argument either. It therefore cannot rediscover the settings the
+ * parent resolved — a DSN supplied only via `SENTRY_DSN`, or any sampling and
+ * redaction choice made in a config file the worker never reads. The parent
+ * serializes its resolved block into `SOCKETHUB_SENTRY_CONFIG` so worker
+ * errors reach the same project under the same settings.
+ */
+
+import { createLogger } from "@sockethub/logger";
+import { errorMessage } from "@sockethub/util/error";
+import config from "./config.js";
+
+export type SentryConfig = {
+    dsn: string;
+    environment: string;
+    release: string;
+    enableLogs: boolean;
+    logLevels: Array<"debug" | "info" | "warn" | "error">;
+    enableMetrics: boolean;
+    tracesSampleRate: number;
+    profileSessionSampleRate: number;
+    sendDefaultPii: boolean;
+};
+
+export const SENTRY_CONFIG_ENV = "SOCKETHUB_SENTRY_CONFIG";
+
+const logger = createLogger("sentry:config");
+
+/**
+ * Serialize resolved Sentry settings for a forked platform worker. Returns
+ * undefined when Sentry is not configured, so the worker's environment stays
+ * as small as it is today and the worker skips Sentry entirely.
+ */
+export function serializeSentryConfig(
+    sentryConfig: SentryConfig,
+): string | undefined {
+    if (!sentryConfig?.dsn) {
+        return undefined;
+    }
+    return JSON.stringify(sentryConfig);
+}
+
+/**
+ * Overlay the parent's forwarded settings onto this process's own resolved
+ * block. Every key the parent sends wins; anything absent keeps the local
+ * value. Throws on malformed JSON so the caller can log it rather than
+ * silently reporting under different settings than the server.
+ */
+export function mergeForwardedSentryConfig(
+    base: SentryConfig,
+    rawConfig: string | undefined,
+): SentryConfig {
+    if (!rawConfig) {
+        return base;
+    }
+    const parsed = JSON.parse(rawConfig);
+    if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+        throw new Error(`${SENTRY_CONFIG_ENV} must be a JSON object`);
+    }
+    return { ...base, ...(parsed as Partial<SentryConfig>) };
+}
+
+/**
+ * The Sentry settings this process should use: its own configuration in the
+ * server process, overlaid with the parent's resolved block in a platform
+ * worker. On malformed forwarded input, log and keep the local settings.
+ */
+export function resolveSentryConfig(): SentryConfig {
+    const base = config.get("sentry") as SentryConfig;
+    try {
+        return mergeForwardedSentryConfig(base, process.env[SENTRY_CONFIG_ENV]);
+    } catch (err) {
+        logger.warn(
+            `ignoring invalid ${SENTRY_CONFIG_ENV}: ${errorMessage(err)}`,
+        );
+        return base;
+    }
+}

--- a/packages/server/src/sentry.ts
+++ b/packages/server/src/sentry.ts
@@ -2,30 +2,18 @@
 
 import * as Sentry from "@sentry/node";
 import { createLogger, setLogSink } from "@sockethub/logger";
-import config from "./config";
 import {
     redactObservabilityLog,
     sanitizeObservabilityNamespace,
     setObservabilityAdapter,
 } from "./observability.js";
+import { resolveSentryConfig } from "./sentry-config.js";
 import { defaultSentryRelease } from "./version.js";
-
-type SentryConfig = {
-    dsn: string;
-    environment: string;
-    release: string;
-    enableLogs: boolean;
-    logLevels: Array<"debug" | "info" | "warn" | "error">;
-    enableMetrics: boolean;
-    tracesSampleRate: number;
-    profileSessionSampleRate: number;
-    sendDefaultPii: boolean;
-};
 
 type MetricAttributes = Record<string, string | number | boolean>;
 
 const logger = createLogger("sentry");
-const sentryConfig = config.get("sentry") as SentryConfig;
+const sentryConfig = resolveSentryConfig();
 
 if (!sentryConfig.dsn) {
     throw new Error("Sentry attempted initialization with no DSN provided");

--- a/packages/server/src/sentry.ts
+++ b/packages/server/src/sentry.ts
@@ -8,6 +8,7 @@ import {
     sanitizeObservabilityNamespace,
     setObservabilityAdapter,
 } from "./observability.js";
+import { defaultSentryRelease } from "./version.js";
 
 type SentryConfig = {
     dsn: string;
@@ -39,7 +40,9 @@ if (sentryConfig.profileSessionSampleRate > 0) {
 Sentry.init({
     dsn: sentryConfig.dsn,
     environment: sentryConfig.environment,
-    release: sentryConfig.release || undefined,
+    // Fall back to the running package version so releases are tagged
+    // correctly without every deployment having to restate its own version.
+    release: sentryConfig.release || defaultSentryRelease(),
     enableLogs: sentryConfig.enableLogs,
     enableMetrics: sentryConfig.enableMetrics,
     tracesSampleRate: sentryConfig.tracesSampleRate,

--- a/packages/server/src/version.test.ts
+++ b/packages/server/src/version.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from "bun:test";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+import { defaultSentryRelease, SOCKETHUB_VERSION } from "./version.js";
+
+describe("version", () => {
+    const packageJson = JSON.parse(
+        readFileSync(join(import.meta.dir, "..", "package.json"), "utf8"),
+    );
+
+    it("reports the running package version", () => {
+        expect(SOCKETHUB_VERSION).toBe(packageJson.version);
+    });
+
+    it("resolves to a non-empty version string", () => {
+        // A broken relative path to the manifest would surface here as
+        // undefined rather than as a mis-tagged release in production.
+        expect(typeof SOCKETHUB_VERSION).toBe("string");
+        expect(SOCKETHUB_VERSION.length).toBeGreaterThan(0);
+    });
+
+    it("builds a sentry release identifier from that version", () => {
+        expect(defaultSentryRelease()).toBe(`sockethub@${packageJson.version}`);
+    });
+});

--- a/packages/server/src/version.test.ts
+++ b/packages/server/src/version.test.ts
@@ -14,8 +14,9 @@ describe("version", () => {
     });
 
     it("resolves to a non-empty version string", () => {
-        // A broken relative path to the manifest would surface here as
-        // undefined rather than as a mis-tagged release in production.
+        // A manifest that resolves but carries no version would surface here
+        // as undefined rather than as a mis-tagged release in production. (A
+        // manifest that does not resolve at all throws on import instead.)
         expect(typeof SOCKETHUB_VERSION).toBe("string");
         expect(SOCKETHUB_VERSION.length).toBeGreaterThan(0);
     });

--- a/packages/server/src/version.ts
+++ b/packages/server/src/version.ts
@@ -1,0 +1,17 @@
+/** The running server's own version, read from the installed package manifest. */
+
+import { createRequire } from "node:module";
+
+const require = createRequire(import.meta.url);
+const packageJson = require("../package.json");
+
+export const SOCKETHUB_VERSION: string = packageJson.version;
+
+/**
+ * The Sentry release identifier to report when the deployment has not set one
+ * explicitly. Derived from the running package version so a deployment does
+ * not have to be told, out of band, which version it is running.
+ */
+export function defaultSentryRelease(): string {
+    return `sockethub@${SOCKETHUB_VERSION}`;
+}


### PR DESCRIPTION
## Why

Two related gaps in Sentry observability:

1. `sentry.release` was only reported when a deployment set it explicitly. That forces every container to be told, out of band, which version it is already running — and the value drifts silently the moment someone forgets to bump it.
2. Platform workers are forked with an explicit environment allowlist and without the server's `--config`, so a worker could not see the settings the server resolved. A DSN supplied via `SENTRY_DSN` never reached it, and sampling/redaction choices made in a config file it does not read did not either. Worker errors were logged and dropped.

## What

**Default release**

- `packages/server/src/version.ts` — reads the version from the server package manifest, exposes `SOCKETHUB_VERSION` and `defaultSentryRelease()`.
- `sentry.ts` — `release: sentryConfig.release || defaultSentryRelease()`, i.e. `sockethub@5.0.0-alpha.20`. An explicit config/env value still wins, for builds that tag releases by git SHA to match uploaded source maps.
- `listener.ts` — the startup banner uses the same shared version read instead of its own `require("../package.json")`.

**Worker reporting**

- `packages/server/src/sentry-config.ts` — resolves Sentry settings for either process kind: the server reads its own config; a worker overlays the parent's forwarded block.
- `platform-instance.ts` — serializes the resolved `sentry` block into `SOCKETHUB_SENTRY_CONFIG` when a DSN is configured. Forwarding the whole block, not just the DSN, keeps a worker from reporting at a different sample rate or with different redaction than the process that forked it. With no DSN configured, nothing is forwarded and the worker environment is unchanged.
- `platform.ts` — gates Sentry init on the resolved DSN rather than on config the worker never receives. Malformed forwarded input is logged and ignored rather than taking the worker down at startup.

Docs updated in `docs/configuration.md` and `packages/server/README.md`.

## Verification

- `bun run lint`, `bun run build`, `bun test` — one pre-existing unrelated failure (`printSettingsInfo > strips colors in non-TTY environment`), confirmed failing on the base commit too.
- Bundled output checked: `dist/index.js` and `dist/platform.js` both keep the runtime `require("../package.json")`, and that path resolves correctly from `dist/` in both the monorepo and the published-package layout.
- End-to-end against a real server (Redis + socket.io client, no config file in cwd, DSN supplied **only** via `SENTRY_DSN`, fake non-routable DSN): a dummy-platform job forked a worker, and both processes initialized Sentry —

  ```
  sockethub:server:init initializing sentry
  sockethub:platform:dummy:<id>:sentry initialized sentry observability
  ```

  The worker leg is exactly what was broken before this change.
