### PR TITLE
fix(platform-metadata): return Reddit hosted videos

### DIFF
--- a/packages/platform-metadata/src/index.test.ts
+++ b/packages/platform-metadata/src/index.test.ts
@@ -226,6 +226,57 @@ describe("reddit structured metadata", () => {
         expect((result as any).object.image).toBeUndefined();
     });
 
+    it("returns Reddit hosted video metadata and its poster", async () => {
+        postResponse = {
+            title: "Hosted video",
+            selftext: "",
+            url: "https://v.redd.it/abc123",
+            secure_media: {
+                reddit_video: {
+                    fallback_url:
+                        "https://v.redd.it/abc123/CMAF_480.mp4?source=fallback",
+                    width: 480,
+                    height: 494,
+                    duration: 41,
+                },
+            },
+            preview: {
+                images: [
+                    {
+                        source: {
+                            url: "https://external-preview.redd.it/post.png",
+                            width: 650,
+                            height: 670,
+                        },
+                    },
+                ],
+            },
+        };
+        const { err, result } = await runFetch(
+            makePlatform(),
+            "https://reddit.com/r/videos/comments/abc123/post/",
+        );
+        expect(err).toBeNull();
+        // biome-ignore lint/suspicious/noExplicitAny: test result shape
+        expect((result as any).object).toMatchObject({
+            description: "",
+            image: [
+                {
+                    url: "https://external-preview.redd.it/post.png",
+                    width: 650,
+                    height: 670,
+                },
+            ],
+            video: {
+                url: "https://v.redd.it/abc123/CMAF_480.mp4?source=fallback",
+                thumbnail: "https://external-preview.redd.it/post.png",
+                width: 480,
+                height: 494,
+                duration: 41,
+            },
+        });
+    });
+
     it("falls back to oEmbed when Reddit JSON fails", async () => {
         redditJsonBehavior = () => Promise.reject(new Error("JSON down"));
         globalThis.fetch = ((url: URL) =>

--- a/packages/platform-metadata/src/index.ts
+++ b/packages/platform-metadata/src/index.ts
@@ -23,6 +23,7 @@ import {
     redditOEmbedImage,
     redditPostImage,
     redditPostImages,
+    redditPostVideo,
     resolveRedditJson,
     resolveTwitterStatus,
     resolveYouTubeOEmbed,
@@ -259,6 +260,7 @@ export default class Metadata implements PlatformInterface {
                     name: "reddit",
                     description: normalizeDescription(post.selftext ?? ""),
                     image: redditPostImage(post),
+                    video: redditPostVideo(post),
                     url: job.actor.id,
                     favicon: "/favicon.ico",
                 };

--- a/packages/platform-metadata/src/resolvers.test.ts
+++ b/packages/platform-metadata/src/resolvers.test.ts
@@ -255,6 +255,26 @@ describe("Reddit JSON metadata", () => {
         expect(redditPostImage(post)).toBeUndefined();
         expect(redditPostVideo(post)).toBeUndefined();
     });
+
+    it("never promotes an HTTP image to a video thumbnail", () => {
+        const post = {
+            title: "Hosted video with insecure poster",
+            url: "http://i.redd.it/post.png",
+            secure_media: {
+                reddit_video: {
+                    fallback_url: "https://v.redd.it/abc123/video.mp4",
+                },
+            },
+        };
+        expect(redditPostImage(post)).toBeUndefined();
+        expect(redditPostVideo(post)).toEqual({
+            url: "https://v.redd.it/abc123/video.mp4",
+            thumbnail: undefined,
+            width: undefined,
+            height: undefined,
+            duration: undefined,
+        });
+    });
 });
 
 describe("redditOEmbedImage", () => {

--- a/packages/platform-metadata/src/resolvers.test.ts
+++ b/packages/platform-metadata/src/resolvers.test.ts
@@ -8,6 +8,7 @@ import {
     redditOEmbedImage,
     redditPostImage,
     redditPostImages,
+    redditPostVideo,
     resolveRedditEmbed,
     resolveRedditJson,
     resolveTwitterStatus,
@@ -181,6 +182,78 @@ describe("Reddit JSON metadata", () => {
         expect(
             redditPostImage({ title: "Link", url: "https://example.com/a.png" }),
         ).toBeUndefined();
+    });
+
+    it("maps a hosted video and its preview image", () => {
+        const post = parseRedditPost([
+            {
+                data: {
+                    children: [
+                        {
+                            data: {
+                                title: "Video post",
+                                selftext: "",
+                                url: "https://v.redd.it/abc123",
+                                secure_media: {
+                                    reddit_video: {
+                                        fallback_url:
+                                            "https://v.redd.it/abc123/CMAF_480.mp4?source=fallback",
+                                        width: 480,
+                                        height: 494,
+                                        duration: 41,
+                                    },
+                                },
+                                preview: {
+                                    images: [
+                                        {
+                                            source: {
+                                                url: "https://external-preview.redd.it/post.png?format=pjpg",
+                                                width: 650,
+                                                height: 670,
+                                            },
+                                        },
+                                    ],
+                                },
+                            },
+                        },
+                    ],
+                },
+            },
+        ]);
+        expect(post).not.toBeNull();
+        expect(redditPostImage(post!)).toEqual([
+            {
+                url: "https://external-preview.redd.it/post.png?format=pjpg",
+                width: 650,
+                height: 670,
+            },
+        ]);
+        expect(redditPostVideo(post!)).toEqual({
+            url: "https://v.redd.it/abc123/CMAF_480.mp4?source=fallback",
+            thumbnail:
+                "https://external-preview.redd.it/post.png?format=pjpg",
+            width: 480,
+            height: 494,
+            duration: 41,
+        });
+    });
+
+    it("rejects untrusted Reddit video and preview URLs", () => {
+        const post = {
+            title: "Unsafe",
+            secure_media: {
+                reddit_video: {
+                    fallback_url: "https://example.com/video.mp4",
+                },
+            },
+            preview: {
+                images: [
+                    { source: { url: "javascript:alert(1)" } },
+                ],
+            },
+        };
+        expect(redditPostImage(post)).toBeUndefined();
+        expect(redditPostVideo(post)).toBeUndefined();
     });
 });
 

--- a/packages/platform-metadata/src/resolvers.ts
+++ b/packages/platform-metadata/src/resolvers.ts
@@ -258,6 +258,7 @@ export function parseRedditPost(value: unknown): RedditPost | null {
     return data as unknown as RedditPost;
 }
 
+/** Return a canonical HTTPS URL when it belongs to an allowed Reddit host. */
 function redditMediaUrl(
     value: unknown,
     allowedHosts: Set<string>,
@@ -274,6 +275,7 @@ function redditMediaUrl(
     }
 }
 
+/** Keep valid media measurements while discarding malformed external values. */
 function finiteNonNegative(value: unknown): number | undefined {
     return typeof value === "number" && Number.isFinite(value) && value >= 0
         ? value
@@ -283,19 +285,11 @@ function finiteNonNegative(value: unknown): number | undefined {
 /** Select only a direct Reddit-hosted image belonging to the post. */
 export function redditPostImage(post: RedditPost): PageObject["image"] {
     for (const candidate of [post.url_overridden_by_dest, post.url]) {
-        if (!candidate) continue;
-        try {
-            const url = new URL(candidate);
-            if (
-                ["i.redd.it", "preview.redd.it"].includes(
-                    url.hostname.toLowerCase(),
-                )
-            ) {
-                return [{ url: url.href }];
-            }
-        } catch {
-            // Try the next candidate.
-        }
+        const url = redditMediaUrl(
+            candidate,
+            new Set(["i.redd.it", "preview.redd.it"]),
+        );
+        if (url) return [{ url }];
     }
     const source = post.preview?.images?.[0]?.source;
     const previewUrl = redditMediaUrl(

--- a/packages/platform-metadata/src/resolvers.ts
+++ b/packages/platform-metadata/src/resolvers.ts
@@ -223,6 +223,23 @@ export interface RedditPost {
     selftext?: string;
     url?: string;
     url_overridden_by_dest?: string;
+    secure_media?: {
+        reddit_video?: {
+            fallback_url?: string;
+            width?: number;
+            height?: number;
+            duration?: number;
+        };
+    };
+    preview?: {
+        images?: Array<{
+            source?: {
+                url?: string;
+                width?: number;
+                height?: number;
+            };
+        }>;
+    };
 }
 
 /** Validate and extract the post object from Reddit's listing response. */
@@ -239,6 +256,28 @@ export function parseRedditPost(value: unknown): RedditPost | null {
             return null;
     }
     return data as unknown as RedditPost;
+}
+
+function redditMediaUrl(
+    value: unknown,
+    allowedHosts: Set<string>,
+): string | null {
+    if (typeof value !== "string") return null;
+    try {
+        const url = new URL(value);
+        return url.protocol === "https:" &&
+            allowedHosts.has(url.hostname.toLowerCase())
+            ? url.href
+            : null;
+    } catch {
+        return null;
+    }
+}
+
+function finiteNonNegative(value: unknown): number | undefined {
+    return typeof value === "number" && Number.isFinite(value) && value >= 0
+        ? value
+        : undefined;
 }
 
 /** Select only a direct Reddit-hosted image belonging to the post. */
@@ -258,7 +297,35 @@ export function redditPostImage(post: RedditPost): PageObject["image"] {
             // Try the next candidate.
         }
     }
+    const source = post.preview?.images?.[0]?.source;
+    const previewUrl = redditMediaUrl(
+        source?.url,
+        new Set(["preview.redd.it", "external-preview.redd.it"]),
+    );
+    if (previewUrl) {
+        return [
+            {
+                url: previewUrl,
+                width: finiteNonNegative(source?.width),
+                height: finiteNonNegative(source?.height),
+            },
+        ];
+    }
     return undefined;
+}
+
+/** Map Reddit's hosted-video payload to the common page video shape. */
+export function redditPostVideo(post: RedditPost): PageObject["video"] {
+    const video = post.secure_media?.reddit_video;
+    const url = redditMediaUrl(video?.fallback_url, new Set(["v.redd.it"]));
+    if (!url) return undefined;
+    return {
+        url,
+        thumbnail: redditPostImage(post)?.[0]?.url,
+        width: finiteNonNegative(video?.width),
+        height: finiteNonNegative(video?.height),
+        duration: finiteNonNegative(video?.duration),
+    };
 }
 
 /** Subset of Reddit's oEmbed response used for link previews. */


### PR DESCRIPTION
## Summary

- map Reddit hosted-video JSON into the metadata `video` response
- use Reddit preview media as the card image and video thumbnail
- restrict mapped media URLs to trusted Reddit HTTPS hosts
- add resolver and end-to-end platform coverage for hosted videos and unsafe URLs

## Testing

- `bun test packages/platform-metadata/src/resolvers.test.ts packages/platform-metadata/src/index.test.ts` (59 pass)
- `bunx biome check packages/platform-metadata/src/index.ts packages/platform-metadata/src/resolvers.ts packages/platform-metadata/src/index.test.ts packages/platform-metadata/src/resolvers.test.ts`
- `bun run --cwd packages/platform-metadata build`

Full repository lint is currently blocked by an unrelated nested Biome root at `.claude/worktrees/pr-1237-review/biome.json`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for displaying videos hosted on Reddit, including thumbnails, dimensions, and duration.
  * Improved Reddit image handling with validated preview images and image dimensions.

* **Bug Fixes**
  * Prevented untrusted or invalid video and preview image URLs from being displayed.
  * Normalized Reddit video descriptions and image metadata for consistent output.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->