### PR TITLE
fix: classify expected metadata failures and unwrap Reddit media links

### DIFF
--- a/packages/platform-metadata/src/index.test.ts
+++ b/packages/platform-metadata/src/index.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, mock } from "bun:test";
+import { isExpectedError } from "@sockethub/util/error";
 import { Agent } from "undici";
 
 // Capture the options passed to open-graph-scraper and control its outcome,
@@ -91,7 +92,9 @@ describe("metadata fetch SSRF hardening", () => {
             Promise.reject({ result: { error: new Error("ogs failed") } });
         const { err, result } = await runFetch(makePlatform());
         expect(err).toBeInstanceOf(Error);
-        expect((err as Error).message).toEqual("ogs failed");
+        expect((err as Error).message).toEqual(
+            "metadata scrape failed for https://example.com: ogs failed",
+        );
         expect(result).toBeUndefined();
     });
 
@@ -100,6 +103,18 @@ describe("metadata fetch SSRF hardening", () => {
         const { err } = await runFetch(makePlatform());
         expect(err).toBeInstanceOf(Error);
         expect((err as Error).message).toMatch(/blocked non-public/);
+    });
+
+    it("marks scrape failures as expected operational errors", async () => {
+        // Remote sites timing out or bot-blocking (403) must not be captured
+        // as Sentry production errors by the job handler.
+        ogsBehavior = () =>
+            Promise.reject({ result: { error: new Error("403 Forbidden") } });
+        const { err } = await runFetch(makePlatform());
+        expect(isExpectedError(err)).toBe(true);
+        expect((err as Error).message).toEqual(
+            "metadata scrape failed for https://example.com: 403 Forbidden",
+        );
     });
 });
 
@@ -275,6 +290,48 @@ describe("reddit structured metadata", () => {
                 duration: 41,
             },
         });
+    });
+
+    it("unwraps reddit.com/media links without any network request", async () => {
+        const { err, result } = await runFetch(
+            makePlatform(),
+            "https://www.reddit.com/media?url=https%3A%2F%2Fi.redd.it%2Fgz85tl8860yg1.png",
+        );
+        expect(err).toBeNull();
+        // biome-ignore lint/suspicious/noExplicitAny: test result shape
+        expect((result as any).object).toMatchObject({
+            type: "page",
+            title: "gz85tl8860yg1.png",
+            name: "reddit",
+            image: [{ url: "https://i.redd.it/gz85tl8860yg1.png" }],
+            url: "https://www.reddit.com/media?url=https%3A%2F%2Fi.redd.it%2Fgz85tl8860yg1.png",
+        });
+        // The image URL came from the link itself: no JSON, oEmbed, or
+        // scrape round-trips.
+        expect(redditJsonUrl).toBeUndefined();
+        expect(fetchCalls).toHaveLength(0);
+        expect(ogsOptions).toBeUndefined();
+    });
+
+    it("marks the no-metadata Reddit failure as expected", async () => {
+        // A Reddit URL shape with no JSON endpoint and a failing oEmbed —
+        // the job fails, but as an expected operational outcome.
+        redditJsonBehavior = () => Promise.reject(new Error("no JSON"));
+        globalThis.fetch = (() =>
+            Promise.resolve({
+                ok: false,
+                status: 400,
+                json: () => Promise.reject(new Error("no body")),
+            })) as any;
+        const { err } = await runFetch(
+            makePlatform(),
+            "https://www.reddit.com/gallery/abc123",
+        );
+        expect(err).toBeInstanceOf(Error);
+        expect((err as Error).message).toEqual(
+            "No Reddit metadata available for https://www.reddit.com/gallery/abc123",
+        );
+        expect(isExpectedError(err)).toBe(true);
     });
 
     it("falls back to oEmbed when Reddit JSON fails", async () => {

--- a/packages/platform-metadata/src/index.ts
+++ b/packages/platform-metadata/src/index.ts
@@ -7,7 +7,7 @@ import type {
     PlatformInterface,
     PlatformSession,
 } from "@sockethub/schemas";
-import { toError } from "@sockethub/util/error";
+import { markExpectedError, toError } from "@sockethub/util/error";
 import { createGuardedDispatcher } from "@sockethub/util/net";
 import ogs from "open-graph-scraper";
 import { fetch as undiciFetch } from "undici";
@@ -25,6 +25,7 @@ import {
     redditPostImages,
     redditPostVideo,
     resolveRedditJson,
+    resolveRedditMedia,
     resolveTwitterStatus,
     resolveYouTubeOEmbed,
     tweetToPageObject,
@@ -234,6 +235,35 @@ export default class Metadata implements PlatformInterface {
     }
 
     private async fetchReddit(job: ActivityStream, cb: PlatformCallback) {
+        // reddit.com/media?url=… wraps a single hosted image; Reddit serves
+        // neither post JSON nor oEmbed for it, so the network pipeline below
+        // can only fail. The image URL is embedded in the link itself —
+        // answer from it directly.
+        const mediaImage = resolveRedditMedia(job.actor.id);
+        if (mediaImage) {
+            const imagePath = new URL(mediaImage).pathname;
+            let title: string;
+            try {
+                title = decodeURIComponent(imagePath).slice(1);
+            } catch {
+                // Malformed percent-sequences survive URL parsing; the title
+                // is cosmetic, so fall back to the undecoded filename.
+                title = imagePath.slice(1);
+            }
+            job.actor.name = "reddit";
+            job.object = {
+                type: "page",
+                title,
+                name: "reddit",
+                description: "",
+                image: [{ url: mediaImage }],
+                url: job.actor.id,
+                favicon: "/favicon.ico",
+            };
+            this.log.debug(`reddit media link unwrapped for ${job.actor.id}`);
+            cb(null, job);
+            return;
+        }
         const jsonUrl = resolveRedditJson(job.actor.id);
         // Start the title fallback immediately. If the richer post JSON fails,
         // this has usually completed already and does not extend the response
@@ -289,7 +319,13 @@ export default class Metadata implements PlatformInterface {
             cb(null, job);
             return;
         }
-        cb(new Error(`No Reddit metadata available for ${job.actor.id}`));
+        // Expected outcome for deleted/blocked posts and unrecognized Reddit
+        // link shapes, not a server defect — keep it out of Sentry.
+        cb(
+            markExpectedError(
+                new Error(`No Reddit metadata available for ${job.actor.id}`),
+            ),
+        );
     }
 
     /**
@@ -544,7 +580,19 @@ export default class Metadata implements PlatformInterface {
                     cb(null, job);
                     return;
                 }
-                cb(err);
+                // Scrape failures are expected operational outcomes of
+                // fetching arbitrary user-supplied URLs — slow sites time
+                // out, bot-blockers return 403s, links go dead. Mark them so
+                // the job handler doesn't report each one to Sentry as a
+                // production error, and name the URL so any report or client
+                // message is self-describing.
+                cb(
+                    markExpectedError(
+                        new Error(
+                            `metadata scrape failed for ${job.actor.id}: ${err.message}`,
+                        ),
+                    ),
+                );
             });
     }
 

--- a/packages/platform-metadata/src/resolvers.test.ts
+++ b/packages/platform-metadata/src/resolvers.test.ts
@@ -11,6 +11,7 @@ import {
     redditPostVideo,
     resolveRedditEmbed,
     resolveRedditJson,
+    resolveRedditMedia,
     resolveTwitterStatus,
     resolveYouTubeOEmbed,
     tweetToPageObject,
@@ -274,6 +275,60 @@ describe("Reddit JSON metadata", () => {
             height: undefined,
             duration: undefined,
         });
+    });
+});
+
+describe("resolveRedditMedia", () => {
+    it("unwraps a media-viewer link to its i.redd.it image", () => {
+        expect(
+            resolveRedditMedia(
+                "https://www.reddit.com/media?url=https%3A%2F%2Fi.redd.it%2Fgz85tl8860yg1.png",
+            ),
+        ).toEqual("https://i.redd.it/gz85tl8860yg1.png");
+    });
+
+    it("accepts preview.redd.it targets and a trailing slash", () => {
+        expect(
+            resolveRedditMedia(
+                "https://reddit.com/media/?url=https%3A%2F%2Fpreview.redd.it%2Fabc.jpg%3Fwidth%3D640",
+            ),
+        ).toEqual("https://preview.redd.it/abc.jpg?width=640");
+    });
+
+    it("rejects non-Reddit-CDN targets", () => {
+        // The url param is attacker-controlled; only Reddit's own image
+        // hosts may be echoed back as the preview image.
+        expect(
+            resolveRedditMedia(
+                "https://www.reddit.com/media?url=https%3A%2F%2Fevil.example%2Fx.png",
+            ),
+        ).toBeNull();
+        expect(
+            resolveRedditMedia(
+                "https://www.reddit.com/media?url=http%3A%2F%2Fi.redd.it%2Fx.png",
+            ),
+        ).toBeNull();
+    });
+
+    it("ignores missing or malformed url params", () => {
+        expect(resolveRedditMedia("https://www.reddit.com/media")).toBeNull();
+        expect(
+            resolveRedditMedia("https://www.reddit.com/media?url=not-a-url"),
+        ).toBeNull();
+    });
+
+    it("does not match other paths or hosts", () => {
+        expect(
+            resolveRedditMedia(
+                "https://www.reddit.com/r/pics/comments/abc/post/",
+            ),
+        ).toBeNull();
+        expect(
+            resolveRedditMedia(
+                "https://example.com/media?url=https%3A%2F%2Fi.redd.it%2Fx.png",
+            ),
+        ).toBeNull();
+        expect(resolveRedditMedia("not a url")).toBeNull();
     });
 });
 

--- a/packages/platform-metadata/src/resolvers.ts
+++ b/packages/platform-metadata/src/resolvers.ts
@@ -218,6 +218,27 @@ export function resolveRedditJson(url: string): string | null {
     return json.href;
 }
 
+/**
+ * Unwrap Reddit's media-viewer URL (`reddit.com/media?url=<image>`) to the
+ * image it displays. Reddit serves neither post JSON nor oEmbed for these
+ * links (its oEmbed endpoint returns HTTP 400), but the target image is
+ * embedded in the link itself, so no network request is needed at all.
+ */
+export function resolveRedditMedia(url: string): string | null {
+    let parsed: URL;
+    try {
+        parsed = new URL(url);
+    } catch {
+        return null;
+    }
+    if (!REDDIT_HOSTS.has(parsed.hostname.toLowerCase())) return null;
+    if (parsed.pathname.replace(/\/+$/, "") !== "/media") return null;
+    return redditMediaUrl(
+        parsed.searchParams.get("url"),
+        new Set(["i.redd.it", "preview.redd.it", "external-preview.redd.it"]),
+    );
+}
+
 export interface RedditPost {
     title: string;
     selftext?: string;

--- a/packages/server/src/platform.ts
+++ b/packages/server/src/platform.ts
@@ -32,7 +32,7 @@ import {
     INTERNAL_PLATFORM_CONTEXT_URL,
 } from "@sockethub/schemas";
 import { crypto, getPlatformId } from "@sockethub/util/crypto";
-import { errorMessage, toError } from "@sockethub/util/error";
+import { errorMessage, isExpectedError, toError } from "@sockethub/util/error";
 import config from "./config";
 import { resolveSentryConfig } from "./sentry-config.js";
 
@@ -88,6 +88,11 @@ async function startPlatformProcess() {
     let sentry: {
         readonly reportError: (err: Error) => void;
         readonly flush?: (timeoutMs?: number) => Promise<boolean>;
+        readonly count?: (
+            name: string,
+            value?: number,
+            attributes?: Record<string, string | number | boolean>,
+        ) => void;
     } = {
         reportError: (err: Error) => {
             logger.debug(
@@ -391,7 +396,21 @@ async function startPlatformProcess() {
                             // toString() failed; fall back to the original error.
                             message = errorMessage(err);
                         }
-                        sentry.reportError(new Error(message));
+                        // Platforms mark errors that are expected
+                        // operational outcomes rather than server defects —
+                        // e.g. metadata scrapes of user-supplied URLs that
+                        // time out or get bot-blocked (#1243, #1245). Those
+                        // still fail the job (the client sees the error) but
+                        // are counted as a metric instead of flooding Sentry
+                        // with per-URL error events.
+                        if (isExpectedError(err)) {
+                            sentry.count?.("platform.job.expected_failure", 1, {
+                                platform: platformName,
+                                type: job.msg.type,
+                            });
+                        } else {
+                            sentry.reportError(new Error(message));
+                        }
                         reject(new Error(message));
                     } else {
                         jobLog.debug(`completed ${job.title} ${job.msg.type}`);

--- a/packages/util/src/error/index.test.ts
+++ b/packages/util/src/error/index.test.ts
@@ -1,6 +1,11 @@
 import { describe, expect, it } from "bun:test";
 
-import { errorMessage, toError } from "./index.js";
+import {
+    errorMessage,
+    isExpectedError,
+    markExpectedError,
+    toError,
+} from "./index.js";
 
 describe("toError", () => {
     it("returns the same Error instance unchanged", () => {
@@ -37,5 +42,31 @@ describe("errorMessage", () => {
         expect(errorMessage("plain")).toEqual("plain");
         expect(errorMessage(7)).toEqual("7");
         expect(errorMessage(null)).toEqual("null");
+    });
+});
+
+describe("markExpectedError / isExpectedError", () => {
+    it("marks an error and returns the same instance", () => {
+        const err = new Error("remote site timed out");
+        expect(markExpectedError(err)).toBe(err);
+        expect(isExpectedError(err)).toBe(true);
+    });
+
+    it("is false for unmarked errors and non-errors", () => {
+        expect(isExpectedError(new Error("boom"))).toBe(false);
+        expect(isExpectedError("boom")).toBe(false);
+        expect(isExpectedError(null)).toBe(false);
+        expect(isExpectedError(undefined)).toBe(false);
+    });
+
+    it("survives toError passthrough", () => {
+        const err = markExpectedError(new Error("expected"));
+        expect(isExpectedError(toError(err))).toBe(true);
+    });
+
+    it("does not leak the mark onto the message or JSON shape", () => {
+        const err = markExpectedError(new Error("expected"));
+        expect(err.message).toEqual("expected");
+        expect(Object.keys(err)).toEqual([]);
     });
 });

--- a/packages/util/src/error/index.ts
+++ b/packages/util/src/error/index.ts
@@ -20,3 +20,32 @@ export function errorMessage(value: unknown): string {
     }
     return String(value);
 }
+
+/**
+ * Marker for errors that represent expected operational outcomes rather than
+ * server defects — e.g. a user-supplied URL timing out, a remote site
+ * refusing a scrape, or a page with no extractable metadata. The platform
+ * job handler skips Sentry error capture for marked errors (counting them as
+ * a metric instead), keeping production error tracking focused on real bugs.
+ *
+ * The mark is a `Symbol.for` property so it survives duplicated copies of
+ * this module in a dependency tree. It is process-local: it does not survive
+ * serialization across IPC or the job queue.
+ */
+const EXPECTED_ERROR = Symbol.for("sockethub.expectedError");
+
+type MarkableError = Error & { [EXPECTED_ERROR]?: boolean };
+
+/** Mark an error as an expected operational failure. Returns the same instance. */
+export function markExpectedError<T extends Error>(err: T): T {
+    (err as MarkableError)[EXPECTED_ERROR] = true;
+    return err;
+}
+
+/** Whether `value` is an Error marked via {@link markExpectedError}. */
+export function isExpectedError(value: unknown): boolean {
+    return (
+        value instanceof Error &&
+        (value as MarkableError)[EXPECTED_ERROR] === true
+    );
+}


### PR DESCRIPTION
Fixes #1243, fixes #1244, fixes #1245.

Production Sentry was collecting an error event for every metadata job that failed on a user-supplied URL — scrape timeouts (SOCKETHUB-PROD-3 / #1243), Reddit media-viewer links that can never resolve (SOCKETHUB-PROD-4 / #1244), and bot-blocked sites returning 403 (SOCKETHUB-PROD-2 / #1245). These are expected operational outcomes of fetching arbitrary URLs, not server defects, and they drown out real errors.

## Changes

### Expected-failure classification (#1243, #1245)
- **`@sockethub/util/error`**: new `markExpectedError()` / `isExpectedError()` — a process-local `Symbol.for` marker for errors representing expected operational failures. Survives duplicated module copies; does not survive IPC/queue serialization (not needed — classification happens in the platform child).
- **`platform-metadata`**: marks scrape failures (timeouts, remote 4xx/5xx, dead links, SSRF-guard blocks) and the Reddit no-metadata failure as expected. Scrape errors now name the target URL (`metadata scrape failed for <url>: <reason>`) so any report or client message is self-describing — the Sentry breadcrumb trail is process-global across concurrent jobs and cannot identify the failing URL.
- **`server` (platform child `doneCallback`)**: marked errors still fail the job — the client receives the error exactly as before — but are counted via the `platform.job.expected_failure` metric (tagged with platform + message type) instead of `Sentry.captureException`. Unexpected errors are reported as before.

### Reddit media-viewer links (#1244)
`reddit.com/media?url=<image>` wraps a single hosted image; Reddit serves neither post JSON nor oEmbed for it (its oEmbed endpoint returns HTTP 400), so the existing pipeline failed 100% of the time. The new `resolveRedditMedia()` unwraps the link to the image it displays with **zero network requests**. The `url` param is attacker-controlled, so only `https:` targets on Reddit's own image hosts (`i.redd.it`, `preview.redd.it`, `external-preview.redd.it`) are accepted, reusing the same `redditMediaUrl` validator as the post-JSON path.

## Testing
- New unit tests: marker helpers, `resolveRedditMedia` (including host/scheme rejection), media unwrap end-to-end (asserts no JSON/oEmbed/scrape round-trips), expected-marking of scrape and Reddit failures.
- `bun run lint`, `bun run build`, `bun test`: 925 pass; the single failure (`util/net/dispatcher.test.ts` "blocks a normalized IP literal through real Node and undici") is pre-existing and environmental — it spawns `node`, which isn't on this sandbox's PATH.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for extracting metadata directly from supported Reddit media links.
  * Improved validation of Reddit media URLs to prevent unsafe or invalid redirects.

* **Bug Fixes**
  * Scraping failures and Reddit links without metadata now retain fallback behavior and are handled as expected operational errors.
  * Expected platform job failures are tracked without being reported as unexpected application errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->