### PR TITLE
fix(platform-metadata): improve YouTube previews

### DIFF
--- a/packages/platform-metadata/src/index.test.ts
+++ b/packages/platform-metadata/src/index.test.ts
@@ -279,6 +279,97 @@ describe("scrape deadline", () => {
     });
 });
 
+describe("youtube video resolution", () => {
+    const realFetch = globalThis.fetch;
+    let fetchedUrl: string | undefined;
+
+    beforeEach(() => {
+        ogsOptions = undefined;
+        ogsBehavior = () =>
+            Promise.resolve({
+                result: {
+                    ogTitle: "Scraped title",
+                    ogDescription: "The video description",
+                    ogSiteName: "YouTube",
+                    ogUrl: "https://www.youtube.com/watch?v=eJnBBLKCLjE",
+                },
+            });
+        fetchedUrl = undefined;
+        // biome-ignore lint/suspicious/noExplicitAny: controlled YouTube fetch stub
+        globalThis.fetch = ((url: string) => {
+            fetchedUrl = String(url);
+            return Promise.resolve({
+                ok: true,
+                status: 200,
+                json: () =>
+                    Promise.resolve({
+                        title: "oEmbed title",
+                        provider_name: "YouTube",
+                        thumbnail_url:
+                            "https://i.ytimg.com/vi/eJnBBLKCLjE/hqdefault.jpg",
+                        thumbnail_width: 480,
+                        thumbnail_height: 360,
+                    }),
+            });
+        }) as any;
+    });
+
+    afterEach(() => {
+        globalThis.fetch = realFetch;
+    });
+
+    it("combines the scraped description with the official thumbnail", async () => {
+        const { err, result } = await runFetch(
+            makePlatform(),
+            "https://www.youtube.com/watch?v=eJnBBLKCLjE",
+        );
+
+        expect(err).toBeNull();
+        expect(fetchedUrl).toEqual(
+            "https://www.youtube.com/oembed?url=https%3A%2F%2Fwww.youtube.com%2Fwatch%3Fv%3DeJnBBLKCLjE&format=json",
+        );
+        expect(sentUserAgent()).toMatch(/Discordbot/);
+        // biome-ignore lint/suspicious/noExplicitAny: test result shape
+        expect((result as any).object).toMatchObject({
+            title: "oEmbed title",
+            name: "YouTube",
+            description: "The video description",
+            image: [
+                {
+                    url: "https://i.ytimg.com/vi/eJnBBLKCLjE/hqdefault.jpg",
+                    width: 480,
+                    height: 360,
+                },
+            ],
+        });
+    });
+
+    it("keeps a higher-quality scraped thumbnail when available", async () => {
+        ogsBehavior = () =>
+            Promise.resolve({
+                result: {
+                    ogDescription: "Description",
+                    ogImage: [
+                        {
+                            url: "https://i.ytimg.com/vi/eJnBBLKCLjE/maxresdefault.jpg",
+                        },
+                    ],
+                },
+            });
+
+        const { result } = await runFetch(
+            makePlatform(),
+            "https://youtu.be/eJnBBLKCLjE",
+        );
+        // biome-ignore lint/suspicious/noExplicitAny: test result shape
+        expect((result as any).object.image).toEqual([
+            {
+                url: "https://i.ytimg.com/vi/eJnBBLKCLjE/maxresdefault.jpg",
+            },
+        ]);
+    });
+});
+
 describe("twitter status resolution", () => {
     const realFetch = globalThis.fetch;
     let fetchedUrl: string | undefined;

--- a/packages/platform-metadata/src/index.test.ts
+++ b/packages/platform-metadata/src/index.test.ts
@@ -368,6 +368,33 @@ describe("youtube video resolution", () => {
             },
         ]);
     });
+
+    it("falls back to oEmbed when the page scrape fails", async () => {
+        ogsBehavior = () => Promise.reject(new Error("scrape unavailable"));
+
+        const { err, result } = await runFetch(
+            makePlatform(),
+            "https://www.youtube.com/watch?v=eJnBBLKCLjE",
+        );
+
+        expect(err).toBeNull();
+        // biome-ignore lint/suspicious/noExplicitAny: test result shape
+        expect((result as any).object).toEqual({
+            type: "page",
+            title: "oEmbed title",
+            name: "YouTube",
+            description: "",
+            image: [
+                {
+                    url: "https://i.ytimg.com/vi/eJnBBLKCLjE/hqdefault.jpg",
+                    width: 480,
+                    height: 360,
+                },
+            ],
+            url: "https://www.youtube.com/watch?v=eJnBBLKCLjE",
+            favicon: "/favicon.ico",
+        });
+    });
 });
 
 describe("twitter status resolution", () => {

--- a/packages/platform-metadata/src/index.ts
+++ b/packages/platform-metadata/src/index.ts
@@ -169,6 +169,7 @@ export default class Metadata implements PlatformInterface {
         this.scrape(job, cb);
     }
 
+    /** Fetch and validate YouTube's official preview metadata. */
     private async fetchYouTubeEmbed(
         embedUrl: string,
     ): Promise<YouTubeOEmbed | undefined> {
@@ -522,6 +523,24 @@ export default class Metadata implements PlatformInterface {
                         cb(null, job);
                         return;
                     }
+                }
+                const youtube = await youtubeEmbed;
+                if (youtube) {
+                    job.actor.name = youtube.provider_name || "YouTube";
+                    job.object = {
+                        type: "page",
+                        title: youtube.title,
+                        name: youtube.provider_name || "YouTube",
+                        description: "",
+                        image: youtubeOEmbedImage(youtube),
+                        url: job.actor.id,
+                        favicon: "/favicon.ico",
+                    };
+                    this.log.debug(
+                        `using youtube oEmbed fallback for ${job.actor.id}`,
+                    );
+                    cb(null, job);
+                    return;
                 }
                 cb(err);
             });

--- a/packages/platform-metadata/src/index.ts
+++ b/packages/platform-metadata/src/index.ts
@@ -18,13 +18,17 @@ import {
     normalizeDescription,
     parseRedditOEmbed,
     parseRedditPost,
+    parseYouTubeOEmbed,
     type RedditOEmbed,
     redditOEmbedImage,
     redditPostImage,
     redditPostImages,
     resolveRedditJson,
     resolveTwitterStatus,
+    resolveYouTubeOEmbed,
     tweetToPageObject,
+    type YouTubeOEmbed,
+    youtubeOEmbedImage,
 } from "./resolvers";
 import { PlatformMetadataSchema } from "./schema";
 
@@ -55,6 +59,7 @@ const COMPAT_USER_AGENT =
 const TWEET_API_TIMEOUT_MS = 10_000;
 const REDDIT_OEMBED_URL = "https://www.reddit.com/oembed";
 const REDDIT_OEMBED_TIMEOUT_MS = 4_000;
+const YOUTUBE_OEMBED_TIMEOUT_MS = 4_000;
 const SCRAPE_TIMEOUT_MS = 5_000;
 const REDDIT_JSON_TIMEOUT_MS = 2_500;
 const REDDIT_JSON_MAX_BYTES = 1_000_000;
@@ -152,7 +157,43 @@ export default class Metadata implements PlatformInterface {
             this.fetchReddit(job, cb);
             return;
         }
+        const youtubeOEmbedUrl = resolveYouTubeOEmbed(job.actor.id);
+        if (youtubeOEmbedUrl) {
+            const embed = withDeadline(
+                this.fetchYouTubeEmbed(youtubeOEmbedUrl),
+                YOUTUBE_OEMBED_TIMEOUT_MS,
+            ).catch(() => undefined);
+            this.scrape(job, cb, undefined, job.actor.id, embed);
+            return;
+        }
         this.scrape(job, cb);
+    }
+
+    private async fetchYouTubeEmbed(
+        embedUrl: string,
+    ): Promise<YouTubeOEmbed | undefined> {
+        try {
+            const res = await this.fetchImpl(embedUrl, {
+                dispatcher: this.getDispatcher(),
+                headers: { "user-agent": this.userAgent() },
+                signal: AbortSignal.timeout(YOUTUBE_OEMBED_TIMEOUT_MS),
+            } as RequestInit & {
+                dispatcher: ReturnType<typeof createGuardedDispatcher>;
+            });
+            if (!res.ok) {
+                throw new Error(`YouTube oEmbed returned HTTP ${res.status}`);
+            }
+            const embed = parseYouTubeOEmbed(await res.json());
+            if (!embed) {
+                throw new Error("YouTube oEmbed returned an invalid payload");
+            }
+            return embed;
+        } catch (err) {
+            this.log.debug(
+                `youtube oEmbed fetch failed for ${embedUrl}: ${String(err)}; using scraped metadata`,
+            );
+            return undefined;
+        }
     }
 
     private async fetchTweet(
@@ -341,11 +382,15 @@ export default class Metadata implements PlatformInterface {
         cb: PlatformCallback,
         redditEmbed?: Promise<RedditOEmbed | undefined>,
         scrapeUrl = job.actor.id,
+        youtubeEmbed?: Promise<YouTubeOEmbed | undefined>,
     ) {
         // Reddit serves its OG data (with the post's real preview image)
         // only to recognized embed-crawler user agents — everything else
         // gets a page without OG tags, or a 403.
-        const userAgent = isRedditUrl(job.actor.id)
+        const useCompatUserAgent =
+            isRedditUrl(job.actor.id) ||
+            Boolean(resolveYouTubeOEmbed(job.actor.id));
+        const userAgent = useCompatUserAgent
             ? this.compatUserAgent()
             : this.userAgent();
         // The server fetches whatever URL a client puts in actor.id, so guard
@@ -414,6 +459,7 @@ export default class Metadata implements PlatformInterface {
                 this.log.debug(`scrape completed for ${job.actor.id}`);
                 const reddit = isRedditUrl(job.actor.id);
                 const embed = reddit ? await redditEmbed : undefined;
+                const youtube = await youtubeEmbed;
                 if (!reddit) job.actor.id = result.ogUrl || job.actor.id;
                 job.actor.name = reddit
                     ? (embed?.provider_name ?? "reddit")
@@ -421,8 +467,11 @@ export default class Metadata implements PlatformInterface {
                 job.object = {
                     type: "page",
                     language: result.ogLocale,
-                    title: embed?.title ?? result.ogTitle,
-                    name: embed?.provider_name ?? result.ogSiteName,
+                    title: embed?.title ?? youtube?.title ?? result.ogTitle,
+                    name:
+                        embed?.provider_name ??
+                        youtube?.provider_name ??
+                        result.ogSiteName,
                     description: normalizeDescription(
                         result.ogDescription || "",
                     ),
@@ -432,7 +481,9 @@ export default class Metadata implements PlatformInterface {
                     image: reddit
                         ? (redditPostImages(result.ogImage) ??
                           redditOEmbedImage(embed ?? {}))
-                        : result.ogImage,
+                        : result.ogImage?.length
+                          ? result.ogImage
+                          : youtubeOEmbedImage(youtube),
                     url: reddit ? job.actor.id : result.ogUrl,
                     // Fall back to the conventional location when the page
                     // declares no icon (vxreddit, many plain sites). It's

--- a/packages/platform-metadata/src/resolvers.test.ts
+++ b/packages/platform-metadata/src/resolvers.test.ts
@@ -4,14 +4,79 @@ import {
     normalizeDescription,
     parseRedditOEmbed,
     parseRedditPost,
+    parseYouTubeOEmbed,
     redditOEmbedImage,
     redditPostImage,
     redditPostImages,
     resolveRedditEmbed,
     resolveRedditJson,
     resolveTwitterStatus,
+    resolveYouTubeOEmbed,
     tweetToPageObject,
+    youtubeOEmbedImage,
 } from "./resolvers";
+
+describe("resolveYouTubeOEmbed", () => {
+    it("resolves supported YouTube video URL forms", () => {
+        for (const url of [
+            "https://www.youtube.com/watch?v=eJnBBLKCLjE&t=10",
+            "https://youtu.be/eJnBBLKCLjE?si=abc",
+            "https://m.youtube.com/shorts/eJnBBLKCLjE",
+            "https://youtube.com/live/eJnBBLKCLjE",
+            "https://www.youtube.com/embed/eJnBBLKCLjE",
+        ]) {
+            expect(resolveYouTubeOEmbed(url)).toEqual(
+                "https://www.youtube.com/oembed?url=https%3A%2F%2Fwww.youtube.com%2Fwatch%3Fv%3DeJnBBLKCLjE&format=json",
+            );
+        }
+    });
+
+    it("ignores non-video, malformed, and lookalike URLs", () => {
+        expect(resolveYouTubeOEmbed("https://youtube.com/@channel")).toBeNull();
+        expect(resolveYouTubeOEmbed("https://youtube.com/watch?v=short")).toBeNull();
+        expect(resolveYouTubeOEmbed("https://notyoutube.com/watch?v=eJnBBLKCLjE")).toBeNull();
+        expect(resolveYouTubeOEmbed("not a URL")).toBeNull();
+    });
+});
+
+describe("YouTube oEmbed metadata", () => {
+    it("validates and maps a thumbnail", () => {
+        const embed = parseYouTubeOEmbed({
+            title: "Video title",
+            provider_name: "YouTube",
+            thumbnail_url: "https://i.ytimg.com/vi/id/hqdefault.jpg",
+            thumbnail_width: 480,
+            thumbnail_height: 360,
+            html: "ignored external field",
+        });
+        expect(embed).not.toBeNull();
+        expect(youtubeOEmbedImage(embed!)).toEqual([
+            {
+                url: "https://i.ytimg.com/vi/id/hqdefault.jpg",
+                width: 480,
+                height: 360,
+            },
+        ]);
+    });
+
+    it("rejects malformed payloads and unsafe thumbnails", () => {
+        expect(parseYouTubeOEmbed(null)).toBeNull();
+        expect(parseYouTubeOEmbed({ title: "Video" })).toBeNull();
+        expect(
+            parseYouTubeOEmbed({
+                title: "Video",
+                thumbnail_url: "javascript:alert(1)",
+            }),
+        ).toBeNull();
+        expect(
+            parseYouTubeOEmbed({
+                title: "Video",
+                thumbnail_url: "https://i.ytimg.com/x.jpg",
+                thumbnail_width: -1,
+            }),
+        ).toBeNull();
+    });
+});
 
 describe("resolveTwitterStatus", () => {
     it("resolves status URLs on every X/Twitter host", () => {

--- a/packages/platform-metadata/src/resolvers.ts
+++ b/packages/platform-metadata/src/resolvers.ts
@@ -26,6 +26,13 @@ const TWITTER_HOSTS = new Set([
     "mobile.x.com",
 ]);
 
+const YOUTUBE_HOSTS = new Set([
+    "youtube.com",
+    "www.youtube.com",
+    "m.youtube.com",
+    "music.youtube.com",
+]);
+
 /** Hosts that serve Reddit posts. */
 const REDDIT_HOSTS = new Set([
     "reddit.com",
@@ -59,6 +66,97 @@ export function resolveTwitterStatus(url: string): string | null {
         return null;
     }
     return `https://api.fxtwitter.com/status/${match[1]}`;
+}
+
+/** Resolve supported YouTube video URLs to the official oEmbed endpoint. */
+export function resolveYouTubeOEmbed(url: string): string | null {
+    let parsed: URL;
+    try {
+        parsed = new URL(url);
+    } catch {
+        return null;
+    }
+    const host = parsed.hostname.toLowerCase();
+    let videoId: string | null | undefined;
+    if (YOUTUBE_HOSTS.has(host)) {
+        if (parsed.pathname === "/watch") {
+            videoId = parsed.searchParams.get("v");
+        } else {
+            videoId = parsed.pathname.match(
+                /^\/(?:shorts|live|embed)\/([A-Za-z0-9_-]{11})(?:\/|$)/,
+            )?.[1];
+        }
+    } else if (host === "youtu.be") {
+        videoId = parsed.pathname.match(/^\/([A-Za-z0-9_-]{11})(?:\/|$)/)?.[1];
+    }
+    if (!videoId || !/^[A-Za-z0-9_-]{11}$/.test(videoId)) return null;
+
+    const canonical = new URL("https://www.youtube.com/watch");
+    canonical.searchParams.set("v", videoId);
+    const endpoint = new URL("https://www.youtube.com/oembed");
+    endpoint.searchParams.set("url", canonical.href);
+    endpoint.searchParams.set("format", "json");
+    return endpoint.href;
+}
+
+export interface YouTubeOEmbed {
+    title: string;
+    provider_name?: string;
+    thumbnail_url: string;
+    thumbnail_width?: number;
+    thumbnail_height?: number;
+}
+
+/** Validate the subset of YouTube's external oEmbed payload we consume. */
+export function parseYouTubeOEmbed(value: unknown): YouTubeOEmbed | null {
+    if (!value || typeof value !== "object" || Array.isArray(value))
+        return null;
+    const embed = value as Record<string, unknown>;
+    if (
+        typeof embed.title !== "string" ||
+        !embed.title ||
+        typeof embed.thumbnail_url !== "string" ||
+        !embed.thumbnail_url
+    ) {
+        return null;
+    }
+    if (
+        embed.provider_name !== undefined &&
+        typeof embed.provider_name !== "string"
+    ) {
+        return null;
+    }
+    for (const key of ["thumbnail_width", "thumbnail_height"]) {
+        if (
+            embed[key] !== undefined &&
+            (typeof embed[key] !== "number" ||
+                !Number.isFinite(embed[key]) ||
+                embed[key] < 0)
+        ) {
+            return null;
+        }
+    }
+    try {
+        const thumbnail = new URL(embed.thumbnail_url);
+        if (!["http:", "https:"].includes(thumbnail.protocol)) return null;
+    } catch {
+        return null;
+    }
+    return embed as unknown as YouTubeOEmbed;
+}
+
+export function youtubeOEmbedImage(
+    embed?: YouTubeOEmbed,
+): PageObject["image"] | undefined {
+    return embed
+        ? [
+              {
+                  url: embed.thumbnail_url,
+                  width: embed.thumbnail_width,
+                  height: embed.thumbnail_height,
+              },
+          ]
+        : undefined;
 }
 
 /**

--- a/packages/platform-metadata/src/resolvers.ts
+++ b/packages/platform-metadata/src/resolvers.ts
@@ -145,6 +145,7 @@ export function parseYouTubeOEmbed(value: unknown): YouTubeOEmbed | null {
     return embed as unknown as YouTubeOEmbed;
 }
 
+/** Map a validated YouTube oEmbed thumbnail to the platform image shape. */
 export function youtubeOEmbedImage(
     embed?: YouTubeOEmbed,
 ): PageObject["image"] | undefined {


### PR DESCRIPTION
## Summary

- recognize YouTube watch, short-link, Shorts, Live, and embed video URLs
- merge official YouTube oEmbed titles and thumbnails with scraped video descriptions
- prefer higher-resolution Open Graph thumbnails and fall back to validated oEmbed thumbnails
- use the compatibility crawler user agent for reliable YouTube description metadata

## Testing

- `bun test packages/platform-metadata/src/resolvers.test.ts packages/platform-metadata/src/index.test.ts` (52 pass)
- `bun run --filter @sockethub/platform-metadata build`
- live metadata fetch for `https://www.youtube.com/watch?v=eJnBBLKCLjE` returned its title, description, and 1280x720 thumbnail

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved metadata detection for YouTube watch, Shorts, live, embed, music, mobile, and shortened URLs.
  * Added richer video preview details, including titles, provider information, and correctly sized thumbnails.
* **Bug Fixes**
  * Improved handling of incomplete or unavailable YouTube metadata through fallback behavior.
  * Added safeguards to reject invalid or unsafe video links and malformed metadata.
  * Improved compatibility when retrieving YouTube preview information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->