### PR TITLE
fix(platform-metadata): extract X Article bodies

### DIFF
--- a/packages/platform-metadata/src/index.test.ts
+++ b/packages/platform-metadata/src/index.test.ts
@@ -343,6 +343,48 @@ describe("twitter status resolution", () => {
         ]);
     });
 
+    it("returns the body of an X Article whose tweet text is empty", async () => {
+        tweetResponse = () =>
+            Promise.resolve({
+                code: 200,
+                tweet: {
+                    url: "https://x.com/thedankoe/status/2010751592346030461",
+                    text: "",
+                    author: { name: "DAN KOE", screen_name: "thedankoe" },
+                    article: {
+                        title: "How to fix your entire life in 1 day",
+                        content: {
+                            blocks: [
+                                {
+                                    type: "unstyled",
+                                    text: "If you're anything like me, you think new years resolutions are stupid.",
+                                },
+                                {
+                                    type: "unstyled",
+                                    text: "Because most people go about changing their lives in the completely wrong way.",
+                                },
+                            ],
+                        },
+                    },
+                },
+            });
+
+        const { err, result } = await runFetch(
+            makePlatform(),
+            "https://x.com/thedankoe/status/2010751592346030461",
+        );
+
+        expect(err).toBeNull();
+        // biome-ignore lint/suspicious/noExplicitAny: test result shape
+        const job = result as any;
+        expect(job.object.title).toEqual(
+            "How to fix your entire life in 1 day",
+        );
+        expect(job.object.description).toEqual(
+            "If you're anything like me, you think new years resolutions are stupid.\n\nBecause most people go about changing their lives in the completely wrong way.",
+        );
+    });
+
     it("falls back to the OG scrape when the FxTwitter API errors", async () => {
         tweetResponse = () => Promise.reject(new Error("api down"));
         const { err, result } = await runFetch(

--- a/packages/platform-metadata/src/resolvers.test.ts
+++ b/packages/platform-metadata/src/resolvers.test.ts
@@ -365,6 +365,23 @@ describe("tweetToPageObject", () => {
         expect(page?.description).toEqual("Article preview");
     });
 
+    it("uses the preview when X Article content blocks are malformed", () => {
+        const page = tweetToPageObject({
+            code: 200,
+            tweet: {
+                text: "",
+                author,
+                article: {
+                    preview_text: "Safe fallback",
+                    // biome-ignore lint/suspicious/noExplicitAny: malformed external payload
+                    content: { blocks: "not an array" as any },
+                },
+            },
+        });
+
+        expect(page?.description).toEqual("Safe fallback");
+    });
+
     it("returns null for API errors so the caller can fall back", () => {
         expect(tweetToPageObject({ code: 404, message: "NOT_FOUND" })).toBeNull();
         expect(tweetToPageObject({ code: 200 })).toBeNull();

--- a/packages/platform-metadata/src/resolvers.test.ts
+++ b/packages/platform-metadata/src/resolvers.test.ts
@@ -304,6 +304,67 @@ describe("tweetToPageObject", () => {
         expect(page?.video).toBeUndefined();
     });
 
+    it("maps an X Article body, title, and cover image", () => {
+        const page = tweetToPageObject({
+            code: 200,
+            tweet: {
+                url: "https://x.com/someperson/status/4",
+                text: "",
+                author,
+                article: {
+                    title: "How to fix your entire life in 1 day",
+                    preview_text: "A short preview that should not win.",
+                    cover_media: {
+                        media_info: {
+                            original_img_url:
+                                "https://pbs.twimg.com/media/cover.jpg",
+                            original_img_width: 1456,
+                            original_img_height: 582,
+                        },
+                    },
+                    content: {
+                        blocks: [
+                            { type: "unstyled", text: "First paragraph." },
+                            { type: "atomic", text: " " },
+                            { type: "header-two", text: "A heading" },
+                            { type: "unstyled", text: "Second paragraph." },
+                        ],
+                    },
+                },
+            },
+        });
+
+        expect(page).toEqual({
+            type: "page",
+            title: "How to fix your entire life in 1 day",
+            name: "X (formerly Twitter)",
+            description:
+                "First paragraph.\n\nA heading\n\nSecond paragraph.",
+            url: "https://x.com/someperson/status/4",
+            favicon: "https://x.com/favicon.ico",
+            image: [
+                {
+                    url: "https://pbs.twimg.com/media/cover.jpg",
+                    width: 1456,
+                    height: 582,
+                },
+            ],
+        });
+    });
+
+    it("uses an X Article preview when content blocks are unavailable", () => {
+        const page = tweetToPageObject({
+            code: 200,
+            tweet: {
+                text: "",
+                author,
+                article: { preview_text: "Article preview" },
+            },
+        });
+
+        expect(page?.description).toEqual("Article preview");
+    });
+
     it("returns null for API errors so the caller can fall back", () => {
         expect(tweetToPageObject({ code: 404, message: "NOT_FOUND" })).toBeNull();
         expect(tweetToPageObject({ code: 200 })).toBeNull();

--- a/packages/platform-metadata/src/resolvers.test.ts
+++ b/packages/platform-metadata/src/resolvers.test.ts
@@ -382,6 +382,19 @@ describe("tweetToPageObject", () => {
         expect(page?.description).toEqual("Safe fallback");
     });
 
+    it("uses tweet text when the X Article preview is blank", () => {
+        const page = tweetToPageObject({
+            code: 200,
+            tweet: {
+                text: "Tweet fallback",
+                author,
+                article: { preview_text: " \t\n " },
+            },
+        });
+
+        expect(page?.description).toEqual("Tweet fallback");
+    });
+
     it("returns null for API errors so the caller can fall back", () => {
         expect(tweetToPageObject({ code: 404, message: "NOT_FOUND" })).toBeNull();
         expect(tweetToPageObject({ code: 200 })).toBeNull();

--- a/packages/platform-metadata/src/resolvers.ts
+++ b/packages/platform-metadata/src/resolvers.ts
@@ -289,6 +289,23 @@ export interface FxTwitterStatus {
                 duration?: number;
             }>;
         };
+        article?: {
+            title?: string;
+            preview_text?: string;
+            cover_media?: {
+                media_info?: {
+                    original_img_url?: string;
+                    original_img_width?: number;
+                    original_img_height?: number;
+                };
+            };
+            content?: {
+                blocks?: Array<{
+                    text?: string;
+                    type?: string;
+                }>;
+            };
+        };
     };
 }
 
@@ -329,18 +346,37 @@ export function tweetToPageObject(status: FxTwitterStatus): PageObject | null {
         return null;
     }
     const author = tweet.author ?? {};
+    const article = tweet.article;
+    const articleBody = article?.content?.blocks
+        ?.map((block) =>
+            block?.type !== "atomic" && typeof block?.text === "string"
+                ? block.text.trim()
+                : "",
+        )
+        .filter(Boolean)
+        .join("\n\n");
     const title =
-        author.name && author.screen_name
+        (typeof article?.title === "string" && article.title) ||
+        (author.name && author.screen_name
             ? `${author.name} (@${author.screen_name}) on X`
-            : (author.name ?? "Post on X");
+            : (author.name ?? "Post on X"));
     const photo = tweet.media?.photos?.[0];
     const video = tweet.media?.videos?.[0];
-    const imageUrl = photo?.url ?? video?.thumbnail_url;
+    const articleImage = article?.cover_media?.media_info;
+    const imageUrl =
+        articleImage?.original_img_url ?? photo?.url ?? video?.thumbnail_url;
     const page: PageObject = {
         type: "page",
         title,
         name: "X (formerly Twitter)",
-        description: normalizeDescription(tweet.text ?? ""),
+        description: normalizeDescription(
+            articleBody ||
+                (typeof article?.preview_text === "string"
+                    ? article.preview_text
+                    : "") ||
+                tweet.text ||
+                "",
+        ),
         url: tweet.url,
         // The API bypasses the page scrape, so no favicon comes back with
         // it — supply the canonical one so clients can decorate the card.
@@ -350,8 +386,14 @@ export function tweetToPageObject(status: FxTwitterStatus): PageObject | null {
         page.image = [
             {
                 url: imageUrl,
-                width: photo?.width ?? video?.width,
-                height: photo?.height ?? video?.height,
+                width:
+                    articleImage?.original_img_width ??
+                    photo?.width ??
+                    video?.width,
+                height:
+                    articleImage?.original_img_height ??
+                    photo?.height ??
+                    video?.height,
             },
         ];
     }

--- a/packages/platform-metadata/src/resolvers.ts
+++ b/packages/platform-metadata/src/resolvers.ts
@@ -374,7 +374,8 @@ export function tweetToPageObject(status: FxTwitterStatus): PageObject | null {
         name: "X (formerly Twitter)",
         description: normalizeDescription(
             articleBody ||
-                (typeof article?.preview_text === "string"
+                (typeof article?.preview_text === "string" &&
+                article.preview_text.trim()
                     ? article.preview_text
                     : "") ||
                 tweet.text ||

--- a/packages/platform-metadata/src/resolvers.ts
+++ b/packages/platform-metadata/src/resolvers.ts
@@ -347,14 +347,17 @@ export function tweetToPageObject(status: FxTwitterStatus): PageObject | null {
     }
     const author = tweet.author ?? {};
     const article = tweet.article;
-    const articleBody = article?.content?.blocks
-        ?.map((block) =>
-            block?.type !== "atomic" && typeof block?.text === "string"
-                ? block.text.trim()
-                : "",
-        )
-        .filter(Boolean)
-        .join("\n\n");
+    const articleBlocks = article?.content?.blocks;
+    const articleBody = Array.isArray(articleBlocks)
+        ? articleBlocks
+              .map((block) =>
+                  block?.type !== "atomic" && typeof block?.text === "string"
+                      ? block.text.trim()
+                      : "",
+              )
+              .filter(Boolean)
+              .join("\n\n")
+        : undefined;
     const title =
         (typeof article?.title === "string" && article.title) ||
         (author.name && author.screen_name


### PR DESCRIPTION
## Summary

- extract full X Article bodies from FxTwitter article content blocks
- use article titles and cover images for metadata previews
- fall back to article preview text when content blocks are unavailable

## Testing

- `bun test packages/platform-metadata/src/resolvers.test.ts packages/platform-metadata/src/index.test.ts`
- `bun run --filter @sockethub/platform-metadata build`
- `bunx biome check packages/platform-metadata/src/resolvers.ts`

Full repository lint remains blocked by an unrelated nested Biome root configuration in `.claude/worktrees/pr-1237-review/biome.json`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved X Article support when importing posts.
  * Article titles and formatted content are now used for page titles and descriptions.
  * Article cover images and dimensions are prioritized when available.
  * Added fallback handling for unavailable or malformed article content using preview text.
  * Existing photo and video media handling continues to be supported.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->