### PR TITLE
fix(platform-metadata): improve Facebook link previews

### DIFF
--- a/packages/platform-metadata/src/index.test.ts
+++ b/packages/platform-metadata/src/index.test.ts
@@ -137,6 +137,78 @@ describe("scrape user agent", () => {
     });
 });
 
+describe("facebook scrape", () => {
+    beforeEach(() => {
+        ogsOptions = undefined;
+        ogsBehavior = () => Promise.resolve({ result: {} });
+    });
+
+    it("presents the compatibility crawler user agent", async () => {
+        await runFetch(
+            makePlatform(),
+            "https://www.facebook.com/share/v/1JudTFVg5h/?mibextid=wwXIfr",
+        );
+        expect(ogsOptions?.url).toEqual(
+            "https://www.facebook.com/share/v/1JudTFVg5h/?mibextid=wwXIfr",
+        );
+        expect(sentUserAgent()).toMatch(/Discordbot/);
+    });
+
+    it("strips engagement stats from the title and supplies the site name", async () => {
+        ogsBehavior = () =>
+            Promise.resolve({
+                result: {
+                    ogTitle:
+                        "2.2M views · 21K reactions | If YOU Take Vitamin D, You NEED To Stop! | Steven Bartlett",
+                    ogDescription: "If YOU Take Vitamin D, You NEED To Stop!",
+                    ogUrl: "https://www.facebook.com/SteveBartlettShow/posts/1607733517402185/",
+                    ogImage: [
+                        {
+                            url: "https://scontent.example/thumb.jpg",
+                            alt: "2.2M views · 21K reactions | If YOU Take Vitamin D, You NEED To Stop! | Steven Bartlett",
+                        },
+                    ],
+                },
+            });
+        const { err, result } = await runFetch(
+            makePlatform(),
+            "https://www.facebook.com/share/v/1JudTFVg5h/",
+        );
+        expect(err).toBeNull();
+        // biome-ignore lint/suspicious/noExplicitAny: test result shape
+        expect((result as any).actor.name).toEqual("Facebook");
+        // biome-ignore lint/suspicious/noExplicitAny: test result shape
+        expect((result as any).object).toMatchObject({
+            title: "If YOU Take Vitamin D, You NEED To Stop! | Steven Bartlett",
+            name: "Facebook",
+            description: "If YOU Take Vitamin D, You NEED To Stop!",
+            image: [
+                {
+                    url: "https://scontent.example/thumb.jpg",
+                    alt: "If YOU Take Vitamin D, You NEED To Stop! | Steven Bartlett",
+                },
+            ],
+        });
+    });
+
+    it("does not rewrite titles on non-facebook pages", async () => {
+        ogsBehavior = () =>
+            Promise.resolve({
+                result: { ogTitle: "5 things · 3 ideas | A listicle" },
+            });
+        const { result } = await runFetch(
+            makePlatform(),
+            "https://example.com/article",
+        );
+        // biome-ignore lint/suspicious/noExplicitAny: test result shape
+        expect((result as any).object.title).toEqual(
+            "5 things · 3 ideas | A listicle",
+        );
+        // biome-ignore lint/suspicious/noExplicitAny: test result shape
+        expect((result as any).object.name).toBeUndefined();
+    });
+});
+
 describe("favicon fallback", () => {
     beforeEach(() => {
         ogsOptions = undefined;

--- a/packages/platform-metadata/src/index.ts
+++ b/packages/platform-metadata/src/index.ts
@@ -14,6 +14,7 @@ import { fetch as undiciFetch } from "undici";
 import packageJson from "../package.json" with { type: "json" };
 import {
     type FxTwitterStatus,
+    isFacebookUrl,
     isRedditUrl,
     normalizeDescription,
     parseRedditOEmbed,
@@ -28,6 +29,7 @@ import {
     resolveRedditMedia,
     resolveTwitterStatus,
     resolveYouTubeOEmbed,
+    stripFacebookEngagement,
     tweetToPageObject,
     type YouTubeOEmbed,
     youtubeOEmbedImage,
@@ -425,9 +427,11 @@ export default class Metadata implements PlatformInterface {
     ) {
         // Reddit serves its OG data (with the post's real preview image)
         // only to recognized embed-crawler user agents — everything else
-        // gets a page without OG tags, or a 403.
+        // gets a page without OG tags, or a 403. Facebook likewise serves
+        // unrecognized scrapers a login interstitial instead of the post.
         const useCompatUserAgent =
             isRedditUrl(job.actor.id) ||
+            isFacebookUrl(job.actor.id) ||
             Boolean(resolveYouTubeOEmbed(job.actor.id));
         const userAgent = useCompatUserAgent
             ? this.compatUserAgent()
@@ -497,20 +501,37 @@ export default class Metadata implements PlatformInterface {
                 const { result } = data;
                 this.log.debug(`scrape completed for ${job.actor.id}`);
                 const reddit = isRedditUrl(job.actor.id);
+                const facebook = isFacebookUrl(job.actor.id);
                 const embed = reddit ? await redditEmbed : undefined;
                 const youtube = await youtubeEmbed;
                 if (!reddit) job.actor.id = result.ogUrl || job.actor.id;
+                // Facebook declares no og:site_name, so supply it; its video
+                // titles come prefixed with localized view/reaction counts.
+                const siteName =
+                    result.ogSiteName ?? (facebook ? "Facebook" : undefined);
+                // The og:image alt inherits the same stats prefix as the title.
+                const scrapedImages = facebook
+                    ? result.ogImage?.map((image) => ({
+                          ...image,
+                          alt: stripFacebookEngagement(image.alt),
+                      }))
+                    : result.ogImage;
                 job.actor.name = reddit
                     ? (embed?.provider_name ?? "reddit")
-                    : (result.ogSiteName ?? job.actor.name ?? "");
+                    : (siteName ?? job.actor.name ?? "");
                 job.object = {
                     type: "page",
                     language: result.ogLocale,
-                    title: embed?.title ?? youtube?.title ?? result.ogTitle,
+                    title:
+                        embed?.title ??
+                        youtube?.title ??
+                        (facebook
+                            ? stripFacebookEngagement(result.ogTitle)
+                            : result.ogTitle),
                     name:
                         embed?.provider_name ??
                         youtube?.provider_name ??
-                        result.ogSiteName,
+                        siteName,
                     description: normalizeDescription(
                         result.ogDescription || "",
                     ),
@@ -520,8 +541,8 @@ export default class Metadata implements PlatformInterface {
                     image: reddit
                         ? (redditPostImages(result.ogImage) ??
                           redditOEmbedImage(embed ?? {}))
-                        : result.ogImage?.length
-                          ? result.ogImage
+                        : scrapedImages?.length
+                          ? scrapedImages
                           : youtubeOEmbedImage(youtube),
                     url: reddit ? job.actor.id : result.ogUrl,
                     // Fall back to the conventional location when the page

--- a/packages/platform-metadata/src/resolvers.test.ts
+++ b/packages/platform-metadata/src/resolvers.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "bun:test";
 import {
+    isFacebookUrl,
     isRedditUrl,
     normalizeDescription,
     parseRedditOEmbed,
@@ -14,6 +15,7 @@ import {
     resolveRedditMedia,
     resolveTwitterStatus,
     resolveYouTubeOEmbed,
+    stripFacebookEngagement,
     tweetToPageObject,
     youtubeOEmbedImage,
 } from "./resolvers";
@@ -430,6 +432,57 @@ describe("isRedditUrl", () => {
         expect(isRedditUrl("https://ireddit.com/r/pics")).toBeFalse();
         expect(isRedditUrl("https://notredd.it/abc")).toBeFalse();
         expect(isRedditUrl("not a url")).toBeFalse();
+    });
+});
+
+describe("isFacebookUrl", () => {
+    it("matches facebook hosts and short links", () => {
+        for (const url of [
+            "https://www.facebook.com/share/v/1JudTFVg5h/?mibextid=wwXIfr",
+            "https://facebook.com/SomePage/videos/1720321322579856/",
+            "https://m.facebook.com/share/p/abc/",
+            "https://web.facebook.com/reel/123",
+            "https://fb.watch/abc123/",
+            "https://fb.com/something",
+        ]) {
+            expect(isFacebookUrl(url)).toBeTrue();
+        }
+    });
+
+    it("ignores other hosts and invalid URLs", () => {
+        expect(isFacebookUrl("https://example.com/share/v/abc")).toBeFalse();
+        // Lookalike suffix must not match (attacker-controlled host).
+        expect(isFacebookUrl("https://notfacebook.com/share")).toBeFalse();
+        expect(isFacebookUrl("https://facebook.com.evil.com/x")).toBeFalse();
+        expect(isFacebookUrl("not a url")).toBeFalse();
+    });
+});
+
+describe("stripFacebookEngagement", () => {
+    it("strips the localized stats segment from video titles", () => {
+        expect(
+            stripFacebookEngagement(
+                "2.2M views · 21K reactions | If YOU Take Vitamin D, You NEED To Stop! | Steven Bartlett",
+            ),
+        ).toEqual(
+            "If YOU Take Vitamin D, You NEED To Stop! | Steven Bartlett",
+        );
+        // Stats arrive in the scraping server's geo-IP language.
+        expect(
+            stripFacebookEngagement(
+                "2,2 mil. zhlédnutí · 21 tis. reakcí | Video | Author",
+            ),
+        ).toEqual("Video | Author");
+    });
+
+    it("leaves titles without a stats segment untouched", () => {
+        expect(stripFacebookEngagement("Steven Bartlett")).toEqual(
+            "Steven Bartlett",
+        );
+        expect(stripFacebookEngagement("My video | Author")).toEqual(
+            "My video | Author",
+        );
+        expect(stripFacebookEngagement(undefined)).toBeUndefined();
     });
 });
 

--- a/packages/platform-metadata/src/resolvers.test.ts
+++ b/packages/platform-metadata/src/resolvers.test.ts
@@ -473,6 +473,12 @@ describe("stripFacebookEngagement", () => {
                 "2,2 mil. zhlédnutí · 21 tis. reakcí | Video | Author",
             ),
         ).toEqual("Video | Author");
+        // Including locales whose stats use non-ASCII decimal digits.
+        expect(
+            stripFacebookEngagement(
+                "٢٫٢ مليون مشاهدة · ٢١ ألف تفاعل | فيديو | Author",
+            ),
+        ).toEqual("فيديو | Author");
     });
 
     it("leaves titles without a stats segment untouched", () => {

--- a/packages/platform-metadata/src/resolvers.ts
+++ b/packages/platform-metadata/src/resolvers.ts
@@ -200,7 +200,7 @@ export function isFacebookUrl(url: string): boolean {
 export function stripFacebookEngagement(
     title: string | undefined,
 ): string | undefined {
-    return title?.replace(/^[^|]*\d[^|]*·[^|]*\|\s*/u, "");
+    return title?.replace(/^[^|]*\p{Nd}[^|]*·[^|]*\|\s*/u, "");
 }
 
 /**

--- a/packages/platform-metadata/src/resolvers.ts
+++ b/packages/platform-metadata/src/resolvers.ts
@@ -4,13 +4,14 @@
  *
  * Some large platforms return a generic banner image (X/Twitter), serve
  * their Open Graph data only to recognized embed crawlers (Reddit), or
- * hide post media behind a login (Facebook). Two of those have working
- * strategies:
+ * hide post media behind a login (Facebook):
  *
  * - X/Twitter → FxTwitter's JSON API (api.fxtwitter.com), built for embed
  *   previews, returns the tweet text plus direct photo/video URLs.
  * - Reddit → the regular scrape works, but only when presented with an
  *   embed-crawler user agent (see COMPAT_USER_AGENT in index.ts).
+ * - Facebook → same crawler-UA gating as Reddit, plus its video titles
+ *   arrive polluted with localized engagement stats that need stripping.
  *
  * These are pure URL matchers/mappers — the platform decides what to do
  * with the resolution (call a JSON API vs. pick a scrape user agent).
@@ -31,6 +32,17 @@ const YOUTUBE_HOSTS = new Set([
     "www.youtube.com",
     "m.youtube.com",
     "music.youtube.com",
+]);
+
+/** Hosts that serve Facebook posts, videos, and reels. */
+const FACEBOOK_HOSTS = new Set([
+    "facebook.com",
+    "www.facebook.com",
+    "m.facebook.com",
+    "web.facebook.com",
+    "mbasic.facebook.com",
+    "fb.com",
+    "www.fb.com",
 ]);
 
 /** Hosts that serve Reddit posts. */
@@ -158,6 +170,37 @@ export function youtubeOEmbedImage(
               },
           ]
         : undefined;
+}
+
+/**
+ * True for Facebook URLs (including fb.watch short links). Facebook serves
+ * an unrecognized scraper a login interstitial instead of the post, but
+ * serves recognized link-preview crawlers the post's Open Graph data —
+ * title, caption, and the video/photo thumbnail — so these URLs scrape
+ * with COMPAT_USER_AGENT (see index.ts), like Reddit.
+ */
+export function isFacebookUrl(url: string): boolean {
+    let parsed: URL;
+    try {
+        parsed = new URL(url);
+    } catch {
+        return false;
+    }
+    const host = parsed.hostname.toLowerCase();
+    return FACEBOOK_HOSTS.has(host) || host === "fb.watch";
+}
+
+/**
+ * Remove the engagement-stats segment Facebook prepends to video titles:
+ * "2.2M views · 21K reactions | <video title> | <author>". The stats are
+ * localized to the *scraping server's* geo-IP language, so match their
+ * shape — a leading pipe-delimited segment containing a digit and the "·"
+ * separator — rather than any particular wording.
+ */
+export function stripFacebookEngagement(
+    title: string | undefined,
+): string | undefined {
+    return title?.replace(/^[^|]*\d[^|]*·[^|]*\|\s*/u, "");
 }
 
 /**


### PR DESCRIPTION
## Problem

Facebook links (e.g. `facebook.com/share/v/…`) produced poor preview data:

- Facebook serves unrecognized scrapers a **login interstitial** instead of the post from most datacenter IPs.
- Even when it responds, canonical video URLs get an `og:title` polluted with engagement stats **localized to the scraping server's geo-IP language**, e.g. `2,2 mil. zhlédnutí · 21 tis. reakcí | If YOU Take Vitamin D… | Steven Bartlett` (Czech, from the server's IP — not the user's locale). The same junk appears in the image `alt`.
- No `og:site_name` is declared, so cards had no site name.

## Changes

- **`isFacebookUrl()`** — matches facebook.com (plus `m.`/`web.`/`mbasic.` subdomains), fb.com, and fb.watch; lookalike hosts rejected.
- **Compat crawler user agent** — Facebook URLs now scrape with the existing `COMPAT_USER_AGENT`, the same approach already used for Reddit. This avoids the login wall, and `/share/` links then serve Facebook's cleaner crawler-facing OG data (author, caption, real video thumbnail).
- **`stripFacebookEngagement()`** — strips the stats prefix from titles and image alt text by *shape* (leading pipe-delimited segment containing a digit and the `·` separator) rather than wording, since the wording is locale-dependent. Applied only to Facebook URLs.
- **Site name** — defaults `name`/`actor.name` to `Facebook` when `og:site_name` is absent.

## Result (live)

`https://www.facebook.com/share/v/1JudTFVg5h/` → title `Steven Bartlett`, description `If YOU Take Vitamin D, You NEED To Stop!`, real fbcdn video thumbnail, `name: Facebook`.

Canonical `/videos/` form → title `If YOU Take Vitamin D, You NEED To Stop! | Steven Bartlett` with the stats junk removed from title and alt.

Limitation: Facebook exposes no `og:video` file URL to any crawler UA (video files require auth), so previews get the thumbnail but no playable `video` field.

## Testing

- 8 new unit tests (URL matcher incl. lookalike-host rejection, stats stripping in two locales, compat-UA routing, site-name defaulting, non-Facebook pages unaffected); 80/80 pass.
- `bun run lint` and package build clean.
- Verified live end-to-end against both the `/share/v/` and canonical `/videos/` URL forms.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added metadata support for Facebook posts and videos, including Facebook short links.
  - Facebook content now uses a compatible scraping method for more reliable metadata retrieval.
  - Facebook titles and image descriptions are cleaned of localized engagement statistics, with Facebook identified as the site when needed.

- **Bug Fixes**
  - Improved handling of localized Facebook engagement text without altering titles from other websites.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->