### PR TITLE
fix(server): flush Sentry on fatal errors, trust the reverse proxy, implement --help

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -288,6 +288,37 @@ Configure how reconnect IP is read:
 Use `proxy` only when Sockethub is behind a trusted reverse proxy that sets and
 sanitizes forwarding headers.
 
+### Trusting a reverse proxy for HTTP requests
+
+`sockethub.trustProxy` is Express's [`trust proxy`][trust-proxy] setting, which
+decides whether `x-forwarded-for` is believed when determining a client's IP
+for HTTP rate limiting:
+
+```json
+{
+  "sockethub": {
+    "trustProxy": 1
+  }
+}
+```
+
+- `false` (default) trusts no proxy: `req.ip` is the connecting peer.
+- a number trusts that many hops closest to Sockethub.
+- a string takes an address, subnet, or preset such as `loopback`.
+- `SOCKETHUB_TRUST_PROXY` sets it from the environment.
+
+Setting `credentialCheck.reconnectIpSource` to `proxy` already declares that a
+trusted proxy sets the forwarded header, so a `trustProxy` left at `false`
+follows it and trusts one hop. Without this, every proxied request appears to
+come from the proxy's own address and shares a single HTTP rate-limit bucket,
+and `express-rate-limit` logs `ERR_ERL_UNEXPECTED_X_FORWARDED_FOR`.
+
+Enable it only behind a proxy that overwrites `x-forwarded-for`; otherwise
+clients can spoof the header and evade rate limiting.
+
+[trust-proxy]: https://expressjs.com/en/guide/behind-proxies.html
+
+
 ### HTTP Actions
 
 HTTP actions provide a one-shot HTTP interface for sending ActivityStreams

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -318,7 +318,6 @@ clients can spoof the header and evade rate limiting.
 
 [trust-proxy]: https://expressjs.com/en/guide/behind-proxies.html
 
-
 ### HTTP Actions
 
 HTTP actions provide a one-shot HTTP interface for sending ActivityStreams
@@ -652,6 +651,16 @@ Verify delivery without starting the service:
 ```bash
 sockethub --sentry-test --config /path/to/sockethub.config.json
 ```
+
+`--sentry-test` sends an informational message. To verify the crash path in
+particular — capture, flush, then exit — use:
+
+```bash
+sockethub --sentry-test-crash --config /path/to/sockethub.config.json
+```
+
+It reports a synthetic fatal error and exits non-zero. Neither flag binds a
+port, so both are safe to run against a host already serving Sockethub.
 
 ## Environment Variables
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -313,6 +313,12 @@ follows it and trusts one hop. Without this, every proxied request appears to
 come from the proxy's own address and shares a single HTTP rate-limit bucket,
 and `express-rate-limit` logs `ERR_ERL_UNEXPECTED_X_FORWARDED_FOR`.
 
+That inference applies only when `credentialCheck.proxyHeader` is
+`x-forwarded-for`, the sole header Express consults. A deployment naming a
+custom `proxyHeader` has vouched for that header alone — its proxy may leave
+`x-forwarded-for` client-settable — so `trustProxy` stays `false` and must be
+set explicitly.
+
 Enable it only behind a proxy that overwrites `x-forwarded-for`; otherwise
 clients can spoof the header and evade rate limiting.
 

--- a/packages/schemas/src/schemas/sockethub-config.ts
+++ b/packages/schemas/src/schemas/sockethub-config.ts
@@ -326,6 +326,20 @@ export const SockethubConfigSchema = {
                     description:
                         "Maximum size in bytes of a single Socket.IO message.",
                 },
+                trustProxy: {
+                    type: ["boolean", "number", "string"],
+                    default: false,
+                    description:
+                        "Express 'trust proxy' setting, deciding whether " +
+                        "'x-forwarded-for' is believed when determining a " +
+                        "client's IP for HTTP rate limiting. false trusts no " +
+                        "proxy; a number trusts that many hops; a string " +
+                        "takes an address, subnet or preset ('loopback'). " +
+                        "Only enable behind a reverse proxy that overwrites " +
+                        "the header. When left false while " +
+                        "credentialCheck.reconnectIpSource is 'proxy', one " +
+                        "hop is trusted so both paths agree.",
+                },
                 cors: {
                     type: "object",
                     additionalProperties: false,

--- a/packages/schemas/src/schemas/sockethub-config.ts
+++ b/packages/schemas/src/schemas/sockethub-config.ts
@@ -337,8 +337,10 @@ export const SockethubConfigSchema = {
                         "takes an address, subnet or preset ('loopback'). " +
                         "Only enable behind a reverse proxy that overwrites " +
                         "the header. When left false while " +
-                        "credentialCheck.reconnectIpSource is 'proxy', one " +
-                        "hop is trusted so both paths agree.",
+                        "credentialCheck.reconnectIpSource is 'proxy' and " +
+                        "credentialCheck.proxyHeader is 'x-forwarded-for', " +
+                        "one hop is trusted so both paths agree; a custom " +
+                        "proxyHeader requires setting this explicitly.",
                 },
                 cors: {
                     type: "object",

--- a/packages/server/README.md
+++ b/packages/server/README.md
@@ -155,14 +155,23 @@ verification event and exit.
 ### Command-line params
 
 ```
-  --help       : this help screen
-  --info       : displays some basic runtime info
+  --help, -h          : this help screen
+  --version, -v       : print the version and exit
+  --info              : displays some basic runtime info
 
-  --examples   : enabled examples page and serves helper files like jquery
+  --examples          : enabled examples page and serves helper files like jquery
 
-  --host       : hostname to bind to
-  --port       : port to bind to
+  --config, -c        : path to a config file
+  --write-config      : write a default config file and exit
+
+  --host              : hostname to bind to
+  --port              : port to bind to
+
+  --sentry-test       : send a verification event to Sentry and exit
 ```
+
+`--help`, `--version` and `--write-config` answer without loading the config
+file or binding a port, so they work on a host already running Sockethub.
 
 ### Start
 

--- a/packages/server/README.md
+++ b/packages/server/README.md
@@ -168,6 +168,7 @@ verification event and exit.
   --port              : port to bind to
 
   --sentry-test       : send a verification event to Sentry and exit
+  --sentry-test-crash : report a synthetic fatal error to Sentry and exit
 ```
 
 `--help`, `--version` and `--write-config` answer without loading the config

--- a/packages/server/src/cli.test.ts
+++ b/packages/server/src/cli.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from "bun:test";
+
+import { parseInfoFlag, renderHelp } from "./cli.js";
+import { SOCKETHUB_VERSION } from "./version.js";
+
+describe("parseInfoFlag", () => {
+    it("recognizes --help and -h", () => {
+        expect(parseInfoFlag(["--help"])).toBe("help");
+        expect(parseInfoFlag(["-h"])).toBe("help");
+    });
+
+    it("recognizes --version and -v", () => {
+        expect(parseInfoFlag(["--version"])).toBe("version");
+        expect(parseInfoFlag(["-v"])).toBe("version");
+    });
+
+    it("finds the flag among other arguments", () => {
+        expect(parseInfoFlag(["--config", "a.json", "--help"])).toBe("help");
+    });
+
+    it("prefers help when both are given", () => {
+        expect(parseInfoFlag(["--version", "--help"])).toBe("help");
+    });
+
+    it("returns undefined for a normal invocation", () => {
+        expect(parseInfoFlag([])).toBeUndefined();
+        expect(parseInfoFlag(["--config", "sockethub.config.json"])).toBe(
+            undefined,
+        );
+    });
+});
+
+describe("renderHelp", () => {
+    it("names the running version", () => {
+        expect(renderHelp()).toContain(SOCKETHUB_VERSION);
+    });
+
+    it("documents the flags that short-circuit startup", () => {
+        const help = renderHelp();
+        for (const flag of [
+            "--config",
+            "--write-config",
+            "--sentry-test",
+            "--version",
+            "--help",
+        ]) {
+            expect(help).toContain(flag);
+        }
+    });
+});

--- a/packages/server/src/cli.test.ts
+++ b/packages/server/src/cli.test.ts
@@ -41,6 +41,7 @@ describe("renderHelp", () => {
             "--config",
             "--write-config",
             "--sentry-test",
+            "--sentry-test-crash",
             "--version",
             "--help",
         ]) {

--- a/packages/server/src/cli.ts
+++ b/packages/server/src/cli.ts
@@ -1,0 +1,53 @@
+/**
+ * Argument handling for the flags that short-circuit startup.
+ *
+ * Deliberately free of imports from the config singleton: `--help` and
+ * `--version` must answer even when the config file in the working directory
+ * is missing or invalid, and must never reach the point of binding a port.
+ */
+
+import { SOCKETHUB_VERSION } from "./version.js";
+
+export function renderHelp(): string {
+    return `Sockethub v${SOCKETHUB_VERSION} — a protocol gateway for web applications
+
+Usage: sockethub [options]
+
+Options:
+  -c, --config <path>       Path to a config file (default: ./sockethub.config.json,
+                            or the SOCKETHUB_CONFIG environment variable)
+      --write-config [path] Write a default config file and exit ("-" for stdout,
+                            default: ./sockethub.config.json)
+      --host <host>         Address to bind (config: sockethub.host)
+      --port <port>         Port to bind (config: sockethub.port)
+      --redis.url <url>     Redis connection URL (config: redis.url)
+      --cors.origin <list>  Allowed CORS origin(s), comma-separated
+                            (config: sockethub.cors.origin)
+      --sentry.dsn <dsn>    Sentry DSN to report to (config: sentry.dsn)
+      --sentry-test         Send a test event to Sentry and exit, reporting
+                            whether it was accepted
+      --examples            Serve the bundled example pages
+      --info                Print runtime information
+  -v, --version             Print the version and exit
+  -h, --help                Print this help and exit
+
+Every config file setting can also be set by environment variable; see
+docs/configuration.md for the full list.
+`;
+}
+
+/**
+ * The short-circuit flag present in `argv`, if any. `--help` wins over
+ * `--version` when both are given.
+ */
+export function parseInfoFlag(
+    argv: Array<string>,
+): "help" | "version" | undefined {
+    if (argv.includes("--help") || argv.includes("-h")) {
+        return "help";
+    }
+    if (argv.includes("--version") || argv.includes("-v")) {
+        return "version";
+    }
+    return undefined;
+}

--- a/packages/server/src/cli.ts
+++ b/packages/server/src/cli.ts
@@ -26,6 +26,8 @@ Options:
       --sentry.dsn <dsn>    Sentry DSN to report to (config: sentry.dsn)
       --sentry-test         Send a test event to Sentry and exit, reporting
                             whether it was accepted
+      --sentry-test-crash   Report a synthetic fatal error to Sentry and exit
+                            non-zero, exercising the crash-reporting path
       --examples            Serve the bundled example pages
       --info                Print runtime information
   -v, --version             Print the version and exit

--- a/packages/server/src/config-schema.ts
+++ b/packages/server/src/config-schema.ts
@@ -106,6 +106,11 @@ const OVERLAY: Record<string, OverlayEntry> = {
         env: "SOCKETHUB_MAX_PAYLOAD_BYTES",
         emptyEnvIsUnset: true,
     },
+    "sockethub.trustProxy": {
+        format: "*",
+        env: "SOCKETHUB_TRUST_PROXY",
+        emptyEnvIsUnset: true,
+    },
     "sockethub.cors.origin": {
         env: "SOCKETHUB_CORS_ORIGIN",
         arg: "cors.origin",

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -1,7 +1,9 @@
 import path from "node:path";
 import { createLogger, initLogger, setLoggerContext } from "@sockethub/logger";
 import { toError } from "@sockethub/util/error";
+import { parseInfoFlag, renderHelp } from "./cli.js";
 import type SockethubType from "./sockethub";
+import { SOCKETHUB_VERSION } from "./version.js";
 import { parseWriteConfigTarget, writeDefaultConfig } from "./write-config";
 
 let sentry: {
@@ -12,10 +14,24 @@ let sentry: {
 };
 
 export async function server() {
+    const argv = process.argv.slice(2);
+
+    // --help/--version short-circuit before anything else: they must answer
+    // without loading config, binding a port, or initializing Sentry.
+    const infoFlag = parseInfoFlag(argv);
+    if (infoFlag === "help") {
+        process.stdout.write(renderHelp());
+        process.exit(0);
+    }
+    if (infoFlag === "version") {
+        console.log(SOCKETHUB_VERSION);
+        process.exit(0);
+    }
+
     // --write-config short-circuits startup: emit a default config file and
     // exit. Handled before the config modules load so it works even when an
     // existing config file in the working directory is invalid.
-    const writeConfigTarget = parseWriteConfigTarget(process.argv.slice(2));
+    const writeConfigTarget = parseWriteConfigTarget(argv);
     if (writeConfigTarget !== undefined) {
         try {
             const message = writeDefaultConfig(writeConfigTarget);
@@ -56,7 +72,7 @@ export async function server() {
         sentry = await import("./sentry");
     }
 
-    if (process.argv.includes("--sentry-test")) {
+    if (argv.includes("--sentry-test")) {
         if (!sentry.sendTestEvent) {
             console.error("Sentry is not configured; no test event was sent");
             process.exit(1);

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -40,14 +40,21 @@ export async function server() {
 
     // --help/--version short-circuit before anything else: they must answer
     // without loading config, binding a port, or initializing Sentry.
+    //
+    // These paths return rather than calling process.exit: writes to a pipe
+    // are asynchronous, and a forced exit can truncate them mid-stream. There
+    // is nothing holding the event loop open here, so returning exits just as
+    // promptly, only after stdout has drained.
     const infoFlag = parseInfoFlag(argv);
     if (infoFlag === "help") {
         process.stdout.write(renderHelp());
-        process.exit(0);
+        process.exitCode = 0;
+        return;
     }
     if (infoFlag === "version") {
         console.log(SOCKETHUB_VERSION);
-        process.exit(0);
+        process.exitCode = 0;
+        return;
     }
 
     // --write-config short-circuits startup: emit a default config file and
@@ -60,11 +67,12 @@ export async function server() {
             if (message) {
                 console.log(message);
             }
-            process.exit(0);
+            process.exitCode = 0;
         } catch (err) {
             console.error(toError(err).message);
-            process.exit(1);
+            process.exitCode = 1;
         }
+        return;
     }
 
     // Loaded lazily (not statically) so the import-time Config singleton
@@ -93,6 +101,28 @@ export async function server() {
         log.info("initializing sentry");
         sentry = await import("./sentry");
     }
+
+    // Registered as soon as Sentry is available and before the remaining
+    // startup imports: a rejected import would otherwise leave `server()` to
+    // reject with no handler attached, exiting without a report. Failures
+    // before this point cannot reach Sentry in any case — the config that
+    // carries the DSN has not been read yet.
+    process.once("uncaughtException", (err: unknown) => {
+        const error = toError(err);
+        console.error(
+            `${(new Date()).toUTCString()} UNCAUGHT EXCEPTION\n`,
+            error.stack,
+        );
+        void reportFatal(error);
+    });
+
+    process.once("unhandledRejection", (err: unknown) => {
+        console.error(
+            `${(new Date()).toUTCString()} UNHANDLED REJECTION\n`,
+            err,
+        );
+        void reportFatal(toError(err));
+    });
 
     if (argv.includes("--sentry-test")) {
         if (!sentry.sendTestEvent) {
@@ -129,22 +159,6 @@ export async function server() {
         console.error(error);
         await reportFatal(error);
     }
-
-    process.once("uncaughtException", (err: Error) => {
-        console.error(
-            `${(new Date()).toUTCString()} UNCAUGHT EXCEPTION\n`,
-            err.stack,
-        );
-        void reportFatal(err);
-    });
-
-    process.once("unhandledRejection", (err: unknown) => {
-        console.error(
-            `${(new Date()).toUTCString()} UNHANDLED REJECTION\n`,
-            err,
-        );
-        void reportFatal(toError(err));
-    });
 
     const gracefulShutdown = async (signal: string) => {
         console.log(`Received ${signal} signal. Shutting down sockethub...`);

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -8,10 +8,26 @@ import { parseWriteConfigTarget, writeDefaultConfig } from "./write-config";
 
 let sentry: {
     readonly reportError: (err: Error) => void;
+    readonly flush?: (timeoutMs?: number) => Promise<boolean>;
     readonly sendTestEvent?: () => Promise<boolean>;
 } = {
     reportError: (_err: Error) => {},
 };
+
+/**
+ * Report a fatal error and exit. Sentry sends events asynchronously, so the
+ * queued event has to be flushed before `process.exit` tears the process down
+ * — otherwise the crash that matters most is the one Sentry never sees.
+ */
+async function reportFatal(err: Error, code = 1): Promise<never> {
+    sentry.reportError(err);
+    try {
+        await sentry.flush?.();
+    } catch {
+        // Never let a failing flush mask the error being reported.
+    }
+    process.exit(code);
+}
 
 export async function server() {
     const argv = process.argv.slice(2);
@@ -84,6 +100,18 @@ export async function server() {
         process.exit(sent ? 0 : 1);
     }
 
+    // Exercises the fatal-error path itself — capture, flush, exit — which is
+    // what a real crash takes and what --sentry-test does not cover. Runs
+    // before the server is constructed, so it never contends for the port.
+    if (argv.includes("--sentry-test-crash")) {
+        if (!sentry.flush) {
+            console.error("Sentry is not configured; no crash was reported");
+            process.exit(1);
+        }
+        console.error("Reporting a synthetic fatal error to Sentry");
+        await reportFatal(new Error("Sockethub Sentry verification crash"));
+    }
+
     // Load the application graph only after Sentry so automatic tracing can
     // instrument Express, Socket.IO, Redis, and child-process dependencies.
     const { default: Sockethub } = await import("./sockethub.js");
@@ -92,9 +120,8 @@ export async function server() {
         sockethub = new Sockethub();
     } catch (err) {
         const error = toError(err);
-        sentry.reportError(error);
         console.error(error);
-        process.exit(1);
+        await reportFatal(error);
     }
 
     process.once("uncaughtException", (err: Error) => {
@@ -102,8 +129,7 @@ export async function server() {
             `${(new Date()).toUTCString()} UNCAUGHT EXCEPTION\n`,
             err.stack,
         );
-        sentry.reportError(err);
-        process.exit(1);
+        void reportFatal(err);
     });
 
     process.once("unhandledRejection", (err: unknown) => {
@@ -111,8 +137,7 @@ export async function server() {
             `${(new Date()).toUTCString()} UNHANDLED REJECTION\n`,
             err,
         );
-        sentry.reportError(toError(err));
-        process.exit(1);
+        void reportFatal(toError(err));
     });
 
     const gracefulShutdown = async (signal: string) => {
@@ -122,9 +147,8 @@ export async function server() {
             process.exit(0);
         } catch (err) {
             const error = toError(err);
-            sentry.reportError(error);
             console.error(error);
-            process.exit(1);
+            await reportFatal(error);
         }
     };
 
@@ -140,8 +164,7 @@ export async function server() {
         await sockethub.boot();
     } catch (err) {
         const error = toError(err);
-        sentry.reportError(error);
         console.error(error);
-        process.exit(1);
+        await reportFatal(error);
     }
 }

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -22,9 +22,15 @@ let sentry: {
 async function reportFatal(err: Error, code = 1): Promise<never> {
     sentry.reportError(err);
     try {
-        await sentry.flush?.();
-    } catch {
-        // Never let a failing flush mask the error being reported.
+        // A false result means the timeout elapsed with the event still
+        // queued. Report it rather than exiting as though it had been
+        // delivered, but exit either way: a failing flush must never mask the
+        // error being reported.
+        if ((await sentry.flush?.()) === false) {
+            console.error("fatal-error-flush timed out; event may be lost");
+        }
+    } catch (flushErr) {
+        console.error(`fatal-error-flush failed: ${toError(flushErr).message}`);
     }
     process.exit(code);
 }

--- a/packages/server/src/listener.ts
+++ b/packages/server/src/listener.ts
@@ -14,6 +14,7 @@ import { Server, type Socket } from "socket.io";
 import config from "./config.js";
 import { parseCorsOrigins } from "./cors.js";
 import routes from "./routes.js";
+import { resolveTrustProxy } from "./trust-proxy.js";
 import { SOCKETHUB_VERSION } from "./version.js";
 
 const require = createRequire(import.meta.url);
@@ -195,6 +196,18 @@ class Listener {
 
     private static initExpress(): Express {
         const app = express();
+        // Decides whether 'x-forwarded-for' is believed when express-rate-limit
+        // keys a client; left at Express's `false` default, every request
+        // behind a reverse proxy shares the proxy's IP and one rate-limit
+        // bucket.
+        const trustProxy = resolveTrustProxy(
+            config.get("sockethub:trustProxy"),
+            config.get("credentialCheck:reconnectIpSource"),
+        );
+        app.set("trust proxy", trustProxy);
+        if (trustProxy !== false) {
+            log.info(`trusting proxy headers (trust proxy: ${trustProxy})`);
+        }
         // templating engines
         app.set("view engine", "ejs");
         // Express bundles body-parser as express.urlencoded(); use it directly.

--- a/packages/server/src/listener.ts
+++ b/packages/server/src/listener.ts
@@ -203,6 +203,7 @@ class Listener {
         const trustProxy = resolveTrustProxy(
             config.get("sockethub:trustProxy"),
             config.get("credentialCheck:reconnectIpSource"),
+            config.get("credentialCheck:proxyHeader"),
         );
         app.set("trust proxy", trustProxy);
         if (trustProxy !== false) {

--- a/packages/server/src/platform.ts
+++ b/packages/server/src/platform.ts
@@ -100,6 +100,21 @@ async function startPlatformProcess() {
             );
         },
     };
+    // Registered before any awaited startup work: an import that rejects
+    // during startup would otherwise never reach the handlers, and the worker
+    // would die without notifying the parent or reporting to Sentry.
+    // `reportFatal` and `safeProcessSend` are function declarations, so they
+    // are hoisted and callable from here.
+    process.once("uncaughtException", (err: Error) => {
+        void reportFatal(err);
+    });
+
+    // A rejection reason can be any value, including null or undefined, which
+    // would throw on `.stack` inside the handler. Normalize it first.
+    process.once("unhandledRejection", (err: unknown) => {
+        void reportFatal(toError(err));
+    });
+
     // Awaited (not fire-and-forget) so a crash during the rest of startup is
     // reported to Sentry rather than to the no-op stub above. Resolved from
     // the parent's forwarded settings, not this process's own config: a
@@ -262,12 +277,9 @@ async function startPlatformProcess() {
     }
 
     /**
-     * Handle any uncaught errors from the platform by alerting the worker and shutting down.
-     */
-    /**
-     * Report a fatal worker error and exit. Sentry sends events
-     * asynchronously, so the queued event must be flushed before
-     * `process.exit` discards it.
+     * Handle any uncaught errors from the platform by alerting the worker and
+     * shutting down. Sentry sends events asynchronously, so the queued event
+     * must be flushed before `process.exit` discards it.
      */
     async function reportFatal(err: Error): Promise<never> {
         console.log("EXCEPTION IN PLATFORM");
@@ -275,20 +287,22 @@ async function startPlatformProcess() {
         console.log("error:\n", err.stack);
         safeProcessSend(["error", err.toString()]);
         try {
-            await sentry.flush?.();
-        } catch {
-            // Never let a failing flush mask the error being reported.
+            // A false result means the timeout elapsed with the event still
+            // queued. Report it rather than exiting as though it had been
+            // delivered, but exit either way: a failing flush must never mask
+            // the error being reported.
+            if ((await sentry.flush?.()) === false) {
+                console.error(
+                    `fatal-error-flush timed out for ${platformName} ${identifier}; event may be lost`,
+                );
+            }
+        } catch (flushErr) {
+            console.error(
+                `fatal-error-flush failed for ${platformName} ${identifier}: ${errorMessage(flushErr)}`,
+            );
         }
         process.exit(1);
     }
-
-    process.once("uncaughtException", (err: Error) => {
-        void reportFatal(err);
-    });
-
-    process.once("unhandledRejection", (err: Error) => {
-        void reportFatal(err);
-    });
 
     /**
      * In the case of a parent disconnect, terminate child process.

--- a/packages/server/src/platform.ts
+++ b/packages/server/src/platform.ts
@@ -105,12 +105,14 @@ async function startPlatformProcess() {
     // would die without notifying the parent or reporting to Sentry.
     // `reportFatal` and `safeProcessSend` are function declarations, so they
     // are hoisted and callable from here.
-    process.once("uncaughtException", (err: Error) => {
-        void reportFatal(err);
+    // Neither a thrown value nor a rejection reason is guaranteed to be an
+    // Error — `throw null` and `Promise.reject(null)` both reach here — and a
+    // non-Error would throw on `.stack` inside the handler, losing the very
+    // report it exists to make. Normalize both first.
+    process.once("uncaughtException", (err: unknown) => {
+        void reportFatal(toError(err));
     });
 
-    // A rejection reason can be any value, including null or undefined, which
-    // would throw on `.stack` inside the handler. Normalize it first.
     process.once("unhandledRejection", (err: unknown) => {
         void reportFatal(toError(err));
     });

--- a/packages/server/src/platform.ts
+++ b/packages/server/src/platform.ts
@@ -85,7 +85,10 @@ async function startPlatformProcess() {
     const loggerCache = new Map<string, Logger>();
 
     // conditionally initialize sentry
-    let sentry: { readonly reportError: (err: Error) => void } = {
+    let sentry: {
+        readonly reportError: (err: Error) => void;
+        readonly flush?: (timeoutMs?: number) => Promise<boolean>;
+    } = {
         reportError: (err: Error) => {
             logger.debug(
                 "Sentry not configured; error not reported to Sentry",
@@ -97,14 +100,14 @@ async function startPlatformProcess() {
             );
         },
     };
-    (async () => {
-        // Resolved from the parent's forwarded settings, not this process's
-        // own config: a worker is forked without the server's config file.
-        if (resolveSentryConfig().dsn) {
-            logger.info("initializing sentry");
-            sentry = await import("./sentry");
-        }
-    })();
+    // Awaited (not fire-and-forget) so a crash during the rest of startup is
+    // reported to Sentry rather than to the no-op stub above. Resolved from
+    // the parent's forwarded settings, not this process's own config: a
+    // worker is forked without the server's config file.
+    if (resolveSentryConfig().dsn) {
+        logger.info("initializing sentry");
+        sentry = await import("./sentry");
+    }
 
     let jobWorker: JobWorker;
     let jobWorkerStarted = false;
@@ -261,20 +264,30 @@ async function startPlatformProcess() {
     /**
      * Handle any uncaught errors from the platform by alerting the worker and shutting down.
      */
-    process.once("uncaughtException", (err: Error) => {
+    /**
+     * Report a fatal worker error and exit. Sentry sends events
+     * asynchronously, so the queued event must be flushed before
+     * `process.exit` discards it.
+     */
+    async function reportFatal(err: Error): Promise<never> {
         console.log("EXCEPTION IN PLATFORM");
         sentry.reportError(err);
         console.log("error:\n", err.stack);
         safeProcessSend(["error", err.toString()]);
+        try {
+            await sentry.flush?.();
+        } catch {
+            // Never let a failing flush mask the error being reported.
+        }
         process.exit(1);
+    }
+
+    process.once("uncaughtException", (err: Error) => {
+        void reportFatal(err);
     });
 
     process.once("unhandledRejection", (err: Error) => {
-        console.log("EXCEPTION IN PLATFORM");
-        sentry.reportError(err);
-        console.log("error:\n", err.stack);
-        safeProcessSend(["error", err.toString()]);
-        process.exit(1);
+        void reportFatal(err);
     });
 
     /**

--- a/packages/server/src/sentry.ts
+++ b/packages/server/src/sentry.ts
@@ -12,6 +12,9 @@ import { defaultSentryRelease } from "./version.js";
 
 type MetricAttributes = Record<string, string | number | boolean>;
 
+/** How long fatal-error paths wait for queued events to reach Sentry. */
+export const SENTRY_FLUSH_TIMEOUT_MS = 2000;
+
 const logger = createLogger("sentry");
 const sentryConfig = resolveSentryConfig();
 
@@ -68,6 +71,16 @@ logger.info("initialized sentry observability");
 export function reportError(err: Error): void {
     logger.warn("reporting error");
     Sentry.captureException(err);
+}
+
+/**
+ * Drain queued events to Sentry. `captureException` only enqueues; a process
+ * that exits without flushing discards everything still in the buffer, which
+ * is exactly the case for fatal-error paths that call `process.exit`.
+ * Resolves `false` if the timeout elapsed with events still unsent.
+ */
+export function flush(timeoutMs = SENTRY_FLUSH_TIMEOUT_MS): Promise<boolean> {
+    return Sentry.flush(timeoutMs);
 }
 
 export function count(

--- a/packages/server/src/trust-proxy.test.ts
+++ b/packages/server/src/trust-proxy.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from "bun:test";
+
+import { resolveTrustProxy } from "./trust-proxy.js";
+
+describe("resolveTrustProxy", () => {
+    it("trusts nothing by default", () => {
+        expect(resolveTrustProxy(false, "socket")).toBe(false);
+    });
+
+    it("passes through an explicit hop count", () => {
+        expect(resolveTrustProxy(2, "socket")).toBe(2);
+    });
+
+    it("passes through a subnet or preset", () => {
+        expect(resolveTrustProxy("loopback", "socket")).toBe("loopback");
+        expect(resolveTrustProxy("10.0.0.0/8", "socket")).toBe("10.0.0.0/8");
+    });
+
+    it("reads boolean strings from the environment as booleans", () => {
+        // Express would otherwise treat "true" as a subnet name.
+        expect(resolveTrustProxy("true", "socket")).toBe(true);
+        expect(resolveTrustProxy("false", "socket")).toBe(false);
+    });
+
+    it("reads a numeric string as a hop count", () => {
+        expect(resolveTrustProxy("3", "socket")).toBe(3);
+    });
+
+    it("treats an empty or non-scalar value as no trust", () => {
+        expect(resolveTrustProxy("", "socket")).toBe(false);
+        expect(resolveTrustProxy("   ", "socket")).toBe(false);
+        expect(resolveTrustProxy(undefined, "socket")).toBe(false);
+        expect(resolveTrustProxy(null, "socket")).toBe(false);
+        expect(resolveTrustProxy({}, "socket")).toBe(false);
+    });
+
+    it("follows reconnectIpSource=proxy when otherwise unset", () => {
+        // Declaring the socket path trusts the forwarded header but leaving
+        // the HTTP path distrusting it is never what an operator means: it
+        // collapses every proxied request into one rate-limit bucket.
+        expect(resolveTrustProxy(false, "proxy")).toBe(1);
+        expect(resolveTrustProxy(undefined, "proxy")).toBe(1);
+        expect(resolveTrustProxy("", "proxy")).toBe(1);
+    });
+
+    it("keeps an explicit setting when reconnectIpSource is proxy", () => {
+        expect(resolveTrustProxy(2, "proxy")).toBe(2);
+        expect(resolveTrustProxy("loopback", "proxy")).toBe("loopback");
+        expect(resolveTrustProxy(true, "proxy")).toBe(true);
+    });
+});

--- a/packages/server/src/trust-proxy.test.ts
+++ b/packages/server/src/trust-proxy.test.ts
@@ -48,4 +48,29 @@ describe("resolveTrustProxy", () => {
         expect(resolveTrustProxy("loopback", "proxy")).toBe("loopback");
         expect(resolveTrustProxy(true, "proxy")).toBe(true);
     });
+
+    it("follows an explicit x-forwarded-for proxyHeader", () => {
+        expect(resolveTrustProxy(false, "proxy", "x-forwarded-for")).toBe(1);
+        expect(resolveTrustProxy(false, "proxy", "X-Forwarded-For")).toBe(1);
+        expect(resolveTrustProxy(false, "proxy", "  x-forwarded-for ")).toBe(1);
+        expect(resolveTrustProxy(false, "proxy", "")).toBe(1);
+        expect(resolveTrustProxy(false, "proxy", undefined)).toBe(1);
+    });
+
+    it("does not auto-trust when a custom proxyHeader is configured", () => {
+        // The operator vouched for that header alone. Their proxy may leave
+        // x-forwarded-for — the only header Express reads — client-settable,
+        // which would hand clients control of their rate-limit identity.
+        expect(resolveTrustProxy(false, "proxy", "cf-connecting-ip")).toBe(
+            false,
+        );
+        expect(resolveTrustProxy(undefined, "proxy", "x-real-ip")).toBe(false);
+    });
+
+    it("still honors an explicit setting with a custom proxyHeader", () => {
+        expect(resolveTrustProxy(1, "proxy", "cf-connecting-ip")).toBe(1);
+        expect(resolveTrustProxy("loopback", "proxy", "x-real-ip")).toBe(
+            "loopback",
+        );
+    });
 });

--- a/packages/server/src/trust-proxy.ts
+++ b/packages/server/src/trust-proxy.ts
@@ -35,20 +35,36 @@ function normalize(value: unknown): TrustProxySetting {
     return trimmed;
 }
 
+/** The only header Express consults for `trust proxy`. */
+const EXPRESS_FORWARDED_HEADER = "x-forwarded-for";
+
 /**
  * The `trust proxy` value to apply, given the configured `sockethub.trustProxy`
- * and `credentialCheck.reconnectIpSource`. Declaring `reconnectIpSource:
+ * and the `credentialCheck` reconnect settings. Declaring `reconnectIpSource:
  * "proxy"` already states that a trusted proxy sets the forwarded header, so
  * an otherwise-unset `trustProxy` follows it and trusts a single hop, keeping
  * the socket and HTTP paths from disagreeing about who the client is.
+ *
+ * That inference only holds while the socket path reads the same header
+ * Express does. A deployment naming a custom `proxyHeader` has vouched for
+ * that header alone; its proxy may well leave `x-forwarded-for` untouched and
+ * client-settable, and trusting it would hand clients control of their own
+ * HTTP rate-limit identity. Such a deployment must set `trustProxy`
+ * explicitly.
  */
 export function resolveTrustProxy(
     configured: unknown,
     reconnectIpSource: unknown,
+    proxyHeader?: unknown,
 ): TrustProxySetting {
     const normalized = normalize(configured);
-    if (normalized === false && reconnectIpSource === "proxy") {
-        return 1;
+    if (normalized !== false || reconnectIpSource !== "proxy") {
+        return normalized;
     }
-    return normalized;
+    // Unset matches the schema default, which is x-forwarded-for.
+    const header =
+        typeof proxyHeader === "string" && proxyHeader.trim() !== ""
+            ? proxyHeader.trim().toLowerCase()
+            : EXPRESS_FORWARDED_HEADER;
+    return header === EXPRESS_FORWARDED_HEADER ? 1 : false;
 }

--- a/packages/server/src/trust-proxy.ts
+++ b/packages/server/src/trust-proxy.ts
@@ -1,0 +1,54 @@
+/**
+ * Resolution of Express's `trust proxy` setting.
+ *
+ * Without it, `req.ip` is the socket peer — the reverse proxy — so every
+ * proxied request shares one rate-limit bucket, and `express-rate-limit`
+ * raises ERR_ERL_UNEXPECTED_X_FORWARDED_FOR when it sees the header it has
+ * been told not to believe.
+ */
+
+export type TrustProxySetting = boolean | number | string;
+
+/**
+ * Coerce a configured value into something Express accepts. Environment
+ * variables arrive as strings, where `"true"`/`"false"` mean the booleans and
+ * a numeric string means a hop count — Express would otherwise read either as
+ * a subnet name.
+ */
+function normalize(value: unknown): TrustProxySetting {
+    if (typeof value === "boolean" || typeof value === "number") {
+        return value;
+    }
+    if (typeof value !== "string") {
+        return false;
+    }
+    const trimmed = value.trim();
+    if (trimmed === "" || trimmed === "false") {
+        return false;
+    }
+    if (trimmed === "true") {
+        return true;
+    }
+    if (/^\d+$/.test(trimmed)) {
+        return Number(trimmed);
+    }
+    return trimmed;
+}
+
+/**
+ * The `trust proxy` value to apply, given the configured `sockethub.trustProxy`
+ * and `credentialCheck.reconnectIpSource`. Declaring `reconnectIpSource:
+ * "proxy"` already states that a trusted proxy sets the forwarded header, so
+ * an otherwise-unset `trustProxy` follows it and trusts a single hop, keeping
+ * the socket and HTTP paths from disagreeing about who the client is.
+ */
+export function resolveTrustProxy(
+    configured: unknown,
+    reconnectIpSource: unknown,
+): TrustProxySetting {
+    const normalized = normalize(configured);
+    if (normalized === false && reconnectIpSource === "proxy") {
+        return 1;
+    }
+    return normalized;
+}

--- a/packages/sockethub/bin/sockethub
+++ b/packages/sockethub/bin/sockethub
@@ -1,4 +1,10 @@
 #!/usr/bin/env node
-import("@sockethub/server").then((sockethub) => {
-    sockethub.server();
-});
+// Startup failures before the server registers its own fatal handlers (a
+// missing build, an unreadable config) would otherwise surface as an
+// unhandled rejection with no clean message and no exit code.
+import("@sockethub/server")
+    .then((sockethub) => sockethub.server())
+    .catch((err) => {
+        console.error(err);
+        process.exitCode = 1;
+    });


### PR DESCRIPTION
Three production bugs found from a running deployment's logs, where a fatal
`EADDRINUSE` was logged locally but never appeared in Sentry.

## 1. Sentry events were discarded on every fatal path

`reportError()` calls `Sentry.captureException()`, which only *enqueues* an
event, and the next statement was `process.exit(1)`. The process died before
the event left the buffer, so no crash was ever reported: `uncaughtException`,
`unhandledRejection`, constructor failure, boot failure, shutdown failure, and
both handlers in the platform workers.

`--sentry-test` masked this — `sendTestEvent()` is the one path that already
did `await Sentry.flush(5000)`, so the verification flag succeeded while every
real crash was dropped.

The fatal paths now go through a `reportFatal` helper that flushes before
exiting. The worker's Sentry import is `await`ed rather than fire-and-forget,
so a crash during the rest of worker startup is reported to Sentry instead of
the no-op stub.

Also adds `--sentry-test-crash`, which exercises capture → flush → exit end to
end. It runs before the server is constructed, so it never contends for the
port and is safe against a host already serving Sockethub.

Verified against a stand-in ingest endpoint: the envelope carrying the crash
event arrives *before* the process exits, and the exit code is 1.

## 2. Express `trust proxy` was never set

Behind a reverse proxy, `req.ip` was the proxy's own address, so every proxied
request to `/sockethub-http` shared a single `express-rate-limit` bucket, and
`express-rate-limit` logged `ERR_ERL_UNEXPECTED_X_FORWARDED_FOR` on each one:

```
ValidationError2: The 'X-Forwarded-For' header is set but the Express
'trust proxy' setting is false (default). ...
  code: 'ERR_ERL_UNEXPECTED_X_FORWARDED_FOR',
```

Adds a `sockethub.trustProxy` setting (`SOCKETHUB_TRUST_PROXY`) and applies it
to the Express app. Configuring `credentialCheck.reconnectIpSource=proxy`
already declares that a trusted proxy sets the forwarded header, so a
`trustProxy` left at its `false` default follows it and trusts one hop rather
than leaving the socket and HTTP paths disagreeing about who the client is.
**Existing deployments that set `reconnectIpSource=proxy` are fixed without a
config change.**

Confirmed with a direct Express + `express-rate-limit` reproduction: with
`trust proxy: false`, two distinct clients both key as `127.0.0.1` and the
validation error fires; with `1`, no error and each client keys separately.

## 3. `--help` was documented but never implemented

`packages/server/README.md` has advertised `--help : this help screen`, but no
flag parsing existed — any unrecognized argument fell through to a full server
boot. Asking a running deployment for its usage tried to bind the port and died
with `EADDRINUSE`.

`--help`/`-h` and `--version`/`-v` are now handled before config loads,
alongside `--write-config`, so both answer without reading a config file or
opening a socket. The help text lists the flags the server actually accepts.

## Testing

- `bun run lint`, `bun run build` clean.
- `bun test`: 889 pass. Two failures (`printSettingsInfo > strips colors in
  non-TTY environment` and `createGuardedDispatcher > blocks a normalized IP
  literal through real Node and undici`) reproduce identically on `master` with
  none of these changes, and are outside the files touched here.
- New unit tests for `resolveTrustProxy` and the CLI flag parsing.
- `--help`, `--version`, `--write-config -`, and `--sentry-test-crash`
  smoke-tested against the built binary.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `trustProxy` configuration for proxy hops, addresses, presets, and environment-variable overrides.
  * Added CLI help, version, configuration-writing, and Sentry verification options.
  * Added a Sentry crash-test option for validating fatal-error reporting.
* **Bug Fixes**
  * Improved fatal-error handling by flushing pending Sentry events before shutdown.
  * Added safer proxy-header handling, including support for custom headers and explicit trust settings.
* **Documentation**
  * Documented proxy configuration, CLI options, startup behavior, and Sentry testing precautions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->