### PR TITLE
feat(server): add privacy-safe usage telemetry

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -640,11 +640,19 @@ identifier — for example a build that must match source maps uploaded under a
 git SHA.
 
 Sentry records aggregate connection and action counters, active connection
-gauges, action-duration distributions, and action traces. Metric dimensions are
-limited to platform and action names; actor IDs, credentials, message bodies,
-URLs, and client IP addresses are not attached. Logs are opt-in and default to
-`warn` and `error`. Profiling is disabled by default; keep its sample rate low
-in production.
+gauges, connection and action-duration distributions, unique platform use per
+socket connection, and action traces. Connections are classified on disconnect
+as inactive, single-platform, or multi-platform. Action metrics include bounded
+`platform`, `action`, and `transport` (`socket` or `http`) dimensions. Platform
+session counters contain only the platform name and count a platform at most
+once per socket connection.
+
+These are service-usage aggregates, not durable user analytics: reconnecting
+creates a new connection and Sockethub does not attempt to identify one person
+across connections. Actor IDs, socket/session IDs, credentials, message bodies,
+servers, rooms, URLs, user agents, and client IP addresses are not attached.
+Logs are opt-in and default to `warn` and `error`. Profiling is disabled by
+default; keep its sample rate low in production.
 
 These settings apply to the server process and to every platform worker it
 forks. Workers are started with a minimal environment and no config file of

--- a/packages/server/src/http/actions.ts
+++ b/packages/server/src/http/actions.ts
@@ -724,6 +724,7 @@ export function registerHttpActionsRoutes(
                 sessionId,
                 sessionSecret,
                 credentialsStore,
+                transport: "http",
                 onPlatformInstance: (platformInstance) => {
                     // Only persistent platforms need lifecycle tracking during
                     // HTTP-only requests.

--- a/packages/server/src/message-handlers.ts
+++ b/packages/server/src/message-handlers.ts
@@ -38,6 +38,10 @@ export interface MessageHandlersOptions {
     // Socket path uses this to preserve existing ProcessManager session behavior.
     platformSessionId?: string;
     onPlatformInstance?: (platformInstance: PlatformInstance) => void;
+    /** Bounded telemetry dimension identifying the public request path. */
+    transport?: "socket" | "http";
+    /** Called only after platform and action labels pass schema validation. */
+    onPlatformAction?: (platform: string, action: string) => void;
 }
 
 /**
@@ -70,6 +74,8 @@ export function createMessageHandlers(
         clientIp,
         platformSessionId,
         onPlatformInstance,
+        transport = "socket",
+        onPlatformAction,
     } = options;
 
     // Shared handler chain for credentials across socket + HTTP paths.
@@ -85,7 +91,10 @@ export function createMessageHandlers(
                 // This runs only after normalization, schema validation, and
                 // successful credential storage, so labels are trusted.
                 const platform = resolvePlatformId(data) ?? "unknown";
-                observability.startAction(platform, "credentials")();
+                onPlatformAction?.(platform, "credentials");
+                observability.startAction(platform, "credentials", {
+                    transport,
+                })();
                 next(data);
             },
         )
@@ -151,7 +160,10 @@ export function createMessageHandlers(
                 }
                 // This middleware runs after AJV validation. Using platform
                 // and action as telemetry labels is safe only from here on.
-                const finish = observability.startAction(platformId, msg.type);
+                onPlatformAction?.(platformId, msg.type);
+                const finish = observability.startAction(platformId, msg.type, {
+                    transport,
+                });
                 let platformInstance: Awaited<
                     ReturnType<ProcessManager["get"]>
                 >;

--- a/packages/server/src/observability.test.ts
+++ b/packages/server/src/observability.test.ts
@@ -5,6 +5,7 @@ import {
     resetObservabilityForTesting,
     setObservabilityAdapter,
     sanitizeObservabilityNamespace,
+    startConnectionTelemetry,
 } from "./observability.js";
 
 describe("observability", () => {
@@ -13,23 +14,41 @@ describe("observability", () => {
     it("is a no-op until an adapter is installed", () => {
         expect(() => observability.count("test.counter")).not.toThrow();
         expect(() => observability.gauge("test.gauge", 1)).not.toThrow();
+        expect(() =>
+            observability.distribution("test.duration", 2, "millisecond"),
+        ).not.toThrow();
         expect(() => observability.startAction("dummy", "echo")()).not.toThrow();
     });
 
     it("forwards privacy-safe metric dimensions", () => {
         const count = mock(() => {});
         const gauge = mock(() => {});
+        const distribution = mock(() => {});
         const finish = mock(() => {});
         const startAction = mock(() => finish);
-        setObservabilityAdapter({ count, gauge, startAction });
+        setObservabilityAdapter({ count, gauge, distribution, startAction });
 
         observability.count("sockethub.connection.opened");
         observability.gauge("sockethub.connection.active", 2);
-        observability.startAction("irc", "join")(false);
+        observability.distribution(
+            "sockethub.connection.duration",
+            250,
+            "millisecond",
+        );
+        observability.startAction("irc", "join", {
+            transport: "socket",
+        })(false);
 
         expect(count).toHaveBeenCalledWith("sockethub.connection.opened");
         expect(gauge).toHaveBeenCalledWith("sockethub.connection.active", 2);
-        expect(startAction).toHaveBeenCalledWith("irc", "join");
+        expect(distribution).toHaveBeenCalledWith(
+            "sockethub.connection.duration",
+            250,
+            "millisecond",
+        );
+        expect(startAction).toHaveBeenCalledWith("irc", "join", {
+            transport: "socket",
+        });
         expect(finish).toHaveBeenCalledWith(false);
     });
 
@@ -49,5 +68,42 @@ describe("observability", () => {
                 "sockethub:platform:irc:private-actor-id:main",
             ),
         ).toBe("sockethub:platform:irc");
+    });
+
+    it("classifies a connection and counts each platform only once", () => {
+        const count = mock(() => {});
+        const gauge = mock(() => {});
+        const distribution = mock(() => {});
+        const startAction = mock(() => () => {});
+        setObservabilityAdapter({ count, gauge, distribution, startAction });
+
+        const connection = startConnectionTelemetry();
+        connection.recordPlatform("irc");
+        connection.recordPlatform("irc");
+        connection.recordPlatform("xmpp");
+        connection.end();
+        connection.end();
+
+        expect(count).toHaveBeenCalledTimes(5);
+        expect(count).toHaveBeenCalledWith(
+            "sockethub.platform_session.started",
+            1,
+            { platform: "irc" },
+        );
+        expect(count).toHaveBeenCalledWith(
+            "sockethub.platform_session.started",
+            1,
+            { platform: "xmpp" },
+        );
+        expect(count).toHaveBeenCalledWith(
+            "sockethub.connection.classified",
+            1,
+            { classification: "multi_platform" },
+        );
+        expect(distribution).toHaveBeenCalledWith(
+            "sockethub.connection.platform_count",
+            2,
+            "none",
+        );
     });
 });

--- a/packages/server/src/observability.ts
+++ b/packages/server/src/observability.ts
@@ -3,12 +3,23 @@ type Attributes = Record<string, string | number | boolean>;
 export interface ObservabilityAdapter {
     count(name: string, value?: number, attributes?: Attributes): void;
     gauge(name: string, value: number, attributes?: Attributes): void;
-    startAction(platform: string, action: string): (error?: boolean) => void;
+    distribution(
+        name: string,
+        value: number,
+        unit: string,
+        attributes?: Attributes,
+    ): void;
+    startAction(
+        platform: string,
+        action: string,
+        attributes?: Attributes,
+    ): (error?: boolean) => void;
 }
 
 const noopAdapter: ObservabilityAdapter = {
     count: () => {},
     gauge: () => {},
+    distribution: () => {},
     startAction: () => () => {},
 };
 
@@ -21,8 +32,65 @@ export function setObservabilityAdapter(next: ObservabilityAdapter): void {
 export const observability: ObservabilityAdapter = {
     count: (...args) => adapter.count(...args),
     gauge: (...args) => adapter.gauge(...args),
+    distribution: (...args) => adapter.distribution(...args),
     startAction: (...args) => adapter.startAction(...args),
 };
+
+export interface ConnectionTelemetry {
+    recordPlatform(platform: string): void;
+    end(): void;
+}
+
+/**
+ * Aggregate one socket connection without exporting its socket/session id.
+ * Platform names have already come from the validated registry by the time
+ * recordPlatform is called.
+ */
+export function startConnectionTelemetry(): ConnectionTelemetry {
+    const startedAt = performance.now();
+    const platforms = new Set<string>();
+    let ended = false;
+
+    observability.count("sockethub.connection.opened");
+
+    return {
+        recordPlatform(platform: string): void {
+            if (ended || platforms.has(platform)) {
+                return;
+            }
+            platforms.add(platform);
+            observability.count("sockethub.platform_session.started", 1, {
+                platform,
+            });
+        },
+        end(): void {
+            if (ended) {
+                return;
+            }
+            ended = true;
+            observability.count("sockethub.connection.closed");
+            observability.distribution(
+                "sockethub.connection.duration",
+                performance.now() - startedAt,
+                "millisecond",
+            );
+            const classification =
+                platforms.size === 0
+                    ? "inactive"
+                    : platforms.size === 1
+                      ? "single_platform"
+                      : "multi_platform";
+            observability.count("sockethub.connection.classified", 1, {
+                classification,
+            });
+            observability.distribution(
+                "sockethub.connection.platform_count",
+                platforms.size,
+                "none",
+            );
+        },
+    };
+}
 
 export function resetObservabilityForTesting(): void {
     adapter = noopAdapter;

--- a/packages/server/src/sentry.ts
+++ b/packages/server/src/sentry.ts
@@ -103,12 +103,24 @@ export function gauge(
     }
 }
 
+export function distribution(
+    name: string,
+    value: number,
+    unit: string,
+    attributes: MetricAttributes = {},
+): void {
+    if (sentryConfig.enableMetrics) {
+        Sentry.metrics.distribution(name, value, { unit, attributes });
+    }
+}
+
 export function startAction(
     platform: string,
     action: string,
+    additionalAttributes: MetricAttributes = {},
 ): (error?: boolean) => void {
     const startedAt = performance.now();
-    const attributes = { platform, action };
+    const attributes = { platform, action, ...additionalAttributes };
     count("sockethub.action.started", 1, attributes);
     const span = Sentry.startInactiveSpan({
         name: `${platform}.${action}`,
@@ -124,12 +136,12 @@ export function startAction(
             1,
             attributes,
         );
-        if (sentryConfig.enableMetrics) {
-            Sentry.metrics.distribution("sockethub.action.duration", duration, {
-                unit: "millisecond",
-                attributes,
-            });
-        }
+        distribution(
+            "sockethub.action.duration",
+            duration,
+            "millisecond",
+            attributes,
+        );
     };
 }
 
@@ -138,4 +150,4 @@ export async function sendTestEvent(): Promise<boolean> {
     return Sentry.flush(5000);
 }
 
-setObservabilityAdapter({ count, gauge, startAction });
+setObservabilityAdapter({ count, gauge, distribution, startAction });

--- a/packages/server/src/sockethub.ts
+++ b/packages/server/src/sockethub.ts
@@ -25,7 +25,7 @@ import { registerHttpActionsRoutes } from "./http/actions.js";
 import janitor from "./janitor.js";
 import listener from "./listener.js";
 import { createMessageHandlers } from "./message-handlers.js";
-import { observability } from "./observability.js";
+import { observability, startConnectionTelemetry } from "./observability.js";
 import ProcessManager from "./process-manager.js";
 import {
     cleanupClient,
@@ -294,7 +294,7 @@ class Sockethub {
             return;
         }
         this.activeConnections += 1;
-        observability.count("sockethub.connection.opened");
+        const connectionTelemetry = startConnectionTelemetry();
         observability.gauge(
             "sockethub.connection.active",
             this.activeConnections,
@@ -353,7 +353,7 @@ class Sockethub {
             clearSessionScopes(socket.id);
             this.releaseIpSlot(clientIp);
             this.activeConnections = Math.max(0, this.activeConnections - 1);
-            observability.count("sockethub.connection.closed");
+            connectionTelemetry.end();
             observability.gauge(
                 "sockethub.connection.active",
                 this.activeConnections,
@@ -368,6 +368,9 @@ class Sockethub {
             clientIp,
             // Keep session registration behavior inside ProcessManager.get().
             platformSessionId: socket.id,
+            transport: "socket",
+            onPlatformAction: (platform) =>
+                connectionTelemetry.recordPlatform(platform),
         });
 
         socket.on("credentials", handlers.credentials);


### PR DESCRIPTION
## Summary

- track connection duration, platform count, and inactive/single-platform/multi-platform classifications
- count each platform at most once per Socket.IO connection without exporting session identifiers
- distinguish Socket.IO and HTTP action telemetry with a bounded transport attribute
- extend the observability adapter with distributions while keeping Sentry isolated behind the adapter
- document the aggregate-only privacy boundary

## Privacy

Telemetry does not attach actor IDs, socket/session IDs, credentials, message bodies, servers, rooms, URLs, user agents, or client IP addresses. Reconnects are treated as new connections; this does not attempt to identify users across sessions.

## Verification

- `bun run build`
- `bun scripts/build-types.js`
- `bun run lint`
- `bun test packages/server/src/observability.test.ts packages/server/src/http/actions.test.ts`
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Observability**
  * Added richer service-usage metrics for connection duration, platform usage, connection classifications, and action transport.
  * Improved action and connection telemetry across socket and HTTP interactions.
  * Expanded privacy protections to exclude socket/session IDs, servers, rooms, and user agents.

* **Documentation**
  * Clarified that these metrics are aggregated service-usage data, not persistent user analytics.
  * Documented the new metric dimensions and connection classifications.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->