### PR TITLE
fix(platform-metadata): support direct image links in metadata previews

### DIFF
--- a/packages/platform-metadata/src/index.test.ts
+++ b/packages/platform-metadata/src/index.test.ts
@@ -137,6 +137,76 @@ describe("scrape user agent", () => {
     });
 });
 
+describe("direct image links", () => {
+    const realFetch = globalThis.fetch;
+
+    afterEach(() => {
+        globalThis.fetch = realFetch;
+    });
+
+    it("returns image metadata when the origin confirms an image", async () => {
+        // biome-ignore lint/suspicious/noExplicitAny: controlled image response
+        globalThis.fetch = (() =>
+            Promise.resolve(
+                new Response(null, {
+                    status: 200,
+                    headers: { "content-type": "image/jpeg" },
+                }),
+            )) as any;
+        const { err, result } = await runFetch(
+            makePlatform(),
+            "https://images.example/A-photo_01.JPG?size=large",
+        );
+        expect(err).toBeNull();
+        // biome-ignore lint/suspicious/noExplicitAny: test result shape
+        expect((result as any).object).toMatchObject({
+            title: "A photo 01",
+            image: [
+                {
+                    url: "https://images.example/A-photo_01.JPG?size=large",
+                    type: "image/jpeg",
+                },
+            ],
+        });
+    });
+
+    it("uses extension metadata when a bot-blocked origin returns 403", async () => {
+        // biome-ignore lint/suspicious/noExplicitAny: controlled blocked response
+        globalThis.fetch = (() =>
+            Promise.resolve(new Response("blocked", { status: 403 }))) as any;
+        const { err, result } = await runFetch(
+            makePlatform(),
+            "https://images.example/a%20real%20photo.webp",
+        );
+        expect(err).toBeNull();
+        // biome-ignore lint/suspicious/noExplicitAny: test result shape
+        expect((result as any).object.image).toEqual([
+            {
+                url: "https://images.example/a%20real%20photo.webp",
+                type: "image/webp",
+            },
+        ]);
+    });
+
+    it("scrapes HTML served from a URL with an image suffix", async () => {
+        ogsBehavior = () =>
+            Promise.resolve({ result: { ogTitle: "Actually a page" } });
+        // biome-ignore lint/suspicious/noExplicitAny: controlled HTML response
+        globalThis.fetch = (() =>
+            Promise.resolve(
+                new Response("<html></html>", {
+                    headers: { "content-type": "text/html" },
+                }),
+            )) as any;
+        const { result } = await runFetch(
+            makePlatform(),
+            "https://example.com/not-really.jpg",
+        );
+        // biome-ignore lint/suspicious/noExplicitAny: test result shape
+        expect((result as any).object.title).toEqual("Actually a page");
+    });
+});
+
 describe("facebook scrape", () => {
     beforeEach(() => {
         ogsOptions = undefined;

--- a/packages/platform-metadata/src/index.test.ts
+++ b/packages/platform-metadata/src/index.test.ts
@@ -170,6 +170,29 @@ describe("direct image links", () => {
         });
     });
 
+    it("uses the final image URL consistently after a redirect", async () => {
+        // biome-ignore lint/suspicious/noExplicitAny: minimal redirected response
+        globalThis.fetch = (() =>
+            Promise.resolve({
+                ok: true,
+                url: "https://cdn.example/final.jpg",
+                headers: new Headers({ "content-type": "image/jpeg" }),
+                body: null,
+            })) as any;
+        const { result } = await runFetch(
+            makePlatform(),
+            "https://images.example/original.jpg",
+        );
+        // biome-ignore lint/suspicious/noExplicitAny: test result shape
+        expect((result as any).actor.id).toEqual(
+            "https://cdn.example/final.jpg",
+        );
+        // biome-ignore lint/suspicious/noExplicitAny: test result shape
+        expect((result as any).object.url).toEqual(
+            "https://cdn.example/final.jpg",
+        );
+    });
+
     it("uses extension metadata when a bot-blocked origin returns 403", async () => {
         // biome-ignore lint/suspicious/noExplicitAny: controlled blocked response
         globalThis.fetch = (() =>
@@ -204,6 +227,40 @@ describe("direct image links", () => {
         );
         // biome-ignore lint/suspicious/noExplicitAny: test result shape
         expect((result as any).object.title).toEqual("Actually a page");
+    });
+
+    it("returns fallback metadata when the image probe never settles", async () => {
+        globalThis.fetch = (() => new Promise(() => {})) as typeof fetch;
+        const platform = makePlatform({ allowPrivateAddresses: true });
+        const job = {
+            "@context": ["x"],
+            type: "fetch",
+            actor: {
+                id: "http://127.0.0.1/stalled.jpg",
+                type: "website",
+            },
+        };
+        const result = await new Promise((resolve) => {
+            // Exercise a short hard deadline without slowing the test suite.
+            // biome-ignore lint/suspicious/noExplicitAny: private method regression test
+            (platform as any).fetchDirectImage(
+                job,
+                {
+                    title: "stalled",
+                    type: "image/jpeg",
+                    url: job.actor.id,
+                },
+                (_err: unknown, produced: unknown) => resolve(produced),
+                5,
+            );
+        });
+        // biome-ignore lint/suspicious/noExplicitAny: test result shape
+        expect((result as any).object.image).toEqual([
+            {
+                url: "http://127.0.0.1/stalled.jpg",
+                type: "image/jpeg",
+            },
+        ]);
     });
 });
 

--- a/packages/platform-metadata/src/index.ts
+++ b/packages/platform-metadata/src/index.ts
@@ -67,6 +67,7 @@ const YOUTUBE_OEMBED_TIMEOUT_MS = 4_000;
 const SCRAPE_TIMEOUT_MS = 5_000;
 const REDDIT_JSON_TIMEOUT_MS = 2_500;
 const REDDIT_JSON_MAX_BYTES = 1_000_000;
+const DIRECT_IMAGE_PROBE_TIMEOUT_MS = 5_000;
 
 const IMAGE_TYPES_BY_EXTENSION: Readonly<Record<string, string>> = {
     avif: "image/avif",
@@ -77,6 +78,7 @@ const IMAGE_TYPES_BY_EXTENSION: Readonly<Record<string, string>> = {
     webp: "image/webp",
 };
 
+/** Build best-effort metadata from a URL with a known image extension. */
 function directImageCandidate(
     rawUrl: string,
 ): { title: string; type: string; url: string } | undefined {
@@ -218,18 +220,22 @@ export default class Metadata implements PlatformInterface {
         job: ActivityStream,
         candidate: { title: string; type: string; url: string },
         cb: PlatformCallback,
+        timeoutMs = DIRECT_IMAGE_PROBE_TIMEOUT_MS,
     ) {
         try {
-            const res = await this.fetchImpl(candidate.url, {
-                dispatcher: this.getDispatcher(),
-                headers: {
-                    accept: "image/avif,image/webp,image/*,*/*;q=0.8",
-                    "user-agent": this.userAgent(),
-                },
-                signal: AbortSignal.timeout(SCRAPE_TIMEOUT_MS),
-            } as RequestInit & {
-                dispatcher: ReturnType<typeof createGuardedDispatcher>;
-            });
+            const res = await withDeadline(
+                this.fetchImpl(candidate.url, {
+                    dispatcher: this.getDispatcher(),
+                    headers: {
+                        accept: "image/avif,image/webp,image/*,*/*;q=0.8",
+                        "user-agent": this.userAgent(),
+                    },
+                    signal: AbortSignal.timeout(timeoutMs),
+                } as RequestInit & {
+                    dispatcher: ReturnType<typeof createGuardedDispatcher>;
+                }),
+                timeoutMs,
+            );
             const contentType = res.headers
                 .get("content-type")
                 ?.split(";", 1)[0]
@@ -249,6 +255,7 @@ export default class Metadata implements PlatformInterface {
             if (res.ok && contentType?.startsWith("image/")) {
                 candidate.type = contentType;
                 candidate.url = res.url || candidate.url;
+                job.actor.id = candidate.url;
             }
         } catch (err) {
             this.log.debug(

--- a/packages/platform-metadata/src/index.ts
+++ b/packages/platform-metadata/src/index.ts
@@ -68,6 +68,37 @@ const SCRAPE_TIMEOUT_MS = 5_000;
 const REDDIT_JSON_TIMEOUT_MS = 2_500;
 const REDDIT_JSON_MAX_BYTES = 1_000_000;
 
+const IMAGE_TYPES_BY_EXTENSION: Readonly<Record<string, string>> = {
+    avif: "image/avif",
+    gif: "image/gif",
+    jpeg: "image/jpeg",
+    jpg: "image/jpeg",
+    png: "image/png",
+    webp: "image/webp",
+};
+
+function directImageCandidate(
+    rawUrl: string,
+): { title: string; type: string; url: string } | undefined {
+    try {
+        const url = new URL(rawUrl);
+        if (url.protocol !== "http:" && url.protocol !== "https:") return;
+        const filename = decodeURIComponent(
+            url.pathname.split("/").at(-1) || "",
+        );
+        const extension = filename.match(/\.([a-z0-9]+)$/i)?.[1].toLowerCase();
+        const type = extension && IMAGE_TYPES_BY_EXTENSION[extension];
+        if (!type) return;
+        return {
+            title: filename.slice(0, -(extension.length + 1)),
+            type,
+            url: url.href,
+        };
+    } catch {
+        return;
+    }
+}
+
 /** Enforce a deadline independently of a dependency's AbortSignal handling. */
 export function withDeadline<T>(
     promise: Promise<T>,
@@ -170,7 +201,69 @@ export default class Metadata implements PlatformInterface {
             this.scrape(job, cb, undefined, job.actor.id, embed);
             return;
         }
+        const image = directImageCandidate(job.actor.id);
+        if (image) {
+            this.fetchDirectImage(job, image, cb);
+            return;
+        }
         this.scrape(job, cb);
+    }
+
+    /**
+     * Verify likely direct-image links when possible. Origins commonly block
+     * server-side preview agents, so a strong file extension remains a useful
+     * fallback: the client can still request the original resource itself.
+     */
+    private async fetchDirectImage(
+        job: ActivityStream,
+        candidate: { title: string; type: string; url: string },
+        cb: PlatformCallback,
+    ) {
+        try {
+            const res = await this.fetchImpl(candidate.url, {
+                dispatcher: this.getDispatcher(),
+                headers: {
+                    accept: "image/avif,image/webp,image/*,*/*;q=0.8",
+                    "user-agent": this.userAgent(),
+                },
+                signal: AbortSignal.timeout(SCRAPE_TIMEOUT_MS),
+            } as RequestInit & {
+                dispatcher: ReturnType<typeof createGuardedDispatcher>;
+            });
+            const contentType = res.headers
+                .get("content-type")
+                ?.split(";", 1)[0]
+                .trim()
+                .toLowerCase();
+            if (res.ok && contentType?.startsWith("text/html")) {
+                if (res.body) await res.body.cancel();
+                this.scrape(job, cb);
+                return;
+            }
+            if (res.ok && contentType && !contentType.startsWith("image/")) {
+                if (res.body) await res.body.cancel();
+                this.scrape(job, cb);
+                return;
+            }
+            if (res.body) await res.body.cancel();
+            if (res.ok && contentType?.startsWith("image/")) {
+                candidate.type = contentType;
+                candidate.url = res.url || candidate.url;
+            }
+        } catch (err) {
+            this.log.debug(
+                `direct image probe failed for ${candidate.url}: ${String(err)}; using URL metadata`,
+            );
+        }
+        job.object = {
+            type: "page",
+            title: candidate.title.replace(/[_-]+/g, " ").trim(),
+            description: "",
+            image: [{ url: candidate.url, type: candidate.type }],
+            url: candidate.url,
+            favicon: "/favicon.ico",
+        };
+        cb(null, job);
     }
 
     /** Fetch and validate YouTube's official preview metadata. */


### PR DESCRIPTION
## Summary

- detect common direct-image URLs before passing them to the Open Graph scraper
- verify candidate images through the SSRF-guarded dispatcher and use the response MIME type and final URL when available
- fall back to URL-derived image metadata when an origin blocks preview bots, while still scraping HTML served behind image-looking paths
- derive readable titles from image filenames

## Testing

- `bun test packages/platform-metadata/src/index.test.ts packages/platform-metadata/src/schema.test.ts packages/platform-metadata/src/resolvers.test.ts` (82 passed)
- `bun run lint`
- `bun run --filter @sockethub/platform-metadata build`
- live smoke test against the reported Look and Learn image URL

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for recognizing direct image links and displaying their image metadata.
  * Added fallback handling for image links that are blocked or return unexpected content, including extension-based metadata and open-graph information.

* **Bug Fixes**
  * Improved metadata detection for image URLs served by different types of origins.
  * Ensured redirected image URLs use the final destination for metadata.
  * Added timeout fallback handling for image probes that stall indefinitely.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->